### PR TITLE
fix font family and change noto sans jp

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -11,7 +11,7 @@
       sizes="180x180" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link
-      href="https://fonts.googleapis.com/css?family=M+PLUS+Rounded+1c"
+      href="https://fonts.googleapis.com/css?family=Noto+Sans+JP"
       rel="stylesheet" />
     <title>GenAI Use Cases</title>
   </head>

--- a/packages/web/tailwind.config.ts
+++ b/packages/web/tailwind.config.ts
@@ -11,7 +11,7 @@ export default {
       },
     },
     fontFamily: {
-      body: ['M PLUS Rounded 1c'],
+      body: ['"Noto Sans JP"'],
     },
     extend: {
       transitionProperty: {


### PR DESCRIPTION
## Description of Changes

以下のキャプチャーの様にフォントの読み込みに失敗しているので、修正のプルリクエストです。
スペースを含むフォントの場合は、ダブルクオーテーションで囲う必要があるようです。
![image](https://github.com/user-attachments/assets/7a177fcb-7289-4bc8-ba43-74b8d0436b31)

修正後以下の様にフォントが読み込まれています。
![image](https://github.com/user-attachments/assets/64c778a8-ccff-4573-a762-e98435e1104a)

M PLUS Rounded 1c だと、以下のような形で、サイズによってはあまりきれいではないので、 Noto Sans JP に変えてプルリクエストさせていただいています。

M PLUS Rounded 1c
![image](https://github.com/user-attachments/assets/d6fff528-eb4e-4178-b618-edfff967fcf7)
![image](https://github.com/user-attachments/assets/f5517e9c-cccd-4169-b5d0-cde2e0d10491)

Noto Sans JP
![image](https://github.com/user-attachments/assets/37236cdc-e88a-4c25-bb1b-89b512b25a7d)
![image](https://github.com/user-attachments/assets/8a934dcc-1f23-4c5c-be4a-27ccf274faf2)

フォント自体の変更を行うかどうかはご判断いただき、変えない方がいい場合は、 M PLUS Rounded 1c にダブルクオーテーションを付けた形でマージしていただければと思います。

## Checklist

- [x] Executed `npm run lint`
- [ ] Modified relevant documentation
- [x] Verified operation in local environment
- [ ] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

Please list related issues as much as possible.
