### PR TITLE
SAML 認証でシェア機能が壊れる件を修正

### DIFF
--- a/packages/cdk/lambda/getSharedChat.ts
+++ b/packages/cdk/lambda/getSharedChat.ts
@@ -22,7 +22,12 @@ export const handler = async (
     const userId = res.userId;
     const chatId = res.chatId;
 
-    const chat = await findChatById(userId.split('#')[1], chatId.split('#')[1]);
+    const chat = await findChatById(
+      // SAML 認証だと userId に # が含まれるため
+      // 例: user#EntraID_hogehoge.com#EXT#@hogehoge.onmicrosoft.com
+      userId.split('#').slice(1).join('#'),
+      chatId.split('#')[1]
+    );
     const messages = await listMessages(chatId.split('#')[1]);
 
     return {

--- a/packages/cdk/lambda/repository.ts
+++ b/packages/cdk/lambda/repository.ts
@@ -338,7 +338,9 @@ export const findShareId = async (
 export const deleteShareId = async (_shareId: string): Promise<void> => {
   const userIdAndChatId = await findUserIdAndChatId(_shareId);
   const share = await findShareId(
-    userIdAndChatId!.userId.split('#')[1],
+    // SAML 認証だと userId に # が含まれるため
+    // 例: user#EntraID_hogehoge.com#EXT#@hogehoge.onmicrosoft.com
+    userIdAndChatId!.userId.split('#').slice(1).join('#'),
     userIdAndChatId!.chatId.split('#')[1]
   );
 


### PR DESCRIPTION
userId に # が含まれるため、`split('#')[1]` だと userId を復元できない