### PR TITLE
Add an option to set multimodal storage destination

### DIFF
--- a/docs/en/DEPLOY_OPTION.md
+++ b/docs/en/DEPLOY_OPTION.md
@@ -171,10 +171,13 @@ const envs: Record<string, Partial<StackInput>> = {
     ragKnowledgeBaseEnabled: true,
     ragKnowledgeBaseId: 'XXXXXXXXXX',
     ragKnowledgeBaseStandbyReplicas: false,
+    ragKnowledgeBaseMultiModalStorage: true,
     ragKnowledgeBaseAdvancedParsing: false,
     ragKnowledgeBaseAdvancedParsingModelId:
-      'anthropic.claude-3-sonnet-20240229-v1:0',
+      'anthropic.claude-3-5-sonnet-20240620-v1:0',
     embeddingModelId: 'amazon.titan-embed-text-v2:0',
+    rerankingModelId: 'amazon.rerank-v1:0',
+    queryDecompositionEnabled: true,
   },
 };
 ```
@@ -188,8 +191,9 @@ const envs: Record<string, Partial<StackInput>> = {
     "ragKnowledgeBaseEnabled": true,
     "ragKnowledgeBaseId": "XXXXXXXXXX",
     "ragKnowledgeBaseStandbyReplicas": false,
+    "ragKnowledgeBaseMultiModalStorage": true,
     "ragKnowledgeBaseAdvancedParsing": false,
-    "ragKnowledgeBaseAdvancedParsingModelId": "anthropic.claude-3-sonnet-20240229-v1:0",
+    "ragKnowledgeBaseAdvancedParsingModelId": "anthropic.claude-3-5-sonnet-20240620-v1:0",
     "embeddingModelId": "amazon.titan-embed-text-v2:0",
     "rerankingModelId": "amazon.rerank-v1:0",
     "queryDecompositionEnabled": true
@@ -201,6 +205,8 @@ const envs: Record<string, Partial<StackInput>> = {
 
 - `false`: Suitable for development and testing purposes. Runs in a single AZ, reducing OCU costs by half.
 - `true`: Suitable for production environments. Runs across multiple AZs, enabling high availability.
+
+`ragKnowledgeBaseMultiModalStorage` enables the Multimodal Storage Destination for Knowledge Base. When this option is enabled, you can directly parse image files (png/jpeg) and use them for answer generation. It must be used together with Advanced Parsing.
 
 `embeddingModelId` is the model used for embedding. Currently, the following models are supported:
 
@@ -249,8 +255,8 @@ You can enable the [Advanced Parsing feature](https://docs.aws.amazon.com/bedroc
 
 - `ragKnowledgeBaseAdvancedParsing`: Set to `true` to enable Advanced Parsing
 - `ragKnowledgeBaseAdvancedParsingModelId`: Specify the model ID used for extracting information
-  - Supported models (as of 2024/08)
-    - `anthropic.claude-3-sonnet-20240229-v1:0`
+  - Supported models (as of 2025/03)
+    - `anthropic.claude-3-5-sonnet-20240620-v1:0`
     - `anthropic.claude-3-haiku-20240307-v1:0`
 
 **Edit [parameter.ts](/packages/cdk/parameter.ts)**
@@ -262,10 +268,13 @@ const envs: Record<string, Partial<StackInput>> = {
     ragKnowledgeBaseEnabled: true,
     ragKnowledgeBaseId: 'XXXXXXXXXX',
     ragKnowledgeBaseStandbyReplicas: false,
+    ragKnowledgeBaseMultiModalStorage: true,
     ragKnowledgeBaseAdvancedParsing: true,
     ragKnowledgeBaseAdvancedParsingModelId:
-      'anthropic.claude-3-sonnet-20240229-v1:0',
+      'anthropic.claude-3-5-sonnet-20240620-v1:0',
     embeddingModelId: 'amazon.titan-embed-text-v2:0',
+    rerankingModelId: 'amazon.rerank-v1:0',
+    queryDecompositionEnabled: true,
   },
 };
 ```
@@ -279,9 +288,12 @@ const envs: Record<string, Partial<StackInput>> = {
     "ragKnowledgeBaseEnabled": true,
     "ragKnowledgeBaseId": "XXXXXXXXXX",
     "ragKnowledgeBaseStandbyReplicas": false,
+    "ragKnowledgeBaseMultiModalStorage": true,
     "ragKnowledgeBaseAdvancedParsing": true,
-    "ragKnowledgeBaseAdvancedParsingModelId": "anthropic.claude-3-sonnet-20240229-v1:0",
-    "embeddingModelId": "amazon.titan-embed-text-v2:0"
+    "ragKnowledgeBaseAdvancedParsingModelId": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "embeddingModelId": "amazon.titan-embed-text-v2:0",
+    "rerankingModelId": "amazon.rerank-v1:0",
+    "queryDecompositionEnabled": true
   }
 }
 ```
@@ -314,8 +326,10 @@ For [Knowledge Base chunking strategy](./DEPLOY_OPTION.md#changing-chunking-stra
 
 - `embeddingModelId`
 - `ragKnowledgeBaseStandbyReplicas`
+- `ragKnowledgeBaseMultiModalStorage`
 - `ragKnowledgeBaseAdvancedParsing`
 - `ragKnowledgeBaseAdvancedParsingModelId`
+- `ragKnowledgeBaseBinaryVector`
 
 To apply changes, follow these steps to delete and recreate the existing Knowledge Base-related resources:
 

--- a/docs/ja/DEPLOY_OPTION.md
+++ b/docs/ja/DEPLOY_OPTION.md
@@ -171,11 +171,14 @@ const envs: Record<string, Partial<StackInput>> = {
     ragKnowledgeBaseEnabled: true,
     ragKnowledgeBaseId: 'XXXXXXXXXX',
     ragKnowledgeBaseStandbyReplicas: false,
+    ragKnowledgeBaseMultiModalStorage: true,
     ragKnowledgeBaseAdvancedParsing: false,
     ragKnowledgeBaseAdvancedParsingModelId:
-      'anthropic.claude-3-sonnet-20240229-v1:0',
+      'anthropic.claude-3-5-sonnet-20240620-v1:0',
     ragKnowledgeBaseBinaryVector: false,
     embeddingModelId: 'amazon.titan-embed-text-v2:0',
+    rerankingModelId: 'amazon.rerank-v1:0',
+    queryDecompositionEnabled: true,
   },
 };
 ```
