### PR TITLE
fix: prevent unintended override of construct and stack props

### DIFF
--- a/packages/cdk/lib/agent-stack.ts
+++ b/packages/cdk/lib/agent-stack.ts
@@ -5,7 +5,7 @@ import { Agent as AgentType } from 'generative-ai-use-cases';
 import { ProcessedStackInput } from './stack-input';
 
 export interface AgentStackProps extends StackProps {
-  params: ProcessedStackInput;
+  readonly params: ProcessedStackInput;
 }
 
 export class AgentStack extends Stack {

--- a/packages/cdk/lib/cloud-front-waf-stack.ts
+++ b/packages/cdk/lib/cloud-front-waf-stack.ts
@@ -10,7 +10,7 @@ import { CommonWebAcl } from './construct/common-web-acl';
 import { ProcessedStackInput } from './stack-input';
 
 interface CloudFrontWafStackProps extends StackProps {
-  params: ProcessedStackInput;
+  readonly params: ProcessedStackInput;
 }
 
 export class CloudFrontWafStack extends Stack {

--- a/packages/cdk/lib/construct/agent.ts
+++ b/packages/cdk/lib/construct/agent.ts
@@ -20,8 +20,8 @@ import { Agent as AgentType } from 'generative-ai-use-cases';
 
 interface AgentProps {
   // Context Params
-  searchAgentEnabled: boolean;
-  searchApiKey?: string | null;
+  readonly searchAgentEnabled: boolean;
+  readonly searchApiKey?: string | null;
 }
 
 export class Agent extends Construct {

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -30,26 +30,26 @@ import {
 
 export interface BackendApiProps {
   // Context Params
-  modelRegion: string;
-  modelIds: ModelConfiguration[];
-  imageGenerationModelIds: ModelConfiguration[];
-  videoGenerationModelIds: ModelConfiguration[];
-  videoBucketRegionMap: Record<string, string>;
-  endpointNames: string[];
-  queryDecompositionEnabled: boolean;
-  rerankingModelId?: string | null;
-  customAgents: Agent[];
-  crossAccountBedrockRoleArn?: string | null;
+  readonly modelRegion: string;
+  readonly modelIds: ModelConfiguration[];
+  readonly imageGenerationModelIds: ModelConfiguration[];
+  readonly videoGenerationModelIds: ModelConfiguration[];
+  readonly videoBucketRegionMap: Record<string, string>;
+  readonly endpointNames: string[];
+  readonly queryDecompositionEnabled: boolean;
+  readonly rerankingModelId?: string | null;
+  readonly customAgents: Agent[];
+  readonly crossAccountBedrockRoleArn?: string | null;
 
   // Resource
-  userPool: UserPool;
-  idPool: IdentityPool;
-  userPoolClient: UserPoolClient;
-  table: Table;
-  knowledgeBaseId?: string;
-  agents?: Agent[];
-  guardrailIdentify?: string;
-  guardrailVersion?: string;
+  readonly userPool: UserPool;
+  readonly idPool: IdentityPool;
+  readonly userPoolClient: UserPoolClient;
+  readonly table: Table;
+  readonly knowledgeBaseId?: string;
+  readonly agents?: Agent[];
+  readonly guardrailIdentify?: string;
+  readonly guardrailVersion?: string;
 }
 
 export class Api extends Construct {

--- a/packages/cdk/lib/construct/auth.ts
+++ b/packages/cdk/lib/construct/auth.ts
@@ -14,11 +14,11 @@ import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 
 export interface AuthProps {
-  selfSignUpEnabled: boolean;
-  allowedIpV4AddressRanges?: string[] | null;
-  allowedIpV6AddressRanges?: string[] | null;
-  allowedSignUpEmailDomains?: string[] | null;
-  samlAuthEnabled: boolean;
+  readonly selfSignUpEnabled: boolean;
+  readonly allowedIpV4AddressRanges?: string[] | null;
+  readonly allowedIpV6AddressRanges?: string[] | null;
+  readonly allowedSignUpEmailDomains?: string[] | null;
+  readonly samlAuthEnabled: boolean;
 }
 
 export class Auth extends Construct {

--- a/packages/cdk/lib/construct/common-web-acl.ts
+++ b/packages/cdk/lib/construct/common-web-acl.ts
@@ -3,10 +3,10 @@ import { CfnIPSet, CfnWebACL, CfnWebACLProps } from 'aws-cdk-lib/aws-wafv2';
 import { Construct } from 'constructs';
 
 export interface CommonWebAclProps {
-  scope: 'REGIONAL' | 'CLOUDFRONT';
-  allowedIpV4AddressRanges?: string[] | null;
-  allowedIpV6AddressRanges?: string[] | null;
-  allowedCountryCodes?: string[] | null;
+  readonly scope: 'REGIONAL' | 'CLOUDFRONT';
+  readonly allowedIpV4AddressRanges?: string[] | null;
+  readonly allowedIpV6AddressRanges?: string[] | null;
+  readonly allowedCountryCodes?: string[] | null;
 }
 
 export class CommonWebAcl extends Construct {

--- a/packages/cdk/lib/construct/rag-knowledge-base.ts
+++ b/packages/cdk/lib/construct/rag-knowledge-base.ts
@@ -13,12 +13,12 @@ import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
 export interface RagKnowledgeBaseProps {
   // Context Params
-  modelRegion: string;
+  readonly modelRegion: string;
 
   // Resource
-  knowledgeBaseId: string;
-  userPool: UserPool;
-  api: RestApi;
+  readonly knowledgeBaseId: string;
+  readonly userPool: UserPool;
+  readonly api: RestApi;
 }
 
 export class RagKnowledgeBase extends Construct {

--- a/packages/cdk/lib/construct/rag.ts
+++ b/packages/cdk/lib/construct/rag.ts
@@ -23,24 +23,24 @@ const KENDRA_STATE_CFN_PARAMETER_NAME = 'kendraState';
 
 export interface RagProps {
   // Context Params
-  envSuffix: string;
-  kendraIndexLanguage: string;
-  kendraIndexArnInCdkContext?: string | null;
-  kendraDataSourceBucketName?: string | null;
-  kendraIndexScheduleEnabled: boolean;
-  kendraIndexScheduleCreateCron?: IndexScheduleCron | null;
-  kendraIndexScheduleDeleteCron?: IndexScheduleCron | null;
+  readonly envSuffix: string;
+  readonly kendraIndexLanguage: string;
+  readonly kendraIndexArnInCdkContext?: string | null;
+  readonly kendraDataSourceBucketName?: string | null;
+  readonly kendraIndexScheduleEnabled: boolean;
+  readonly kendraIndexScheduleCreateCron?: IndexScheduleCron | null;
+  readonly kendraIndexScheduleDeleteCron?: IndexScheduleCron | null;
 
   // Resource
-  userPool: UserPool;
-  api: RestApi;
+  readonly userPool: UserPool;
+  readonly api: RestApi;
 }
 
 export interface IndexScheduleCron {
-  minute: string;
-  hour: string;
-  month: string;
-  weekDay: string;
+  readonly minute: string;
+  readonly hour: string;
+  readonly month: string;
+  readonly weekDay: string;
 }
 
 class KendraIndexWithCfnParameter extends kendra.CfnIndex {

--- a/packages/cdk/lib/construct/transcribe.ts
+++ b/packages/cdk/lib/construct/transcribe.ts
@@ -19,9 +19,9 @@ import {
 import { Construct } from 'constructs';
 
 export interface TranscribeProps {
-  userPool: UserPool;
-  idPool: IdentityPool;
-  api: RestApi;
+  readonly userPool: UserPool;
+  readonly idPool: IdentityPool;
+  readonly api: RestApi;
 }
 
 export class Transcribe extends Construct {

--- a/packages/cdk/lib/construct/use-case-builder.ts
+++ b/packages/cdk/lib/construct/use-case-builder.ts
@@ -15,8 +15,8 @@ import { UserPool } from 'aws-cdk-lib/aws-cognito';
 import * as ddb from 'aws-cdk-lib/aws-dynamodb';
 
 export interface UseCaseBuilderProps {
-  userPool: UserPool;
-  api: RestApi;
+  readonly userPool: UserPool;
+  readonly api: RestApi;
 }
 export class UseCaseBuilder extends Construct {
   constructor(scope: Construct, id: string, props: UseCaseBuilderProps) {

--- a/packages/cdk/lib/construct/web.ts
+++ b/packages/cdk/lib/construct/web.ts
@@ -18,35 +18,35 @@ import {
 import { ComputeType } from 'aws-cdk-lib/aws-codebuild';
 
 export interface WebProps {
-  apiEndpointUrl: string;
-  userPoolId: string;
-  userPoolClientId: string;
-  idPoolId: string;
-  predictStreamFunctionArn: string;
-  ragEnabled: boolean;
-  ragKnowledgeBaseEnabled: boolean;
-  agentEnabled: boolean;
-  flows?: Flow[];
-  flowStreamFunctionArn: string;
-  optimizePromptFunctionArn: string;
-  selfSignUpEnabled: boolean;
-  webAclId?: string;
-  modelRegion: string;
-  modelIds: ModelConfiguration[];
-  imageGenerationModelIds: ModelConfiguration[];
-  videoGenerationModelIds: ModelConfiguration[];
-  endpointNames: string[];
-  samlAuthEnabled: boolean;
-  samlCognitoDomainName?: string | null;
-  samlCognitoFederatedIdentityProviderName?: string | null;
-  agentNames: string[];
-  inlineAgents: boolean;
-  cert?: ICertificate;
-  hostName?: string | null;
-  domainName?: string | null;
-  hostedZoneId?: string | null;
-  useCaseBuilderEnabled: boolean;
-  hiddenUseCases: HiddenUseCases;
+  readonly apiEndpointUrl: string;
+  readonly userPoolId: string;
+  readonly userPoolClientId: string;
+  readonly idPoolId: string;
+  readonly predictStreamFunctionArn: string;
+  readonly ragEnabled: boolean;
+  readonly ragKnowledgeBaseEnabled: boolean;
+  readonly agentEnabled: boolean;
+  readonly flows?: Flow[];
+  readonly flowStreamFunctionArn: string;
+  readonly optimizePromptFunctionArn: string;
+  readonly selfSignUpEnabled: boolean;
+  readonly webAclId?: string;
+  readonly modelRegion: string;
+  readonly modelIds: ModelConfiguration[];
+  readonly imageGenerationModelIds: ModelConfiguration[];
+  readonly videoGenerationModelIds: ModelConfiguration[];
+  readonly endpointNames: string[];
+  readonly samlAuthEnabled: boolean;
+  readonly samlCognitoDomainName?: string | null;
+  readonly samlCognitoFederatedIdentityProviderName?: string | null;
+  readonly agentNames: string[];
+  readonly inlineAgents: boolean;
+  readonly cert?: ICertificate;
+  readonly hostName?: string | null;
+  readonly domainName?: string | null;
+  readonly hostedZoneId?: string | null;
+  readonly useCaseBuilderEnabled: boolean;
+  readonly hiddenUseCases: HiddenUseCases;
 }
 
 export class Web extends Construct {

--- a/packages/cdk/lib/dashboard-stack.ts
+++ b/packages/cdk/lib/dashboard-stack.ts
@@ -7,10 +7,10 @@ import { ProcessedStackInput } from './stack-input';
 import { ModelConfiguration } from 'generative-ai-use-cases';
 
 export interface DashboardStackProps extends StackProps {
-  params: ProcessedStackInput;
-  userPool: cognito.UserPool;
-  userPoolClient: cognito.UserPoolClient;
-  appRegion: string;
+  readonly params: ProcessedStackInput;
+  readonly userPool: cognito.UserPool;
+  readonly userPoolClient: cognito.UserPoolClient;
+  readonly appRegion: string;
 }
 
 export class DashboardStack extends Stack {

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -18,21 +18,21 @@ import { UseCaseBuilder } from './construct/use-case-builder';
 import { ProcessedStackInput } from './stack-input';
 
 export interface GenerativeAiUseCasesStackProps extends StackProps {
-  params: ProcessedStackInput;
+  readonly params: ProcessedStackInput;
   // RAG Knowledge Base
-  knowledgeBaseId?: string;
-  knowledgeBaseDataSourceBucketName?: string;
+  readonly knowledgeBaseId?: string;
+  readonly knowledgeBaseDataSourceBucketName?: string;
   // Agent
-  agents?: Agent[];
+  readonly agents?: Agent[];
   // Video Generation
-  videoBucketRegionMap: Record<string, string>;
+  readonly videoBucketRegionMap: Record<string, string>;
   // Guardrail
-  guardrailIdentifier?: string;
-  guardrailVersion?: string;
+  readonly guardrailIdentifier?: string;
+  readonly guardrailVersion?: string;
   // WAF
-  webAclId?: string;
+  readonly webAclId?: string;
   // Custom Domain
-  cert?: ICertificate;
+  readonly cert?: ICertificate;
 }
 
 export class GenerativeAiUseCasesStack extends Stack {

--- a/packages/cdk/lib/rag-knowledge-base-stack.ts
+++ b/packages/cdk/lib/rag-knowledge-base-stack.ts
@@ -76,13 +76,13 @@ Financial Activity	6,291	9,718`;
 const EMBEDDING_MODELS = Object.keys(MODEL_VECTOR_MAPPING);
 
 interface OpenSearchServerlessIndexProps {
-  collectionId: string;
-  vectorIndexName: string;
-  vectorField: string;
-  metadataField: string;
-  textField: string;
-  vectorDimension: string;
-  ragKnowledgeBaseBinaryVector: boolean;
+  readonly collectionId: string;
+  readonly vectorIndexName: string;
+  readonly vectorField: string;
+  readonly metadataField: string;
+  readonly textField: string;
+  readonly vectorDimension: string;
+  readonly ragKnowledgeBaseBinaryVector: boolean;
 }
 
 class OpenSearchServerlessIndex extends Construct {


### PR DESCRIPTION
## Description of Changes

This PR implements a safety improvement by making all props properties readonly in CDK constructs and stacks to prevent unintended property overrides.

## Checklist

- [x] Executed `npm run lint`
- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues
`N/A`

Please list related issues as much as possible.
