### PR TITLE
Agent の出力した画像が見れないバグの修正

### DIFF
--- a/packages/cdk/lambda/utils/bedrockAgentApi.ts
+++ b/packages/cdk/lambda/utils/bedrockAgentApi.ts
@@ -209,7 +209,7 @@ const bedrockAgentApi: Pick<ApiInterface, 'invokeStream'> = {
               Body: file.bytes,
             });
             await s3Client.send(command);
-            const url = `https://s3.${process.env.AGENT_REGION}.amazonaws.com/${bucket}/${encodeUrlString(key)}`;
+            const url = `https://${bucket}.s3.amazonaws.com/${encodeUrlString(key)}`;
 
             // Yield file path
             if (file.type?.split('/')[0] === 'image') {


### PR DESCRIPTION
## 変更内容の説明
Agent の出力した画像はデプロイ region に保存されていますが、AGENT_REGION の S3 Bucket endpoint に差し替えられていたため無効な URL になっていました。これを修正します。(元の対応 https://github.com/aws-samples/generative-ai-use-cases-jp/pull/778/files#diff-f7e5c9146b4e4612d5b015eb737388e1ee6e7584f6ce9435da40aa3ea11b481eL189-R212)

Agent RAG の参考ドキュメントのリンクは有効 (AGENT_REGION の Bucket) であることは確認しました。(デグレがないことの確認。)

## チェック項目
- [x] npm run lint を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み

## 関連する Issue
https://github.com/aws-samples/generative-ai-use-cases-jp/issues/822