@@ -189,8 +192,9 @@ const envs: Record<string, Partial<StackInput>> = {
     "ragKnowledgeBaseEnabled": true,
     "ragKnowledgeBaseId": "XXXXXXXXXX",
     "ragKnowledgeBaseStandbyReplicas": false,
+    "ragKnowledgeBaseMultiModalStorage": true,
     "ragKnowledgeBaseAdvancedParsing": false,
-    "ragKnowledgeBaseAdvancedParsingModelId": "anthropic.claude-3-sonnet-20240229-v1:0",
+    "ragKnowledgeBaseAdvancedParsingModelId": "anthropic.claude-3-5-sonnet-20240620-v1:0",
     "ragKnowledgeBaseBinaryVector": false,
     "embeddingModelId": "amazon.titan-embed-text-v2:0",
     "rerankingModelId": "amazon.rerank-v1:0",
@@ -212,6 +216,8 @@ const envs: Record<string, Partial<StackInput>> = {
 "cohere.embed-multilingual-v3"
 "cohere.embed-english-v3"
 ```
+
+`ragKnowledgeBaseMultiModalStorage` は、Knowledge Base のマルチモーダルストレージの保存先 (Multimodal Storage Destination) を有効化します。本オプションを有効化すると、画像ファイル (png/jpeg) 単体を直接パースし、回答生成に利用することが可能となります。Advanced Parsing と合わせて利用する必要があります。
 
 `rerankingModelId` は reranking に利用するモデルです。現状、以下モデルをサポートしています。（デフォルトは `null`）
 
@@ -251,8 +257,8 @@ Status が Available になれば完了です。S3 に保存されているフ�
 
 - `ragKnowledgeBaseAdvancedParsing` : `true` で Advanced Parsing を有効化
 - `ragKnowledgeBaseAdvancedParsingModelId` : 情報を抽出するときに利用するモデル ID を指定
-  - サポートしているモデル (2024/08 現在)
-    - `anthropic.claude-3-sonnet-20240229-v1:0`
+  - サポートしているモデル (2025/03 現在)
+    - `anthropic.claude-3-5-sonnet-20240620-v1:0`
     - `anthropic.claude-3-haiku-20240307-v1:0`
 
 **[parameter.ts](/packages/cdk/parameter.ts) を編集**
@@ -264,11 +270,14 @@ const envs: Record<string, Partial<StackInput>> = {
     ragKnowledgeBaseEnabled: true,
     ragKnowledgeBaseId: 'XXXXXXXXXX',
     ragKnowledgeBaseStandbyReplicas: false,
+    ragKnowledgeBaseMultiModalStorage: true,
     ragKnowledgeBaseAdvancedParsing: true,
     ragKnowledgeBaseAdvancedParsingModelId:
-      'anthropic.claude-3-sonnet-20240229-v1:0',
+      'anthropic.claude-3-5-sonnet-20240620-v1:0',
     ragKnowledgeBaseBinaryVector: false,
     embeddingModelId: 'amazon.titan-embed-text-v2:0',
+    rerankingModelId: 'amazon.rerank-v1:0',
+    queryDecompositionEnabled: true,
   },
 };
 ```
@@ -282,10 +291,13 @@ const envs: Record<string, Partial<StackInput>> = {
     "ragKnowledgeBaseEnabled": true,
     "ragKnowledgeBaseId": "XXXXXXXXXX",
     "ragKnowledgeBaseStandbyReplicas": false,
+    "ragKnowledgeBaseMultiModalStorage": true,
     "ragKnowledgeBaseAdvancedParsing": true,
-    "ragKnowledgeBaseAdvancedParsingModelId": "anthropic.claude-3-sonnet-20240229-v1:0",
+    "ragKnowledgeBaseAdvancedParsingModelId": "anthropic.claude-3-5-sonnet-20240620-v1:0",
     "ragKnowledgeBaseBinaryVector": false,
-    "embeddingModelId": "amazon.titan-embed-text-v2:0"
+    "embeddingModelId": "amazon.titan-embed-text-v2:0",
+    "rerankingModelId": "amazon.rerank-v1:0",
+    "queryDecompositionEnabled": true
   }
 }
 ```
@@ -328,6 +340,7 @@ chunkingConfiguration: {
 
 - `embeddingModelId`
 - `ragKnowledgeBaseStandbyReplicas`
+- `ragKnowledgeBaseMultiModalStorage`
 - `ragKnowledgeBaseAdvancedParsing`
 - `ragKnowledgeBaseAdvancedParsingModelId`
 - `ragKnowledgeBaseBinaryVector`

--- a/package-lock.json
+++ b/package-lock.json
@@ -497,40 +497,38 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/aws-cognito-identitypool-alpha": {
-      "version": "2.154.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cognito-identitypool-alpha/-/aws-cognito-identitypool-alpha-2.154.1-alpha.0.tgz",
-      "integrity": "sha512-gP9kn2ujY7ndMBoXIj/mlJPTay/pJZP6WhsdWHHRMx817H7gJ1bnZa83agmLBpg8Cdt/G9RQETc9Iwn5007ZQg==",
-      "license": "Apache-2.0",
+      "version": "2.186.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cognito-identitypool-alpha/-/aws-cognito-identitypool-alpha-2.186.0-alpha.0.tgz",
+      "integrity": "sha512-Dzq+HEmEqWjLrbJZ4QsGawGMUGd1bkVpKF2E1c64ax2CcCV0xW8VXUmS71RRcFzhM7qwEN3buWjU03M5sqzUKg==",
+      "deprecated": "This package has been stabilized and moved to aws-cdk-lib",
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.154.1",
+        "aws-cdk-lib": "^2.186.0",
         "constructs": "^10.0.0"
       }
     },
     "node_modules/@aws-cdk/aws-lambda-python-alpha": {
-      "version": "2.154.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.154.1-alpha.0.tgz",
-      "integrity": "sha512-dxF42coofSaoE+czVUX12rlKDERZ2XPSWr2ghs/OnVHdgRoEB63qLQ2uPY8ARZKURZ2Om7RKMIO2hH/eI1gYVQ==",
-      "license": "Apache-2.0",
+      "version": "2.187.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.187.0-alpha.0.tgz",
+      "integrity": "sha512-g6GY0W2SAH7mKzW7KHvkk/cJ5czR+wONONjiTwoWCm03dq17tCCuWENho/+imFbAjMT8NjGZhTw8hREADM7TkQ==",
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.154.1",
+        "aws-cdk-lib": "^2.187.0",
         "constructs": "^10.0.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "40.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-40.7.0.tgz",
-      "integrity": "sha512-00wVKn9pOOGXbeNwA4E8FUFt0zIB4PmSO7PvIiDWgpaFX3G/sWyy0A3s6bg/n2Yvkghu8r4a8ckm+mAzkAYmfA==",
+      "version": "41.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-41.2.0.tgz",
+      "integrity": "sha512-JaulVS6z9y5+u4jNmoWbHZRs9uGOnmn/ktXygNWKNu1k6lF3ad4so3s18eRu15XCbUIomxN9WPYT6Ehh7hzONw==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
-      "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "~1.4.1",
         "semver": "^7.7.1"
@@ -16205,11 +16203,10 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1005.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1005.0.tgz",
-      "integrity": "sha512-4ejfGGrGCEl0pg1xcqkxK0lpBEZqNI48wtrXhk6dYOFYPYMZtqn1kdla29ONN+eO2unewkNF4nLP1lPYhlf9Pg==",
+      "version": "2.1006.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1006.0.tgz",
+      "integrity": "sha512-6qYnCt4mBN+3i/5F+FC2yMETkDHY/IL7gt3EuqKVPcaAO4jU7oXfVSlR60CYRkZWL4fnAurUV14RkJuJyVG/IA==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
       },
@@ -16221,9 +16218,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.185.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.185.0.tgz",
-      "integrity": "sha512-RNcQeNnInumDF1hq3gAf+/A6jhvYDof5a7418gEs/y6359gTYZpTCQkgItC50iV3MmkgerrBAdOE7CDEtQNDWw==",
+      "version": "2.187.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.187.0.tgz",
+      "integrity": "sha512-OrAWin+LD5sZhRF5cWuEYEkmC/sxxlgcAasCpfzeRsj6yDImwmeQsaKhM7xqzZQBInog6ZbN6oFZYiWEGJMSIA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -16237,11 +16234,10 @@
         "yaml",
         "mime-types"
       ],
-      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.227",
+        "@aws-cdk/asset-awscli-v1": "^2.2.229",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^40.7.0",
+        "@aws-cdk/cloud-assembly-schema": "^41.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.0",
@@ -33461,8 +33457,8 @@
     "packages/cdk": {
       "hasInstallScript": true,
       "dependencies": {
-        "@aws-cdk/aws-cognito-identitypool-alpha": "^2.154.1-alpha.0",
-        "@aws-cdk/aws-lambda-python-alpha": "^2.154.1-alpha.0",
+        "@aws-cdk/aws-cognito-identitypool-alpha": "^2.186.0-alpha.0",
+        "@aws-cdk/aws-lambda-python-alpha": "^2.187.0-alpha.0",
         "@aws-sdk/client-bedrock-agent": "^3.755.0",
         "@aws-sdk/client-bedrock-agent-runtime": "^3.755.0",
         "@aws-sdk/client-bedrock-runtime": "^3.755.0",
@@ -33475,7 +33471,7 @@
         "@aws-sdk/lib-dynamodb": "^3.755.0",
         "@aws-sdk/s3-request-presigner": "^3.755.0",
         "@aws-solutions-constructs/aws-cloudfront-s3": "^2.68.0",
-        "aws-cdk-lib": "^2.154.1",
+        "aws-cdk-lib": "^2.187.0",
         "aws-jwt-verify": "^4.0.0",
         "constructs": "^10.3.0",
         "deploy-time-build": "^0.3.17",
@@ -33492,7 +33488,7 @@
         "@types/sanitize-html": "^2.13.0",
         "@typescript-eslint/eslint-plugin": "^7.6.0",
         "@typescript-eslint/parser": "^7.6.0",
-        "aws-cdk": "^2.154.1",
+        "aws-cdk": "^2.1006.0",
         "eslint": "^8.56.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -12,7 +12,7 @@ import { IFunction, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { Table } from 'aws-cdk-lib/aws-dynamodb';
-import { IdentityPool } from '@aws-cdk/aws-cognito-identitypool-alpha';
+import { IdentityPool } from 'aws-cdk-lib/aws-cognito-identitypool';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import {
   BlockPublicAccess,

--- a/packages/cdk/lib/construct/auth.ts
+++ b/packages/cdk/lib/construct/auth.ts
@@ -7,7 +7,7 @@ import {
 import {
   IdentityPool,
   UserPoolAuthenticationProvider,
-} from '@aws-cdk/aws-cognito-identitypool-alpha';
+} from 'aws-cdk-lib/aws-cognito-identitypool';
 import { Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';

--- a/packages/cdk/lib/construct/transcribe.ts
+++ b/packages/cdk/lib/construct/transcribe.ts
@@ -6,7 +6,7 @@ import {
   RestApi,
 } from 'aws-cdk-lib/aws-apigateway';
 import { UserPool } from 'aws-cdk-lib/aws-cognito';
-import { IdentityPool } from '@aws-cdk/aws-cognito-identitypool-alpha';
+import { IdentityPool } from 'aws-cdk-lib/aws-cognito-identitypool';
 import { Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';

--- a/packages/cdk/lib/rag-knowledge-base-stack.ts
+++ b/packages/cdk/lib/rag-knowledge-base-stack.ts
@@ -1,313 +1,290 @@
-import { Stack, StackProps, RemovalPolicy } from 'aws-cdk-lib';
-import { Construct } from 'constructs';
-import * as cdk from 'aws-cdk-lib';
-import * as lambda from 'aws-cdk-lib/aws-lambda';
-import * as bedrock from 'aws-cdk-lib/aws-bedrock';
-import * as oss from 'aws-cdk-lib/aws-opensearchserverless';
-import * as s3 from 'aws-cdk-lib/aws-s3';
-import * as s3Deploy from 'aws-cdk-lib/aws-s3-deployment';
-import * as iam from 'aws-cdk-lib/aws-iam';
-import { ProcessedStackInput } from './stack-input';
+  import { Stack, StackProps, RemovalPolicy } from 'aws-cdk-lib';
+  import { Construct } from 'constructs';
+  import * as cdk from 'aws-cdk-lib';
+  import * as lambda from 'aws-cdk-lib/aws-lambda';
+  import * as bedrock from 'aws-cdk-lib/aws-bedrock';
+  import * as oss from 'aws-cdk-lib/aws-opensearchserverless';
+  import * as s3 from 'aws-cdk-lib/aws-s3';
+  import * as s3Deploy from 'aws-cdk-lib/aws-s3-deployment';
+  import * as iam from 'aws-cdk-lib/aws-iam';
+  import { ProcessedStackInput } from './stack-input';
 
-const UUID = '339C5FED-A1B5-43B6-B40A-5E8E59E5734D';
+  const UUID = '339C5FED-A1B5-43B6-B40A-5E8E59E5734D';
 
-// Embedding models supported by Bedrock
-// Dimension is passed as a prop of the Custom resource, but there is an issue that the type is automatically converted, so it is set to string instead of number.
-// https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1037
-const MODEL_VECTOR_MAPPING: { [key: string]: string } = {
-  'amazon.titan-embed-text-v1': '1536',
-  'amazon.titan-embed-text-v2:0': '1024',
-  'cohere.embed-multilingual-v3': '1024',
-  'cohere.embed-english-v3': '1024',
-};
+  // Embedding models supported by Bedrock
+  // Dimension is passed as a prop of the Custom resource, but there is an issue that the type is automatically converted, so it is set to string instead of number.
+  // https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1037
+  const MODEL_VECTOR_MAPPING: { [key: string]: string } = {
+    'amazon.titan-embed-text-v1': '1536',
+    'amazon.titan-embed-text-v2:0': '1024',
+    'cohere.embed-multilingual-v3': '1024',
+    'cohere.embed-english-v3': '1024',
+  };
 
-// The parsingConfiguration has a feature to read images, graphs, and tables embedded in PDF files.
-// The prompt for reading can be defined arbitrarily. The following is defined as a const. By changing the prompt according to the environment, you can expect higher accuracy.
-// https://docs.aws.amazon.com/bedrock/latest/userguide/kb-chunking-parsing.html#kb-advanced-parsing
-const PARSING_PROMPT = `Write the text from the image, graph, and table content in the document, and output it in Markdown syntax, not a code block. Follow the following steps:
+  // The parsingConfiguration has a feature to read images, graphs, and tables embedded in PDF files.
+  // The prompt for reading can be defined arbitrarily. The following is defined as a const. By changing the prompt according to the environment, you can expect higher accuracy.
+  // https://docs.aws.amazon.com/bedrock/latest/userguide/kb-chunking-parsing.html#kb-advanced-parsing
+  const PARSING_PROMPT = `Write the text from the image, graph, and table content in the document, and output it in Markdown syntax, not a code block. Follow the following steps:
 
-1. Carefully examine the provided page.
+  1. Carefully examine the provided page.
 
-2. Identify all elements on the page. This includes headings, body text, footnotes, tables, visualizations, captions, and page numbers.
+  2. Identify all elements on the page. This includes headings, body text, footnotes, tables, visualizations, captions, and page numbers.
 
-3. Output using Markdown syntax:
-- Headings: Use # for main headings, ## for sections, ### for sub-sections, etc.
-- Lists: Use * or - for bullet points, and 1. 2. 3. for numbered lists.
-- Avoid repetition.
-- IMPORTANT:Output in same language as the document.
+  3. Output using Markdown syntax:
+  - Headings: Use # for main headings, ## for sections, ### for sub-sections, etc.
+  - Lists: Use * or - for bullet points, and 1. 2. 3. for numbered lists.
+  - Avoid repetition.
+  - IMPORTANT:Output in same language as the document.
 
-4. If the element is a Visualization:
-- Provide a detailed description in natural language.
-- Do not transcribe the text in the Visualization after providing the description.
+  4. If the element is a Visualization:
+  - Provide a detailed description in natural language.
+  - Do not transcribe the text in the Visualization after providing the description.
 
-5. If the element is a Table:
-- Create a Markdown table with all rows having the same number of columns.
-- Keep the cell placement as faithful as possible.
-- Do not split the table into multiple tables.
-- If a combined cell spans multiple rows or columns, place the text in the top-left cell and output ' ' for other cells.
-- Use | for column separators and |-|-| for header row separators.
-- If a cell contains multiple items, list them in separate rows.
-- If a table has a sub-header, separate the sub-header from the header on a different row.
+  5. If the element is a Table:
+  - Create a Markdown table with all rows having the same number of columns.
+  - Keep the cell placement as faithful as possible.
+  - Do not split the table into multiple tables.
+  - If a combined cell spans multiple rows or columns, place the text in the top-left cell and output ' ' for other cells.
+  - Use | for column separators and |-|-| for header row separators.
+  - If a cell contains multiple items, list them in separate rows.
+  - If a table has a sub-header, separate the sub-header from the header on a different row.
 
-6. If the element is a Paragraph:
-- Transcribe the text elements as they appear.
+  6. If the element is a Paragraph:
+  - Transcribe the text elements as they appear.
 
-7. If the element is a Header, Footer, Footnote, or Page Number:
-- Transcribe the text elements as they appear.
+  7. If the element is a Header, Footer, Footnote, or Page Number:
+  - Transcribe the text elements as they appear.
 
-Output Example:
+  Output Example:
 
-A bar chart showing annual sales with the Y-axis labeled "Sales ($million)" and the X-axis labeled "Year". The chart has bars for 2018 ($12M), 2019 ($18M), 2020 ($8M), and 2021 ($22M).
-Figure 3: This chart shows annual sales in millions of dollars. 2020 was significantly reduced due to the COVID-19 pandemic.
+  A bar chart showing annual sales with the Y-axis labeled "Sales ($million)" and the X-axis labeled "Year". The chart has bars for 2018 ($12M), 2019 ($18M), 2020 ($8M), and 2021 ($22M).
+  Figure 3: This chart shows annual sales in millions of dollars. 2020 was significantly reduced due to the COVID-19 pandemic.
 
-Annual Report
-Financial Highlights
-Revenue: $40M
-Profit: $12M
-EPS: $1.25
-| | 12/31 ended year | |
+  Annual Report
+  Financial Highlights
+  Revenue: $40M
+  Profit: $12M
+  EPS: $1.25
+  | | 12/31 ended year | |
 
-2021	2022
-Cash Flow:		
-Operating Activity	$ 46,327	$ 46,752
-Investing Activity	(58,154)	(37,601)
-Financial Activity	6,291	9,718`;
+  2021	2022
+  Cash Flow:		
+  Operating Activity	$ 46,327	$ 46,752
+  Investing Activity	(58,154)	(37,601)
+  Financial Activity	6,291	9,718`;
 
-const EMBEDDING_MODELS = Object.keys(MODEL_VECTOR_MAPPING);
+  const EMBEDDING_MODELS = Object.keys(MODEL_VECTOR_MAPPING);
 
-interface OpenSearchServerlessIndexProps {
-  collectionId: string;
-  vectorIndexName: string;
-  vectorField: string;
-  metadataField: string;
-  textField: string;
-  vectorDimension: string;
-  ragKnowledgeBaseBinaryVector: boolean;
-}
-
-class OpenSearchServerlessIndex extends Construct {
-  public readonly customResourceHandler: lambda.IFunction;
-  public readonly customResource: cdk.CustomResource;
-
-  constructor(
-    scope: Construct,
-    id: string,
-    props: OpenSearchServerlessIndexProps
-  ) {
-    super(scope, id);
-
-    const customResourceHandler = new lambda.SingletonFunction(
-      this,
-      'OpenSearchServerlessIndex',
-      {
-        runtime: lambda.Runtime.NODEJS_LATEST,
-        code: lambda.Code.fromAsset('custom-resources'),
-        handler: 'oss-index.handler',
-        uuid: UUID,
-        lambdaPurpose: 'OpenSearchServerlessIndex',
-        timeout: cdk.Duration.minutes(15),
-      }
-    );
-
-    const customResource = new cdk.CustomResource(this, 'CustomResource', {
-      serviceToken: customResourceHandler.functionArn,
-      resourceType: 'Custom::OssIndex',
-      properties: props,
-    });
-
-    this.customResourceHandler = customResourceHandler;
-    this.customResource = customResource;
+  interface OpenSearchServerlessIndexProps {
+    collectionId: string;
+    vectorIndexName: string;
+    vectorField: string;
+    metadataField: string;
+    textField: string;
+    vectorDimension: string;
+    ragKnowledgeBaseBinaryVector: boolean;
   }
-}
 
-export interface RagKnowledgeBaseStackProps extends StackProps {
-  params: ProcessedStackInput;
-  collectionName?: string;
-  vectorIndexName?: string;
-  vectorField?: string;
-  metadataField?: string;
-  textField?: string;
-}
+  class OpenSearchServerlessIndex extends Construct {
+    public readonly customResourceHandler: lambda.IFunction;
+    public readonly customResource: cdk.CustomResource;
 
-export class RagKnowledgeBaseStack extends Stack {
-  public readonly knowledgeBaseId: string;
-  public readonly dataSourceBucketName: string;
-
-  constructor(scope: Construct, id: string, props: RagKnowledgeBaseStackProps) {
-    super(scope, id, props);
-
-    const {
-      env,
-      embeddingModelId,
-      ragKnowledgeBaseStandbyReplicas,
-      ragKnowledgeBaseAdvancedParsing,
-      ragKnowledgeBaseAdvancedParsingModelId,
-      ragKnowledgeBaseBinaryVector,
-      ragKnowledgeBaseMultiModalStorage,
-    } = props.params;
-
-    if (typeof embeddingModelId !== 'string') {
-      throw new Error(
-        'Knowledge Base RAG is enabled, but embeddingModelId is not specified'
-      );
-    }
-
-    if (!EMBEDDING_MODELS.includes(embeddingModelId)) {
-      throw new Error(
-        `embeddingModelId is invalid (valid embeddingModelId: ${EMBEDDING_MODELS})`
-      );
-    }
-
-    const collectionName =
-      props.collectionName ?? `generative-ai-use-cases-jp${env.toLowerCase()}`;
-    const vectorIndexName =
-      props.vectorIndexName ?? 'bedrock-knowledge-base-default';
-    const vectorField =
-      props.vectorField ?? 'bedrock-knowledge-base-default-vector';
-    const textField = props.textField ?? 'AMAZON_BEDROCK_TEXT_CHUNK';
-    const metadataField = props.metadataField ?? 'AMAZON_BEDROCK_METADATA';
-
-    const knowledgeBaseRole = new iam.Role(this, 'KnowledgeBaseRole', {
-      assumedBy: new iam.ServicePrincipal('bedrock.amazonaws.com'),
-    });
-
-    if (
-      ragKnowledgeBaseAdvancedParsing &&
-      typeof ragKnowledgeBaseAdvancedParsingModelId !== 'string'
+    constructor(
+      scope: Construct,
+      id: string,
+      props: OpenSearchServerlessIndexProps
     ) {
-      throw new Error(
-        'Knowledge Base RAG Advanced Parsing is enabled, but ragKnowledgeBaseAdvancedParsingModelId is not specified or is not a string'
+      super(scope, id);
+
+      const customResourceHandler = new lambda.SingletonFunction(
+        this,
+        'OpenSearchServerlessIndex',
+        {
+          runtime: lambda.Runtime.NODEJS_LATEST,
+          code: lambda.Code.fromAsset('custom-resources'),
+          handler: 'oss-index.handler',
+          uuid: UUID,
+          lambdaPurpose: 'OpenSearchServerlessIndex',
+          timeout: cdk.Duration.minutes(15),
+        }
       );
+
+      const customResource = new cdk.CustomResource(this, 'CustomResource', {
+        serviceToken: customResourceHandler.functionArn,
+        resourceType: 'Custom::OssIndex',
+        properties: props,
+      });
+
+      this.customResourceHandler = customResourceHandler;
+      this.customResource = customResource;
     }
+  }
 
-    const collection = new oss.CfnCollection(this, 'Collection', {
-      name: collectionName,
-      description: 'GenU Collection',
-      type: 'VECTORSEARCH',
-      standbyReplicas: ragKnowledgeBaseStandbyReplicas ? 'ENABLED' : 'DISABLED',
-    });
+  export interface RagKnowledgeBaseStackProps extends StackProps {
+    params: ProcessedStackInput;
+    collectionName?: string;
+    vectorIndexName?: string;
+    vectorField?: string;
+    metadataField?: string;
+    textField?: string;
+  }
 
-    const ossIndex = new OpenSearchServerlessIndex(this, 'OssIndex', {
-      collectionId: collection.ref,
-      vectorIndexName,
-      vectorField,
-      textField,
-      metadataField,
-      vectorDimension: MODEL_VECTOR_MAPPING[embeddingModelId],
-      ragKnowledgeBaseBinaryVector,
-    });
+  export class RagKnowledgeBaseStack extends Stack {
+    public readonly knowledgeBaseId: string;
+    public readonly dataSourceBucketName: string;
 
-    ossIndex.customResourceHandler.addToRolePolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        resources: [cdk.Token.asString(collection.getAtt('Arn'))],
-        actions: ['aoss:APIAccessAll'],
-      })
-    );
+    constructor(scope: Construct, id: string, props: RagKnowledgeBaseStackProps) {
+      super(scope, id, props);
 
-    const accessPolicy = new oss.CfnAccessPolicy(this, 'AccessPolicy', {
-      name: collectionName,
-      policy: JSON.stringify([
-        {
-          Rules: [
-            {
-              Resource: [`collection/${collectionName}`],
-              Permission: [
-                'aoss:DescribeCollectionItems',
-                'aoss:CreateCollectionItems',
-                'aoss:UpdateCollectionItems',
-              ],
-              ResourceType: 'collection',
-            },
-            {
-              Resource: [`index/${collectionName}/*`],
-              Permission: [
-                'aoss:UpdateIndex',
-                'aoss:DescribeIndex',
-                'aoss:ReadDocument',
-                'aoss:WriteDocument',
-                'aoss:CreateIndex',
-                'aoss:DeleteIndex',
-              ],
-              ResourceType: 'index',
-            },
-          ],
-          Principal: [
-            knowledgeBaseRole.roleArn,
-            ossIndex.customResourceHandler.role?.roleArn,
-          ],
-          Description: '',
-        },
-      ]),
-      type: 'data',
-    });
+      const {
+        env,
+        embeddingModelId,
+        ragKnowledgeBaseStandbyReplicas,
+        ragKnowledgeBaseAdvancedParsing,
+        ragKnowledgeBaseAdvancedParsingModelId,
+        ragKnowledgeBaseBinaryVector,
+        ragKnowledgeBaseMultiModalStorage,
+      } = props.params;
 
-    const networkPolicy = new oss.CfnSecurityPolicy(this, 'NetworkPolicy', {
-      name: collectionName,
-      policy: JSON.stringify([
-        {
-          Rules: [
-            {
-              Resource: [`collection/${collectionName}`],
-              ResourceType: 'collection',
-            },
-            {
-              Resource: [`collection/${collectionName}`],
-              ResourceType: 'dashboard',
-            },
-          ],
-          AllowFromPublic: true,
-        },
-      ]),
-      type: 'network',
-    });
-
-    const encryptionPolicy = new oss.CfnSecurityPolicy(
-      this,
-      'EncryptionPolicy',
-      {
-        name: collectionName,
-        policy: JSON.stringify({
-          Rules: [
-            {
-              Resource: [`collection/${collectionName}`],
-              ResourceType: 'collection',
-            },
-          ],
-          AWSOwnedKey: true,
-        }),
-        type: 'encryption',
+      if (typeof embeddingModelId !== 'string') {
+        throw new Error(
+          'Knowledge Base RAG is enabled, but embeddingModelId is not specified'
+        );
       }
-    );
 
-    collection.node.addDependency(accessPolicy);
-    collection.node.addDependency(networkPolicy);
-    collection.node.addDependency(encryptionPolicy);
+      if (!EMBEDDING_MODELS.includes(embeddingModelId)) {
+        throw new Error(
+          `embeddingModelId is invalid (valid embeddingModelId: ${EMBEDDING_MODELS})`
+        );
+      }
 
-    const accessLogsBucket = new s3.Bucket(this, 'DataSourceAccessLogsBucket', {
-      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-      encryption: s3.BucketEncryption.S3_MANAGED,
-      autoDeleteObjects: true,
-      removalPolicy: RemovalPolicy.DESTROY,
-      objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
-      enforceSSL: true,
-    });
+      const collectionName =
+        props.collectionName ?? `generative-ai-use-cases-jp${env.toLowerCase()}`;
+      const vectorIndexName =
+        props.vectorIndexName ?? 'bedrock-knowledge-base-default';
+      const vectorField =
+        props.vectorField ?? 'bedrock-knowledge-base-default-vector';
+      const textField = props.textField ?? 'AMAZON_BEDROCK_TEXT_CHUNK';
+      const metadataField = props.metadataField ?? 'AMAZON_BEDROCK_METADATA';
 
-    const dataSourceBucket = new s3.Bucket(this, 'DataSourceBucket', {
-      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-      encryption: s3.BucketEncryption.S3_MANAGED,
-      autoDeleteObjects: true,
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
-      objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
-      serverAccessLogsBucket: accessLogsBucket,
-      serverAccessLogsPrefix: 'AccessLogs/',
-      enforceSSL: true,
-    });
+      const knowledgeBaseRole = new iam.Role(this, 'KnowledgeBaseRole', {
+        assumedBy: new iam.ServicePrincipal('bedrock.amazonaws.com'),
+      });
 
-    let multiModalStorageBucket: s3.Bucket | undefined;
+      if (
+        ragKnowledgeBaseAdvancedParsing &&
+        typeof ragKnowledgeBaseAdvancedParsingModelId !== 'string'
+      ) {
+        throw new Error(
+          'Knowledge Base RAG Advanced Parsing is enabled, but ragKnowledgeBaseAdvancedParsingModelId is not specified or is not a string'
+        );
+      }
 
-    if (ragKnowledgeBaseMultiModalStorage) {
-      const multiModalStorageAccessLogsBucket = new s3.Bucket(this, 'MultiModalStorageAccessLogsBucket', {
+      const collection = new oss.CfnCollection(this, 'Collection', {
+        name: collectionName,
+        description: 'GenU Collection',
+        type: 'VECTORSEARCH',
+        standbyReplicas: ragKnowledgeBaseStandbyReplicas ? 'ENABLED' : 'DISABLED',
+      });
+
+      const ossIndex = new OpenSearchServerlessIndex(this, 'OssIndex', {
+        collectionId: collection.ref,
+        vectorIndexName,
+        vectorField,
+        textField,
+        metadataField,
+        vectorDimension: MODEL_VECTOR_MAPPING[embeddingModelId],
+        ragKnowledgeBaseBinaryVector,
+      });
+
+      ossIndex.customResourceHandler.addToRolePolicy(
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          resources: [cdk.Token.asString(collection.getAtt('Arn'))],
+          actions: ['aoss:APIAccessAll'],
+        })
+      );
+
+      const accessPolicy = new oss.CfnAccessPolicy(this, 'AccessPolicy', {
+        name: collectionName,
+        policy: JSON.stringify([
+          {
+            Rules: [
+              {
+                Resource: [`collection/${collectionName}`],
+                Permission: [
+                  'aoss:DescribeCollectionItems',
+                  'aoss:CreateCollectionItems',
+                  'aoss:UpdateCollectionItems',
+                ],
+                ResourceType: 'collection',
+              },
+              {
+                Resource: [`index/${collectionName}/*`],
+                Permission: [
+                  'aoss:UpdateIndex',
+                  'aoss:DescribeIndex',
+                  'aoss:ReadDocument',
+                  'aoss:WriteDocument',
+                  'aoss:CreateIndex',
+                  'aoss:DeleteIndex',
+                ],
+                ResourceType: 'index',
+              },
+            ],
+            Principal: [
+              knowledgeBaseRole.roleArn,
+              ossIndex.customResourceHandler.role?.roleArn,
+            ],
+            Description: '',
+          },
+        ]),
+        type: 'data',
+      });
+
+      const networkPolicy = new oss.CfnSecurityPolicy(this, 'NetworkPolicy', {
+        name: collectionName,
+        policy: JSON.stringify([
+          {
+            Rules: [
+              {
+                Resource: [`collection/${collectionName}`],
+                ResourceType: 'collection',
+              },
+              {
+                Resource: [`collection/${collectionName}`],
+                ResourceType: 'dashboard',
+              },
+            ],
+            AllowFromPublic: true,
+          },
+        ]),
+        type: 'network',
+      });
+
+      const encryptionPolicy = new oss.CfnSecurityPolicy(
+        this,
+        'EncryptionPolicy',
+        {
+          name: collectionName,
+          policy: JSON.stringify({
+            Rules: [
+              {
+                Resource: [`collection/${collectionName}`],
+                ResourceType: 'collection',
+              },
+            ],
+            AWSOwnedKey: true,
+          }),
+          type: 'encryption',
+        }
+      );
+
+      collection.node.addDependency(accessPolicy);
+      collection.node.addDependency(networkPolicy);
+      collection.node.addDependency(encryptionPolicy);
+
+      const accessLogsBucket = new s3.Bucket(this, 'DataSourceAccessLogsBucket', {
         blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
         encryption: s3.BucketEncryption.S3_MANAGED,
         autoDeleteObjects: true,
@@ -315,180 +292,222 @@ export class RagKnowledgeBaseStack extends Stack {
         objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
         enforceSSL: true,
       });
-    
-      multiModalStorageBucket = new s3.Bucket(this, 'MultiModalStorageBucket', {
+
+      const dataSourceBucket = new s3.Bucket(this, 'DataSourceBucket', {
         blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
         encryption: s3.BucketEncryption.S3_MANAGED,
         autoDeleteObjects: true,
         removalPolicy: cdk.RemovalPolicy.DESTROY,
         objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
-        serverAccessLogsBucket: multiModalStorageAccessLogsBucket,
+        serverAccessLogsBucket: accessLogsBucket,
         serverAccessLogsPrefix: 'AccessLogs/',
         enforceSSL: true,
       });
-    }
 
-    knowledgeBaseRole.addToPolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        resources: ['*'],
-        actions: ['bedrock:InvokeModel'],
-      })
-    );
+      let multiModalStorageBucket: s3.Bucket | undefined;
 
-    knowledgeBaseRole.addToPolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        resources: [cdk.Token.asString(collection.getAtt('Arn'))],
-        actions: ['aoss:APIAccessAll'],
-      })
-    );
+      if (ragKnowledgeBaseMultiModalStorage) {
+        const multiModalStorageAccessLogsBucket = new s3.Bucket(this, 'MultiModalStorageAccessLogsBucket', {
+          blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+          encryption: s3.BucketEncryption.S3_MANAGED,
+          autoDeleteObjects: true,
+          removalPolicy: RemovalPolicy.DESTROY,
+          objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
+          enforceSSL: true,
+        });
+      
+        multiModalStorageBucket = new s3.Bucket(this, 'MultiModalStorageBucket', {
+          blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+          encryption: s3.BucketEncryption.S3_MANAGED,
+          autoDeleteObjects: true,
+          removalPolicy: cdk.RemovalPolicy.DESTROY,
+          objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
+          serverAccessLogsBucket: multiModalStorageAccessLogsBucket,
+          serverAccessLogsPrefix: 'AccessLogs/',
+          enforceSSL: true,
+        });
+      }
 
-    knowledgeBaseRole.addToPolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        resources: [`arn:aws:s3:::${dataSourceBucket.bucketName}`],
-        actions: ['s3:ListBucket'],
-      })
-    );
+      knowledgeBaseRole.addToPolicy(
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          resources: ['*'],
+          actions: ['bedrock:InvokeModel'],
+        })
+      );
 
-    knowledgeBaseRole.addToPolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        resources: [`arn:aws:s3:::${dataSourceBucket.bucketName}/*`],
-        actions: ['s3:GetObject'],
-      })
-    );
+      knowledgeBaseRole.addToPolicy(
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          resources: [cdk.Token.asString(collection.getAtt('Arn'))],
+          actions: ['aoss:APIAccessAll'],
+        })
+      );
 
-    const knowledgeBase = new bedrock.CfnKnowledgeBase(this, 'KnowledgeBase', {
-      name: collectionName,
-      roleArn: knowledgeBaseRole.roleArn,
-      knowledgeBaseConfiguration: {
-        type: 'VECTOR',
-        vectorKnowledgeBaseConfiguration: {
-          embeddingModelArn: `arn:aws:bedrock:${this.region}::foundation-model/${embeddingModelId}`,
-          ...(ragKnowledgeBaseBinaryVector
-            ? {
-                embeddingModelConfiguration: {
-                  bedrockEmbeddingModelConfiguration: {
-                    embeddingDataType: 'BINARY',
-                  },
-                },
-              }
-            : {}),
-          ...(ragKnowledgeBaseMultiModalStorage && multiModalStorageBucket
-            ? {
-                supplementalDataStorageConfiguration: {
-                  supplementalDataStorageLocations: [
-                    {
-                      supplementalDataStorageLocationType: 'S3',
-                      s3Location: {
-                        uri: `s3://${multiModalStorageBucket.bucketName}`,
-                      },
+      knowledgeBaseRole.addToPolicy(
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          resources: [`arn:aws:s3:::${dataSourceBucket.bucketName}`],
+          actions: ['s3:ListBucket'],
+        })
+      );
+
+      knowledgeBaseRole.addToPolicy(
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          resources: [`arn:aws:s3:::${dataSourceBucket.bucketName}/*`],
+          actions: ['s3:GetObject'],
+        })
+      );
+
+      if (ragKnowledgeBaseMultiModalStorage && multiModalStorageBucket) {
+        knowledgeBaseRole.addToPolicy(
+          new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            resources: [`arn:aws:s3:::${multiModalStorageBucket.bucketName}`],
+            actions: ['s3:ListBucket'],
+          })
+        );
+      
+        knowledgeBaseRole.addToPolicy(
+          new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            resources: [`arn:aws:s3:::${multiModalStorageBucket.bucketName}/*`],
+            actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject' ],
+          })
+        );
+       
+      }
+
+      const knowledgeBase = new bedrock.CfnKnowledgeBase(this, 'KnowledgeBase', {
+        name: collectionName,
+        roleArn: knowledgeBaseRole.roleArn,
+        knowledgeBaseConfiguration: {
+          type: 'VECTOR',
+          vectorKnowledgeBaseConfiguration: {
+            embeddingModelArn: `arn:aws:bedrock:${this.region}::foundation-model/${embeddingModelId}`,
+            ...(ragKnowledgeBaseBinaryVector
+              ? {
+                  embeddingModelConfiguration: {
+                    bedrockEmbeddingModelConfiguration: {
+                      embeddingDataType: 'BINARY',
                     },
-                  ],
+                  },
+                }
+              : {}),
+            ...(ragKnowledgeBaseMultiModalStorage && multiModalStorageBucket
+              ? {
+                  supplementalDataStorageConfiguration: {
+                    supplementalDataStorageLocations: [
+                      {
+                        supplementalDataStorageLocationType: 'S3',
+                        s3Location: {
+                          uri: `s3://${multiModalStorageBucket.bucketName}`,
+                        },
+                      },
+                    ],
+                  },
+                }
+              : {}),
+          },
+        },
+        storageConfiguration: {
+          type: 'OPENSEARCH_SERVERLESS',
+          opensearchServerlessConfiguration: {
+            collectionArn: cdk.Token.asString(collection.getAtt('Arn')),
+            fieldMapping: {
+              metadataField,
+              textField,
+              vectorField,
+            },
+            vectorIndexName,
+          },
+        },
+      });
+
+      new bedrock.CfnDataSource(this, 'DataSource', {
+        dataSourceConfiguration: {
+          s3Configuration: {
+            bucketArn: `arn:aws:s3:::${dataSourceBucket.bucketName}`,
+            inclusionPrefixes: ['docs/'],
+          },
+          type: 'S3',
+        },
+        vectorIngestionConfiguration: {
+          ...(ragKnowledgeBaseAdvancedParsing
+            ? {
+                // Enable Advanced Parsing only if it is enabled
+                parsingConfiguration: {
+                  parsingStrategy: 'BEDROCK_FOUNDATION_MODEL',
+                  bedrockFoundationModelConfiguration: {
+                    modelArn: `arn:aws:bedrock:${this.region}::foundation-model/${ragKnowledgeBaseAdvancedParsingModelId}`,
+                    parsingPrompt: {
+                      parsingPromptText: PARSING_PROMPT,
+                    },
+                  },
                 },
               }
             : {}),
+          // If you want to change the chunking strategy, uncomment the following and adjust the various parameters to build an environment suitable for your needs.
+          // The following 4 types of chunking strategies are available.
+          // - Default (no specification)
+          // - Semantic Chunk
+          // - Hierarchical Chunk
+          // - Standard Chunk
+          // Please refer to the following Document for details.
+          // https://docs.aws.amazon.com/bedrock/latest/userguide/kb-chunking-parsing.html
+          // https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_bedrock.CfnDataSource.ChunkingConfigurationProperty.html
+          //
+          // Semantic Chunk
+          // chunkingConfiguration: {
+          //   chunkingStrategy: 'SEMANTIC',
+          //   semanticChunkingConfiguration: {
+          //     maxTokens: 300,
+          //     bufferSize: 0,
+          //     breakpointPercentileThreshold: 95,
+          //   },
+          // },
+          //
+          // Hierarchical Chunk
+          // chunkingConfiguration: {
+          //   chunkingStrategy: 'HIERARCHICAL',
+          //   hierarchicalChunkingConfiguration: {
+          //     levelConfigurations: [
+          //       {
+          //         maxTokens: 1500, // Max Token size of the parent chunk
+          //       },
+          //       {
+          //         maxTokens: 300, // Max Token size of the child chunk
+          //       },
+          //     ],
+          //     overlapTokens: 60,
+          //   },
+          // },
+          //
+          // Standard Chunk
+          // chunkingConfiguration: {
+          //   chunkingStrategy: 'FIXED_SIZE',
+          //   fixedSizeChunkingConfiguration: {
+          //     maxTokens: 300,
+          //     overlapPercentage: 10,
+          //   },
+          // },
         },
-      },
-      storageConfiguration: {
-        type: 'OPENSEARCH_SERVERLESS',
-        opensearchServerlessConfiguration: {
-          collectionArn: cdk.Token.asString(collection.getAtt('Arn')),
-          fieldMapping: {
-            metadataField,
-            textField,
-            vectorField,
-          },
-          vectorIndexName,
-        },
-      },
-    });
+        knowledgeBaseId: knowledgeBase.ref,
+        name: 's3-data-source',
+      });
 
-    new bedrock.CfnDataSource(this, 'DataSource', {
-      dataSourceConfiguration: {
-        s3Configuration: {
-          bucketArn: `arn:aws:s3:::${dataSourceBucket.bucketName}`,
-          inclusionPrefixes: ['docs/'],
-        },
-        type: 'S3',
-      },
-      vectorIngestionConfiguration: {
-        ...(ragKnowledgeBaseAdvancedParsing
-          ? {
-              // Enable Advanced Parsing only if it is enabled
-              parsingConfiguration: {
-                parsingStrategy: 'BEDROCK_FOUNDATION_MODEL',
-                bedrockFoundationModelConfiguration: {
-                  modelArn: `arn:aws:bedrock:${this.region}::foundation-model/${ragKnowledgeBaseAdvancedParsingModelId}`,
-                  parsingPrompt: {
-                    parsingPromptText: PARSING_PROMPT,
-                  },
-                },
-              },
-            }
-          : {}),
-        // If you want to change the chunking strategy, uncomment the following and adjust the various parameters to build an environment suitable for your needs.
-        // The following 4 types of chunking strategies are available.
-        // - Default (no specification)
-        // - Semantic Chunk
-        // - Hierarchical Chunk
-        // - Standard Chunk
-        // Please refer to the following Document for details.
-        // https://docs.aws.amazon.com/bedrock/latest/userguide/kb-chunking-parsing.html
-        // https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_bedrock.CfnDataSource.ChunkingConfigurationProperty.html
-        //
-        // Semantic Chunk
-        // chunkingConfiguration: {
-        //   chunkingStrategy: 'SEMANTIC',
-        //   semanticChunkingConfiguration: {
-        //     maxTokens: 300,
-        //     bufferSize: 0,
-        //     breakpointPercentileThreshold: 95,
-        //   },
-        // },
-        //
-        // Hierarchical Chunk
-        // chunkingConfiguration: {
-        //   chunkingStrategy: 'HIERARCHICAL',
-        //   hierarchicalChunkingConfiguration: {
-        //     levelConfigurations: [
-        //       {
-        //         maxTokens: 1500, // Max Token size of the parent chunk
-        //       },
-        //       {
-        //         maxTokens: 300, // Max Token size of the child chunk
-        //       },
-        //     ],
-        //     overlapTokens: 60,
-        //   },
-        // },
-        //
-        // Standard Chunk
-        // chunkingConfiguration: {
-        //   chunkingStrategy: 'FIXED_SIZE',
-        //   fixedSizeChunkingConfiguration: {
-        //     maxTokens: 300,
-        //     overlapPercentage: 10,
-        //   },
-        // },
-      },
-      knowledgeBaseId: knowledgeBase.ref,
-      name: 's3-data-source',
-    });
+      knowledgeBase.addDependency(collection);
+      knowledgeBase.node.addDependency(ossIndex.customResource);
 
-    knowledgeBase.addDependency(collection);
-    knowledgeBase.node.addDependency(ossIndex.customResource);
+      new s3Deploy.BucketDeployment(this, 'DeployDocs', {
+        sources: [s3Deploy.Source.asset('./rag-docs')],
+        destinationBucket: dataSourceBucket,
+        // There is a possibility that access logs are still in the same Bucket from the previous configuration, so this setting is left.
+        exclude: ['AccessLogs/*', 'logs*'],
+      });
 
-    new s3Deploy.BucketDeployment(this, 'DeployDocs', {
-      sources: [s3Deploy.Source.asset('./rag-docs')],
-      destinationBucket: dataSourceBucket,
-      // There is a possibility that access logs are still in the same Bucket from the previous configuration, so this setting is left.
-      exclude: ['AccessLogs/*', 'logs*'],
-    });
-
-    this.knowledgeBaseId = knowledgeBase.ref;
-    this.dataSourceBucketName = dataSourceBucket.bucketName;
+      this.knowledgeBaseId = knowledgeBase.ref;
+      this.dataSourceBucketName = dataSourceBucket.bucketName;
+    }
   }
-}

--- a/packages/cdk/lib/rag-knowledge-base-stack.ts
+++ b/packages/cdk/lib/rag-knowledge-base-stack.ts
@@ -1,30 +1,30 @@
-  import { Stack, StackProps, RemovalPolicy } from 'aws-cdk-lib';
-  import { Construct } from 'constructs';
-  import * as cdk from 'aws-cdk-lib';
-  import * as lambda from 'aws-cdk-lib/aws-lambda';
-  import * as bedrock from 'aws-cdk-lib/aws-bedrock';
-  import * as oss from 'aws-cdk-lib/aws-opensearchserverless';
-  import * as s3 from 'aws-cdk-lib/aws-s3';
-  import * as s3Deploy from 'aws-cdk-lib/aws-s3-deployment';
-  import * as iam from 'aws-cdk-lib/aws-iam';
-  import { ProcessedStackInput } from './stack-input';
+import { Stack, StackProps, RemovalPolicy } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as bedrock from 'aws-cdk-lib/aws-bedrock';
+import * as oss from 'aws-cdk-lib/aws-opensearchserverless';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as s3Deploy from 'aws-cdk-lib/aws-s3-deployment';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { ProcessedStackInput } from './stack-input';
 
-  const UUID = '339C5FED-A1B5-43B6-B40A-5E8E59E5734D';
+const UUID = '339C5FED-A1B5-43B6-B40A-5E8E59E5734D';
 
-  // Embedding models supported by Bedrock
-  // Dimension is passed as a prop of the Custom resource, but there is an issue that the type is automatically converted, so it is set to string instead of number.
-  // https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1037
-  const MODEL_VECTOR_MAPPING: { [key: string]: string } = {
-    'amazon.titan-embed-text-v1': '1536',
-    'amazon.titan-embed-text-v2:0': '1024',
-    'cohere.embed-multilingual-v3': '1024',
-    'cohere.embed-english-v3': '1024',
-  };
+// Embedding models supported by Bedrock
+// Dimension is passed as a prop of the Custom resource, but there is an issue that the type is automatically converted, so it is set to string instead of number.
+// https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1037
+const MODEL_VECTOR_MAPPING: { [key: string]: string } = {
+  'amazon.titan-embed-text-v1': '1536',
+  'amazon.titan-embed-text-v2:0': '1024',
+  'cohere.embed-multilingual-v3': '1024',
+  'cohere.embed-english-v3': '1024',
+};
 
-  // The parsingConfiguration has a feature to read images, graphs, and tables embedded in PDF files.
-  // The prompt for reading can be defined arbitrarily. The following is defined as a const. By changing the prompt according to the environment, you can expect higher accuracy.
-  // https://docs.aws.amazon.com/bedrock/latest/userguide/kb-chunking-parsing.html#kb-advanced-parsing
-  const PARSING_PROMPT = `Write the text from the image, graph, and table content in the document, and output it in Markdown syntax, not a code block. Follow the following steps:
+// The parsingConfiguration has a feature to read images, graphs, and tables embedded in PDF files.
+// The prompt for reading can be defined arbitrarily. The following is defined as a const. By changing the prompt according to the environment, you can expect higher accuracy.
+// https://docs.aws.amazon.com/bedrock/latest/userguide/kb-chunking-parsing.html#kb-advanced-parsing
+const PARSING_PROMPT = `Write the text from the image, graph, and table content in the document, and output it in Markdown syntax, not a code block. Follow the following steps:
 
   1. Carefully examine the provided page.
 
@@ -73,281 +73,302 @@
   Investing Activity	(58,154)	(37,601)
   Financial Activity	6,291	9,718`;
 
-  const EMBEDDING_MODELS = Object.keys(MODEL_VECTOR_MAPPING);
+const EMBEDDING_MODELS = Object.keys(MODEL_VECTOR_MAPPING);
 
-  interface OpenSearchServerlessIndexProps {
-    collectionId: string;
-    vectorIndexName: string;
-    vectorField: string;
-    metadataField: string;
-    textField: string;
-    vectorDimension: string;
-    ragKnowledgeBaseBinaryVector: boolean;
+interface OpenSearchServerlessIndexProps {
+  collectionId: string;
+  vectorIndexName: string;
+  vectorField: string;
+  metadataField: string;
+  textField: string;
+  vectorDimension: string;
+  ragKnowledgeBaseBinaryVector: boolean;
+}
+
+class OpenSearchServerlessIndex extends Construct {
+  public readonly customResourceHandler: lambda.IFunction;
+  public readonly customResource: cdk.CustomResource;
+
+  constructor(
+    scope: Construct,
+    id: string,
+    props: OpenSearchServerlessIndexProps
+  ) {
+    super(scope, id);
+
+    const customResourceHandler = new lambda.SingletonFunction(
+      this,
+      'OpenSearchServerlessIndex',
+      {
+        runtime: lambda.Runtime.NODEJS_LATEST,
+        code: lambda.Code.fromAsset('custom-resources'),
+        handler: 'oss-index.handler',
+        uuid: UUID,
+        lambdaPurpose: 'OpenSearchServerlessIndex',
+        timeout: cdk.Duration.minutes(15),
+      }
+    );
+
+    const customResource = new cdk.CustomResource(this, 'CustomResource', {
+      serviceToken: customResourceHandler.functionArn,
+      resourceType: 'Custom::OssIndex',
+      properties: props,
+    });
+
+    this.customResourceHandler = customResourceHandler;
+    this.customResource = customResource;
   }
+}
 
-  class OpenSearchServerlessIndex extends Construct {
-    public readonly customResourceHandler: lambda.IFunction;
-    public readonly customResource: cdk.CustomResource;
+export interface RagKnowledgeBaseStackProps extends StackProps {
+  params: ProcessedStackInput;
+  collectionName?: string;
+  vectorIndexName?: string;
+  vectorField?: string;
+  metadataField?: string;
+  textField?: string;
+}
 
-    constructor(
-      scope: Construct,
-      id: string,
-      props: OpenSearchServerlessIndexProps
-    ) {
-      super(scope, id);
+export class RagKnowledgeBaseStack extends Stack {
+  public readonly knowledgeBaseId: string;
+  public readonly dataSourceBucketName: string;
 
-      const customResourceHandler = new lambda.SingletonFunction(
-        this,
-        'OpenSearchServerlessIndex',
-        {
-          runtime: lambda.Runtime.NODEJS_LATEST,
-          code: lambda.Code.fromAsset('custom-resources'),
-          handler: 'oss-index.handler',
-          uuid: UUID,
-          lambdaPurpose: 'OpenSearchServerlessIndex',
-          timeout: cdk.Duration.minutes(15),
-        }
+  constructor(scope: Construct, id: string, props: RagKnowledgeBaseStackProps) {
+    super(scope, id, props);
+
+    const {
+      env,
+      embeddingModelId,
+      ragKnowledgeBaseStandbyReplicas,
+      ragKnowledgeBaseAdvancedParsing,
+      ragKnowledgeBaseAdvancedParsingModelId,
+      ragKnowledgeBaseBinaryVector,
+      ragKnowledgeBaseMultiModalStorage,
+    } = props.params;
+
+    if (typeof embeddingModelId !== 'string') {
+      throw new Error(
+        'Knowledge Base RAG is enabled, but embeddingModelId is not specified'
       );
-
-      const customResource = new cdk.CustomResource(this, 'CustomResource', {
-        serviceToken: customResourceHandler.functionArn,
-        resourceType: 'Custom::OssIndex',
-        properties: props,
-      });
-
-      this.customResourceHandler = customResourceHandler;
-      this.customResource = customResource;
     }
-  }
 
-  export interface RagKnowledgeBaseStackProps extends StackProps {
-    params: ProcessedStackInput;
-    collectionName?: string;
-    vectorIndexName?: string;
-    vectorField?: string;
-    metadataField?: string;
-    textField?: string;
-  }
-
-  export class RagKnowledgeBaseStack extends Stack {
-    public readonly knowledgeBaseId: string;
-    public readonly dataSourceBucketName: string;
-
-    constructor(scope: Construct, id: string, props: RagKnowledgeBaseStackProps) {
-      super(scope, id, props);
-
-      const {
-        env,
-        embeddingModelId,
-        ragKnowledgeBaseStandbyReplicas,
-        ragKnowledgeBaseAdvancedParsing,
-        ragKnowledgeBaseAdvancedParsingModelId,
-        ragKnowledgeBaseBinaryVector,
-        ragKnowledgeBaseMultiModalStorage,
-      } = props.params;
-
-      if (typeof embeddingModelId !== 'string') {
-        throw new Error(
-          'Knowledge Base RAG is enabled, but embeddingModelId is not specified'
-        );
-      }
-
-      if (!EMBEDDING_MODELS.includes(embeddingModelId)) {
-        throw new Error(
-          `embeddingModelId is invalid (valid embeddingModelId: ${EMBEDDING_MODELS})`
-        );
-      }
-
-      const collectionName =
-        props.collectionName ?? `generative-ai-use-cases-jp${env.toLowerCase()}`;
-      const vectorIndexName =
-        props.vectorIndexName ?? 'bedrock-knowledge-base-default';
-      const vectorField =
-        props.vectorField ?? 'bedrock-knowledge-base-default-vector';
-      const textField = props.textField ?? 'AMAZON_BEDROCK_TEXT_CHUNK';
-      const metadataField = props.metadataField ?? 'AMAZON_BEDROCK_METADATA';
-
-      const knowledgeBaseRole = new iam.Role(this, 'KnowledgeBaseRole', {
-        assumedBy: new iam.ServicePrincipal('bedrock.amazonaws.com'),
-      });
-
-      if (
-        ragKnowledgeBaseAdvancedParsing &&
-        typeof ragKnowledgeBaseAdvancedParsingModelId !== 'string'
-      ) {
-        throw new Error(
-          'Knowledge Base RAG Advanced Parsing is enabled, but ragKnowledgeBaseAdvancedParsingModelId is not specified or is not a string'
-        );
-      }
-
-      const collection = new oss.CfnCollection(this, 'Collection', {
-        name: collectionName,
-        description: 'GenU Collection',
-        type: 'VECTORSEARCH',
-        standbyReplicas: ragKnowledgeBaseStandbyReplicas ? 'ENABLED' : 'DISABLED',
-      });
-
-      const ossIndex = new OpenSearchServerlessIndex(this, 'OssIndex', {
-        collectionId: collection.ref,
-        vectorIndexName,
-        vectorField,
-        textField,
-        metadataField,
-        vectorDimension: MODEL_VECTOR_MAPPING[embeddingModelId],
-        ragKnowledgeBaseBinaryVector,
-      });
-
-      ossIndex.customResourceHandler.addToRolePolicy(
-        new iam.PolicyStatement({
-          effect: iam.Effect.ALLOW,
-          resources: [cdk.Token.asString(collection.getAtt('Arn'))],
-          actions: ['aoss:APIAccessAll'],
-        })
+    if (!EMBEDDING_MODELS.includes(embeddingModelId)) {
+      throw new Error(
+        `embeddingModelId is invalid (valid embeddingModelId: ${EMBEDDING_MODELS})`
       );
+    }
 
-      const accessPolicy = new oss.CfnAccessPolicy(this, 'AccessPolicy', {
-        name: collectionName,
-        policy: JSON.stringify([
-          {
-            Rules: [
-              {
-                Resource: [`collection/${collectionName}`],
-                Permission: [
-                  'aoss:DescribeCollectionItems',
-                  'aoss:CreateCollectionItems',
-                  'aoss:UpdateCollectionItems',
-                ],
-                ResourceType: 'collection',
-              },
-              {
-                Resource: [`index/${collectionName}/*`],
-                Permission: [
-                  'aoss:UpdateIndex',
-                  'aoss:DescribeIndex',
-                  'aoss:ReadDocument',
-                  'aoss:WriteDocument',
-                  'aoss:CreateIndex',
-                  'aoss:DeleteIndex',
-                ],
-                ResourceType: 'index',
-              },
-            ],
-            Principal: [
-              knowledgeBaseRole.roleArn,
-              ossIndex.customResourceHandler.role?.roleArn,
-            ],
-            Description: '',
-          },
-        ]),
-        type: 'data',
-      });
+    const collectionName =
+      props.collectionName ?? `generative-ai-use-cases-jp${env.toLowerCase()}`;
+    const vectorIndexName =
+      props.vectorIndexName ?? 'bedrock-knowledge-base-default';
+    const vectorField =
+      props.vectorField ?? 'bedrock-knowledge-base-default-vector';
+    const textField = props.textField ?? 'AMAZON_BEDROCK_TEXT_CHUNK';
+    const metadataField = props.metadataField ?? 'AMAZON_BEDROCK_METADATA';
 
-      const networkPolicy = new oss.CfnSecurityPolicy(this, 'NetworkPolicy', {
-        name: collectionName,
-        policy: JSON.stringify([
-          {
-            Rules: [
-              {
-                Resource: [`collection/${collectionName}`],
-                ResourceType: 'collection',
-              },
-              {
-                Resource: [`collection/${collectionName}`],
-                ResourceType: 'dashboard',
-              },
-            ],
-            AllowFromPublic: true,
-          },
-        ]),
-        type: 'network',
-      });
+    const knowledgeBaseRole = new iam.Role(this, 'KnowledgeBaseRole', {
+      assumedBy: new iam.ServicePrincipal('bedrock.amazonaws.com'),
+    });
 
-      const encryptionPolicy = new oss.CfnSecurityPolicy(
-        this,
-        'EncryptionPolicy',
+    if (
+      ragKnowledgeBaseAdvancedParsing &&
+      typeof ragKnowledgeBaseAdvancedParsingModelId !== 'string'
+    ) {
+      throw new Error(
+        'Knowledge Base RAG Advanced Parsing is enabled, but ragKnowledgeBaseAdvancedParsingModelId is not specified or is not a string'
+      );
+    }
+
+    const collection = new oss.CfnCollection(this, 'Collection', {
+      name: collectionName,
+      description: 'GenU Collection',
+      type: 'VECTORSEARCH',
+      standbyReplicas: ragKnowledgeBaseStandbyReplicas ? 'ENABLED' : 'DISABLED',
+    });
+
+    const ossIndex = new OpenSearchServerlessIndex(this, 'OssIndex', {
+      collectionId: collection.ref,
+      vectorIndexName,
+      vectorField,
+      textField,
+      metadataField,
+      vectorDimension: MODEL_VECTOR_MAPPING[embeddingModelId],
+      ragKnowledgeBaseBinaryVector,
+    });
+
+    ossIndex.customResourceHandler.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        resources: [cdk.Token.asString(collection.getAtt('Arn'))],
+        actions: ['aoss:APIAccessAll'],
+      })
+    );
+
+    const accessPolicy = new oss.CfnAccessPolicy(this, 'AccessPolicy', {
+      name: collectionName,
+      policy: JSON.stringify([
         {
-          name: collectionName,
-          policy: JSON.stringify({
-            Rules: [
-              {
-                Resource: [`collection/${collectionName}`],
-                ResourceType: 'collection',
-              },
-            ],
-            AWSOwnedKey: true,
-          }),
-          type: 'encryption',
-        }
-      );
+          Rules: [
+            {
+              Resource: [`collection/${collectionName}`],
+              Permission: [
+                'aoss:DescribeCollectionItems',
+                'aoss:CreateCollectionItems',
+                'aoss:UpdateCollectionItems',
+              ],
+              ResourceType: 'collection',
+            },
+            {
+              Resource: [`index/${collectionName}/*`],
+              Permission: [
+                'aoss:UpdateIndex',
+                'aoss:DescribeIndex',
+                'aoss:ReadDocument',
+                'aoss:WriteDocument',
+                'aoss:CreateIndex',
+                'aoss:DeleteIndex',
+              ],
+              ResourceType: 'index',
+            },
+          ],
+          Principal: [
+            knowledgeBaseRole.roleArn,
+            ossIndex.customResourceHandler.role?.roleArn,
+          ],
+          Description: '',
+        },
+      ]),
+      type: 'data',
+    });
 
-      collection.node.addDependency(accessPolicy);
-      collection.node.addDependency(networkPolicy);
-      collection.node.addDependency(encryptionPolicy);
+    const networkPolicy = new oss.CfnSecurityPolicy(this, 'NetworkPolicy', {
+      name: collectionName,
+      policy: JSON.stringify([
+        {
+          Rules: [
+            {
+              Resource: [`collection/${collectionName}`],
+              ResourceType: 'collection',
+            },
+            {
+              Resource: [`collection/${collectionName}`],
+              ResourceType: 'dashboard',
+            },
+          ],
+          AllowFromPublic: true,
+        },
+      ]),
+      type: 'network',
+    });
 
-      const accessLogsBucket = new s3.Bucket(this, 'DataSourceAccessLogsBucket', {
-        blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-        encryption: s3.BucketEncryption.S3_MANAGED,
-        autoDeleteObjects: true,
-        removalPolicy: RemovalPolicy.DESTROY,
-        objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
-        enforceSSL: true,
-      });
+    const encryptionPolicy = new oss.CfnSecurityPolicy(
+      this,
+      'EncryptionPolicy',
+      {
+        name: collectionName,
+        policy: JSON.stringify({
+          Rules: [
+            {
+              Resource: [`collection/${collectionName}`],
+              ResourceType: 'collection',
+            },
+          ],
+          AWSOwnedKey: true,
+        }),
+        type: 'encryption',
+      }
+    );
 
-      const dataSourceBucket = new s3.Bucket(this, 'DataSourceBucket', {
-        blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-        encryption: s3.BucketEncryption.S3_MANAGED,
-        autoDeleteObjects: true,
-        removalPolicy: cdk.RemovalPolicy.DESTROY,
-        objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
-        serverAccessLogsBucket: accessLogsBucket,
-        serverAccessLogsPrefix: 'AccessLogs/',
-        enforceSSL: true,
-      });
+    collection.node.addDependency(accessPolicy);
+    collection.node.addDependency(networkPolicy);
+    collection.node.addDependency(encryptionPolicy);
 
-      let multiModalStorageBucket: s3.Bucket | undefined;
+    const accessLogsBucket = new s3.Bucket(this, 'DataSourceAccessLogsBucket', {
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      autoDeleteObjects: true,
+      removalPolicy: RemovalPolicy.DESTROY,
+      objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
+      enforceSSL: true,
+    });
 
-      if (ragKnowledgeBaseMultiModalStorage) {
-        const multiModalStorageAccessLogsBucket = new s3.Bucket(this, 'MultiModalStorageAccessLogsBucket', {
+    const dataSourceBucket = new s3.Bucket(this, 'DataSourceBucket', {
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      autoDeleteObjects: true,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
+      serverAccessLogsBucket: accessLogsBucket,
+      serverAccessLogsPrefix: 'AccessLogs/',
+      enforceSSL: true,
+    });
+
+    let multiModalStorageBucket: s3.Bucket | undefined;
+
+    if (ragKnowledgeBaseMultiModalStorage) {
+      const multiModalStorageAccessLogsBucket = new s3.Bucket(
+        this,
+        'MultiModalStorageAccessLogsBucket',
+        {
           blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
           encryption: s3.BucketEncryption.S3_MANAGED,
           autoDeleteObjects: true,
           removalPolicy: RemovalPolicy.DESTROY,
           objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
           enforceSSL: true,
-        });
-      
-        multiModalStorageBucket = new s3.Bucket(this, 'MultiModalStorageBucket', {
-          blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-          encryption: s3.BucketEncryption.S3_MANAGED,
-          autoDeleteObjects: true,
-          removalPolicy: cdk.RemovalPolicy.DESTROY,
-          objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
-          serverAccessLogsBucket: multiModalStorageAccessLogsBucket,
-          serverAccessLogsPrefix: 'AccessLogs/',
-          enforceSSL: true,
-        });
-      }
-
-      knowledgeBaseRole.addToPolicy(
-        new iam.PolicyStatement({
-          effect: iam.Effect.ALLOW,
-          resources: ['*'],
-          actions: ['bedrock:InvokeModel'],
-        })
+        }
       );
 
-      knowledgeBaseRole.addToPolicy(
-        new iam.PolicyStatement({
-          effect: iam.Effect.ALLOW,
-          resources: [cdk.Token.asString(collection.getAtt('Arn'))],
-          actions: ['aoss:APIAccessAll'],
-        })
-      );
+      multiModalStorageBucket = new s3.Bucket(this, 'MultiModalStorageBucket', {
+        blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+        encryption: s3.BucketEncryption.S3_MANAGED,
+        autoDeleteObjects: true,
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+        objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
+        serverAccessLogsBucket: multiModalStorageAccessLogsBucket,
+        serverAccessLogsPrefix: 'AccessLogs/',
+        enforceSSL: true,
+      });
+    }
 
+    knowledgeBaseRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        resources: ['*'],
+        actions: ['bedrock:InvokeModel'],
+      })
+    );
+
+    knowledgeBaseRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        resources: [cdk.Token.asString(collection.getAtt('Arn'))],
+        actions: ['aoss:APIAccessAll'],
+      })
+    );
+
+    knowledgeBaseRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        resources: [`arn:aws:s3:::${dataSourceBucket.bucketName}`],
+        actions: ['s3:ListBucket'],
+      })
+    );
+
+    knowledgeBaseRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        resources: [`arn:aws:s3:::${dataSourceBucket.bucketName}/*`],
+        actions: ['s3:GetObject'],
+      })
+    );
+
+    if (ragKnowledgeBaseMultiModalStorage && multiModalStorageBucket) {
       knowledgeBaseRole.addToPolicy(
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
-          resources: [`arn:aws:s3:::${dataSourceBucket.bucketName}`],
+          resources: [`arn:aws:s3:::${multiModalStorageBucket.bucketName}`],
           actions: ['s3:ListBucket'],
         })
       );
@@ -355,159 +376,141 @@
       knowledgeBaseRole.addToPolicy(
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
-          resources: [`arn:aws:s3:::${dataSourceBucket.bucketName}/*`],
-          actions: ['s3:GetObject'],
+          resources: [`arn:aws:s3:::${multiModalStorageBucket.bucketName}/*`],
+          actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
         })
       );
+    }
 
-      if (ragKnowledgeBaseMultiModalStorage && multiModalStorageBucket) {
-        knowledgeBaseRole.addToPolicy(
-          new iam.PolicyStatement({
-            effect: iam.Effect.ALLOW,
-            resources: [`arn:aws:s3:::${multiModalStorageBucket.bucketName}`],
-            actions: ['s3:ListBucket'],
-          })
-        );
-      
-        knowledgeBaseRole.addToPolicy(
-          new iam.PolicyStatement({
-            effect: iam.Effect.ALLOW,
-            resources: [`arn:aws:s3:::${multiModalStorageBucket.bucketName}/*`],
-            actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject' ],
-          })
-        );
-       
-      }
-
-      const knowledgeBase = new bedrock.CfnKnowledgeBase(this, 'KnowledgeBase', {
-        name: collectionName,
-        roleArn: knowledgeBaseRole.roleArn,
-        knowledgeBaseConfiguration: {
-          type: 'VECTOR',
-          vectorKnowledgeBaseConfiguration: {
-            embeddingModelArn: `arn:aws:bedrock:${this.region}::foundation-model/${embeddingModelId}`,
-            ...(ragKnowledgeBaseBinaryVector
-              ? {
-                  embeddingModelConfiguration: {
-                    bedrockEmbeddingModelConfiguration: {
-                      embeddingDataType: 'BINARY',
-                    },
-                  },
-                }
-              : {}),
-            ...(ragKnowledgeBaseMultiModalStorage && multiModalStorageBucket
-              ? {
-                  supplementalDataStorageConfiguration: {
-                    supplementalDataStorageLocations: [
-                      {
-                        supplementalDataStorageLocationType: 'S3',
-                        s3Location: {
-                          uri: `s3://${multiModalStorageBucket.bucketName}`,
-                        },
-                      },
-                    ],
-                  },
-                }
-              : {}),
-          },
-        },
-        storageConfiguration: {
-          type: 'OPENSEARCH_SERVERLESS',
-          opensearchServerlessConfiguration: {
-            collectionArn: cdk.Token.asString(collection.getAtt('Arn')),
-            fieldMapping: {
-              metadataField,
-              textField,
-              vectorField,
-            },
-            vectorIndexName,
-          },
-        },
-      });
-
-      new bedrock.CfnDataSource(this, 'DataSource', {
-        dataSourceConfiguration: {
-          s3Configuration: {
-            bucketArn: `arn:aws:s3:::${dataSourceBucket.bucketName}`,
-            inclusionPrefixes: ['docs/'],
-          },
-          type: 'S3',
-        },
-        vectorIngestionConfiguration: {
-          ...(ragKnowledgeBaseAdvancedParsing
+    const knowledgeBase = new bedrock.CfnKnowledgeBase(this, 'KnowledgeBase', {
+      name: collectionName,
+      roleArn: knowledgeBaseRole.roleArn,
+      knowledgeBaseConfiguration: {
+        type: 'VECTOR',
+        vectorKnowledgeBaseConfiguration: {
+          embeddingModelArn: `arn:aws:bedrock:${this.region}::foundation-model/${embeddingModelId}`,
+          ...(ragKnowledgeBaseBinaryVector
             ? {
-                // Enable Advanced Parsing only if it is enabled
-                parsingConfiguration: {
-                  parsingStrategy: 'BEDROCK_FOUNDATION_MODEL',
-                  bedrockFoundationModelConfiguration: {
-                    modelArn: `arn:aws:bedrock:${this.region}::foundation-model/${ragKnowledgeBaseAdvancedParsingModelId}`,
-                    parsingPrompt: {
-                      parsingPromptText: PARSING_PROMPT,
-                    },
+                embeddingModelConfiguration: {
+                  bedrockEmbeddingModelConfiguration: {
+                    embeddingDataType: 'BINARY',
                   },
                 },
               }
             : {}),
-          // If you want to change the chunking strategy, uncomment the following and adjust the various parameters to build an environment suitable for your needs.
-          // The following 4 types of chunking strategies are available.
-          // - Default (no specification)
-          // - Semantic Chunk
-          // - Hierarchical Chunk
-          // - Standard Chunk
-          // Please refer to the following Document for details.
-          // https://docs.aws.amazon.com/bedrock/latest/userguide/kb-chunking-parsing.html
-          // https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_bedrock.CfnDataSource.ChunkingConfigurationProperty.html
-          //
-          // Semantic Chunk
-          // chunkingConfiguration: {
-          //   chunkingStrategy: 'SEMANTIC',
-          //   semanticChunkingConfiguration: {
-          //     maxTokens: 300,
-          //     bufferSize: 0,
-          //     breakpointPercentileThreshold: 95,
-          //   },
-          // },
-          //
-          // Hierarchical Chunk
-          // chunkingConfiguration: {
-          //   chunkingStrategy: 'HIERARCHICAL',
-          //   hierarchicalChunkingConfiguration: {
-          //     levelConfigurations: [
-          //       {
-          //         maxTokens: 1500, // Max Token size of the parent chunk
-          //       },
-          //       {
-          //         maxTokens: 300, // Max Token size of the child chunk
-          //       },
-          //     ],
-          //     overlapTokens: 60,
-          //   },
-          // },
-          //
-          // Standard Chunk
-          // chunkingConfiguration: {
-          //   chunkingStrategy: 'FIXED_SIZE',
-          //   fixedSizeChunkingConfiguration: {
-          //     maxTokens: 300,
-          //     overlapPercentage: 10,
-          //   },
-          // },
+          ...(ragKnowledgeBaseMultiModalStorage && multiModalStorageBucket
+            ? {
+                supplementalDataStorageConfiguration: {
+                  supplementalDataStorageLocations: [
+                    {
+                      supplementalDataStorageLocationType: 'S3',
+                      s3Location: {
+                        uri: `s3://${multiModalStorageBucket.bucketName}`,
+                      },
+                    },
+                  ],
+                },
+              }
+            : {}),
         },
-        knowledgeBaseId: knowledgeBase.ref,
-        name: 's3-data-source',
-      });
+      },
+      storageConfiguration: {
+        type: 'OPENSEARCH_SERVERLESS',
+        opensearchServerlessConfiguration: {
+          collectionArn: cdk.Token.asString(collection.getAtt('Arn')),
+          fieldMapping: {
+            metadataField,
+            textField,
+            vectorField,
+          },
+          vectorIndexName,
+        },
+      },
+    });
 
-      knowledgeBase.addDependency(collection);
-      knowledgeBase.node.addDependency(ossIndex.customResource);
+    new bedrock.CfnDataSource(this, 'DataSource', {
+      dataSourceConfiguration: {
+        s3Configuration: {
+          bucketArn: `arn:aws:s3:::${dataSourceBucket.bucketName}`,
+          inclusionPrefixes: ['docs/'],
+        },
+        type: 'S3',
+      },
+      vectorIngestionConfiguration: {
+        ...(ragKnowledgeBaseAdvancedParsing
+          ? {
+              // Enable Advanced Parsing only if it is enabled
+              parsingConfiguration: {
+                parsingStrategy: 'BEDROCK_FOUNDATION_MODEL',
+                bedrockFoundationModelConfiguration: {
+                  modelArn: `arn:aws:bedrock:${this.region}::foundation-model/${ragKnowledgeBaseAdvancedParsingModelId}`,
+                  parsingPrompt: {
+                    parsingPromptText: PARSING_PROMPT,
+                  },
+                },
+              },
+            }
+          : {}),
+        // If you want to change the chunking strategy, uncomment the following and adjust the various parameters to build an environment suitable for your needs.
+        // The following 4 types of chunking strategies are available.
+        // - Default (no specification)
+        // - Semantic Chunk
+        // - Hierarchical Chunk
+        // - Standard Chunk
+        // Please refer to the following Document for details.
+        // https://docs.aws.amazon.com/bedrock/latest/userguide/kb-chunking-parsing.html
+        // https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_bedrock.CfnDataSource.ChunkingConfigurationProperty.html
+        //
+        // Semantic Chunk
+        // chunkingConfiguration: {
+        //   chunkingStrategy: 'SEMANTIC',
+        //   semanticChunkingConfiguration: {
+        //     maxTokens: 300,
+        //     bufferSize: 0,
+        //     breakpointPercentileThreshold: 95,
+        //   },
+        // },
+        //
+        // Hierarchical Chunk
+        // chunkingConfiguration: {
+        //   chunkingStrategy: 'HIERARCHICAL',
+        //   hierarchicalChunkingConfiguration: {
+        //     levelConfigurations: [
+        //       {
+        //         maxTokens: 1500, // Max Token size of the parent chunk
+        //       },
+        //       {
+        //         maxTokens: 300, // Max Token size of the child chunk
+        //       },
+        //     ],
+        //     overlapTokens: 60,
+        //   },
+        // },
+        //
+        // Standard Chunk
+        // chunkingConfiguration: {
+        //   chunkingStrategy: 'FIXED_SIZE',
+        //   fixedSizeChunkingConfiguration: {
+        //     maxTokens: 300,
+        //     overlapPercentage: 10,
+        //   },
+        // },
+      },
+      knowledgeBaseId: knowledgeBase.ref,
+      name: 's3-data-source',
+    });
 
-      new s3Deploy.BucketDeployment(this, 'DeployDocs', {
-        sources: [s3Deploy.Source.asset('./rag-docs')],
-        destinationBucket: dataSourceBucket,
-        // There is a possibility that access logs are still in the same Bucket from the previous configuration, so this setting is left.
-        exclude: ['AccessLogs/*', 'logs*'],
-      });
+    knowledgeBase.addDependency(collection);
+    knowledgeBase.node.addDependency(ossIndex.customResource);
 
-      this.knowledgeBaseId = knowledgeBase.ref;
-      this.dataSourceBucketName = dataSourceBucket.bucketName;
-    }
+    new s3Deploy.BucketDeployment(this, 'DeployDocs', {
+      sources: [s3Deploy.Source.asset('./rag-docs')],
+      destinationBucket: dataSourceBucket,
+      // There is a possibility that access logs are still in the same Bucket from the previous configuration, so this setting is left.
+      exclude: ['AccessLogs/*', 'logs*'],
+    });
+
+    this.knowledgeBaseId = knowledgeBase.ref;
+    this.dataSourceBucketName = dataSourceBucket.bucketName;
   }
+}

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -104,6 +104,7 @@ export const stackInputSchema = z.object({
   ragKnowledgeBaseBinaryVector: z.boolean().default(false),
   queryDecompositionEnabled: z.boolean().default(false),
   rerankingModelId: z.string().nullish(),
+  multiModalStorage: z.boolean().default(true),
   // Agent
   agentEnabled: z.boolean().default(false),
   searchAgentEnabled: z.boolean().default(false),

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -98,13 +98,13 @@ export const stackInputSchema = z.object({
   embeddingModelId: z.string().default('amazon.titan-embed-text-v2:0'),
   ragKnowledgeBaseStandbyReplicas: z.boolean().default(false),
   ragKnowledgeBaseAdvancedParsing: z.boolean().default(false),
+  ragKnowledgeBaseMultiModalStorage: z.boolean().default(true),
   ragKnowledgeBaseAdvancedParsingModelId: z
     .string()
     .default('anthropic.claude-3-sonnet-20240229-v1:0'),
   ragKnowledgeBaseBinaryVector: z.boolean().default(false),
   queryDecompositionEnabled: z.boolean().default(false),
   rerankingModelId: z.string().nullish(),
-  multiModalStorage: z.boolean().default(true),
   // Agent
   agentEnabled: z.boolean().default(false),
   searchAgentEnabled: z.boolean().default(false),

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -17,7 +17,7 @@
     "@types/sanitize-html": "^2.13.0",
     "@typescript-eslint/eslint-plugin": "^7.6.0",
     "@typescript-eslint/parser": "^7.6.0",
-    "aws-cdk": "^2.154.1",
+    "aws-cdk": "^2.1006.0",
     "eslint": "^8.56.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
@@ -25,8 +25,7 @@
     "typescript": "~5.4.5"
   },
   "dependencies": {
-    "@aws-cdk/aws-cognito-identitypool-alpha": "^2.154.1-alpha.0",
-    "@aws-cdk/aws-lambda-python-alpha": "^2.154.1-alpha.0",
+    "@aws-cdk/aws-lambda-python-alpha": "^2.187.0-alpha.0",
     "@aws-sdk/client-bedrock-agent": "^3.755.0",
     "@aws-sdk/client-bedrock-agent-runtime": "^3.755.0",
     "@aws-sdk/client-bedrock-runtime": "^3.755.0",
@@ -39,7 +38,7 @@
     "@aws-sdk/lib-dynamodb": "^3.755.0",
     "@aws-sdk/s3-request-presigner": "^3.755.0",
     "@aws-solutions-constructs/aws-cloudfront-s3": "^2.68.0",
-    "aws-cdk-lib": "^2.154.1",
+    "aws-cdk-lib": "^2.187.0",
     "aws-jwt-verify": "^4.0.0",
     "constructs": "^10.3.0",
     "deploy-time-build": "^0.3.17",

--- a/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
+++ b/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
@@ -751,6 +751,26 @@ exports[`GenerativeAiUseCases matches the snapshot 2`] = `
           "Type": "VECTOR",
           "VectorKnowledgeBaseConfiguration": {
             "EmbeddingModelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v2:0",
+            "SupplementalDataStorageConfiguration": {
+              "SupplementalDataStorageLocations": [
+                {
+                  "S3Location": {
+                    "URI": {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "s3://",
+                          {
+                            "Ref": "MultiModalStorageBucket9C577012",
+                          },
+                        ],
+                      ],
+                    },
+                  },
+                  "SupplementalDataStorageLocationType": "S3",
+                },
+              ],
+            },
           },
         },
         "Name": "generative-ai-use-cases-jp",
@@ -847,6 +867,41 @@ exports[`GenerativeAiUseCases matches the snapshot 2`] = `
                 ],
               },
             },
+            {
+              "Action": "s3:ListBucket",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "MultiModalStorageBucket9C577012",
+                    },
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "MultiModalStorageBucket9C577012",
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -858,6 +913,293 @@ exports[`GenerativeAiUseCases matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "MultiModalStorageAccessLogsBucket8144EEC9": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "AccessControl": "LogDeliveryWrite",
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256",
+              },
+            },
+          ],
+        },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter",
+            },
+          ],
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": [
+          {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "MultiModalStorageAccessLogsBucketAutoDeleteObjectsCustomResourceF12D7ECB": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "MultiModalStorageAccessLogsBucketPolicy561A0CBC",
+      ],
+      "Properties": {
+        "BucketName": {
+          "Ref": "MultiModalStorageAccessLogsBucket8144EEC9",
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "MultiModalStorageAccessLogsBucketPolicy561A0CBC": {
+      "Properties": {
+        "Bucket": {
+          "Ref": "MultiModalStorageAccessLogsBucket8144EEC9",
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*",
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "MultiModalStorageAccessLogsBucket8144EEC9",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "MultiModalStorageAccessLogsBucket8144EEC9",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": [
+                "s3:PutBucketPolicy",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "MultiModalStorageAccessLogsBucket8144EEC9",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "MultiModalStorageAccessLogsBucket8144EEC9",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "MultiModalStorageBucket9C577012": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256",
+              },
+            },
+          ],
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "MultiModalStorageAccessLogsBucket8144EEC9",
+          },
+          "LogFilePrefix": "AccessLogs/",
+        },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter",
+            },
+          ],
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": [
+          {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "MultiModalStorageBucketAutoDeleteObjectsCustomResourceE699BC6C": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "MultiModalStorageBucketPolicy33ADD93E",
+      ],
+      "Properties": {
+        "BucketName": {
+          "Ref": "MultiModalStorageBucket9C577012",
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "MultiModalStorageBucketPolicy33ADD93E": {
+      "Properties": {
+        "Bucket": {
+          "Ref": "MultiModalStorageBucket9C577012",
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*",
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "MultiModalStorageBucket9C577012",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "MultiModalStorageBucket9C577012",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": [
+                "s3:PutBucketPolicy",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "MultiModalStorageBucket9C577012",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "MultiModalStorageBucket9C577012",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
     },
     "NetworkPolicy": {
       "Properties": {

--- a/packages/cdk/test/generative-ai-use-cases.test.ts
+++ b/packages/cdk/test/generative-ai-use-cases.test.ts
@@ -19,9 +19,10 @@ describe('GenerativeAiUseCases', () => {
       kendraIndexScheduleDeleteCron: null,
       ragKnowledgeBaseEnabled: true,
       ragKnowledgeBaseStandbyReplicas: false,
+      ragKnowledgeBaseMultiModalStorage: true,
       ragKnowledgeBaseAdvancedParsing: false,
       ragKnowledgeBaseAdvancedParsingModelId:
-        'anthropic.claude-3-sonnet-20240229-v1:0',
+        'anthropic.claude-3-5-sonnet-20240620-v1:0',
       embeddingModelId: 'amazon.titan-embed-text-v2:0',
       selfSignUpEnabled: true,
       allowedSignUpEmailDomains: null,


### PR DESCRIPTION
## Description of Changes
Please explain the changes in detail.
If there is any impact on existing users (compatibility, degradation, breaking changes, etc.), be sure to include it in the explanation.

- Add `ragKnowledgeBaseMultiModalStorage` to enable parsing image files (png/jpeg) directly
- Update documentation

Note that enabling the option requires remake of the existing knowledge base.

## Checklist

- [X] Executed `npm run lint`
- [X] Modified relevant documentation
- [X] Verified operation in local environment
- [X] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

#895