### PR TITLE
変数名idTokenPayloadの誤記修正

### DIFF
--- a/packages/common/src/custom/rag-knowledge-base.ts
+++ b/packages/common/src/custom/rag-knowledge-base.ts
@@ -23,7 +23,7 @@ export const getDynamicFilters = (
   // Example 1: Filter by cognito user group
   // Cognito のユーザーグループによってフィルタを適用する
 
-  // const groups = idTokenPayload['cognito:groups'];
+  // const groups = _idTokenPayload['cognito:groups'];
   // if (!groups) throw new Error('cognito:groups is not set'); // Group が設定されていない場合はアクセスできずにエラーにする
   // const groupFilter: RetrievalFilter = {
   //   in: {
@@ -37,7 +37,7 @@ export const getDynamicFilters = (
   // SAML IdP グループのカスタム属性によってフィルタを適用する
   // カスタム属性の設定方法は docs/SAML_WITH_ENTRA_ID.md を参照してください
 
-  // const groups = (idTokenPayload['custom:idpGroup'] as string) // group を string で保持している (i.e. [group1id, group2id])
+  // const groups = (_idTokenPayload['custom:idpGroup'] as string) // group を string で保持している (i.e. [group1id, group2id])
   //   .slice(1, -1) // 先頭と末尾の括弧を削除
   //   .split(/, ?/) // カンマとスペースで分割
   //   .filter(Boolean); // 空文字列を除去;


### PR DESCRIPTION
## 変更内容の説明
RAG (Bedrock Knowledge Base) ユースケースのメタデータフィルタリング機能のうち「Dynamic Filter」を有効にするために rag-knowledge-base.ts のコメントアウト部分を解除してデプロイを試みると、コンパイルエラーが発生します。

```
TSError: ⨯ Unable to compile TypeScript:
../common/src/custom/rag-knowledge-base.ts:26:18 - error TS2552: Cannot find name 'idTokenPayload'. Did you mean '_idTokenPayload'?
```

エラーメッセージに従って、コメントアウト部分のコードに登場する `idTokenPayload` (2箇所) を `_idTokenPayload` に修正しました。

(コメントアウト部分であるのでPRするか迷いましたが・・・ご無礼ありましたら申し訳ございません)

## チェック項目
- [x] `npm run lint` を実行した
- [ ] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み
- [ ] `npm run cdk:test` を実行しスナップショット差分がある場合は `npm run cdk:test:update-snapshot` を実行してスナップショットを更新した

## 関連する Issue
なし
