### PR TITLE
fix: CWE-285 in API Gateway

### DIFF
--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -674,6 +674,7 @@ export class Api extends Construct {
         allowMethods: Cors.ALL_METHODS,
       },
       cloudWatchRole: true,
+      defaultMethodOptions: commonAuthorizerProps,
     });
 
     api.addGatewayResponse('Api4XX', {


### PR DESCRIPTION
## Description of Changes

Added default authorization settings to all API Gateway methods using `defaultMethodOptions` to fix CWE-285 security vulnerability.

## Checklist

- [x] Executed `npm run lint`
- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

`N/A`
