### PR TITLE
チャット入力が空白の場合の修正

### DIFF
--- a/packages/web/src/components/InputChatContent.tsx
+++ b/packages/web/src/components/InputChatContent.tsx
@@ -102,7 +102,7 @@ const InputChatContent: React.FC<Props> = (props) => {
 
   const disabledSend = useMemo(() => {
     return (
-      props.content === '' ||
+      props.content.trim() === '' ||
       props.disabled ||
       uploading ||
       errorMessages.length > 0


### PR DESCRIPTION
## Description of Changes

- チャット入力空欄の時は Validation で送信できないが、空白（半角、全角）の時は Validation が通るが Bedrock 側でエラーになる問題の修正。

## Checklist

- [x] Executed `npm run lint`
- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

Please list related issues as much as possible.
