### PR TITLE
Do not delete files in the RAG bucket

### DIFF
--- a/packages/cdk/lib/construct/rag.ts
+++ b/packages/cdk/lib/construct/rag.ts
@@ -187,6 +187,7 @@ export class Rag extends Construct {
           'docs/bedrock-ug.pdf.metadata.json',
           'docs/nova-ug.pdf.metadata.json',
         ],
+        prune: false,
         memoryLimit: 1024,
       });
 

--- a/packages/cdk/lib/rag-knowledge-base-stack.ts
+++ b/packages/cdk/lib/rag-knowledge-base-stack.ts
@@ -447,6 +447,7 @@ export class RagKnowledgeBaseStack extends Stack {
       destinationBucket: dataSourceBucket,
       // There is a possibility that access logs are still in the same Bucket from the previous configuration, so this setting is left.
       exclude: ['AccessLogs/*', 'logs*'],
+      prune: false,
       memoryLimit: 1024,
     });
 

--- a/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
+++ b/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
@@ -717,7 +717,7 @@ exports[`GenerativeAiUseCases matches the snapshot 2`] = `
           "logs*",
         ],
         "OutputObjectKeys": true,
-        "Prune": true,
+        "Prune": false,
         "ServiceToken": {
           "Fn::GetAtt": [
             "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C1024MiBB049752D",
@@ -15599,7 +15599,7 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
           "docs/nova-ug.pdf.metadata.json",
         ],
         "OutputObjectKeys": true,
-        "Prune": true,
+        "Prune": false,
         "ServiceToken": {
           "Fn::GetAtt": [
             "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C1024MiBB049752D",


### PR DESCRIPTION
## Description of Changes

We recently added nova-ug.pdf in rag-docs/docs/ as a sample document written in English.
If user uploaded their private docs manually into the bucket, the docs will be deleted since docs under the rag-docs was updated as above when user execute `npm run cdk:deploy`.

By adding `prune: false`, the docs manually uploaded will be remaining.

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

N/A