### PR TITLE
Fix query generation prompt

### DIFF
--- a/docs/ja/DEPLOY_OPTION.md
+++ b/docs/ja/DEPLOY_OPTION.md
@@ -84,7 +84,7 @@ npm run cdk:deploy
 const envs: Record<string, Partial<StackInput>> = {
   dev: {
     ragEnabled: true,
-    kendraIndexLanguage: 'jp',
+    kendraIndexLanguage: 'ja',
   },
 };
 ```
@@ -96,7 +96,7 @@ const envs: Record<string, Partial<StackInput>> = {
 {
   "context": {
     "ragEnabled": true,
-    "kendraIndexLanguage": "jp"
+    "kendraIndexLanguage": "ja"
   }
 }
 ```

--- a/packages/web/src/prompts/claude.ts
+++ b/packages/web/src/prompts/claude.ts
@@ -209,6 +209,7 @@ Please generate a query following the <Query generation steps></Query generation
 * Do not use the suffixes "About 〜", "Tell me about 〜", "Explain 〜" in the query.
 * If there is no output query, output "No Query".
 * Output only the generated query. Do not output any other text. There are no exceptions.
+* Automatically detect the language of the user's request and think and answer in the same language.
 </Query generation steps>
 
 <Query history>


### PR DESCRIPTION
## Description of Changes

Previously, search queries were always generated in English, which reduced search accuracy for non-English languages in Kendra. This PR fixed the query generation to use the same language as the user's question, improving non-English search accuracy.


## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

Please list related issues as much as possible.
