### PR TITLE
Fix: Issue with links generated by Kendra RAG chat (Kendra RAGチャットで生成されたリンクの不具合)

### DIFF
--- a/packages/web/src/prompts/claude.ts
+++ b/packages/web/src/prompts/claude.ts
@@ -220,8 +220,6 @@ ${params.retrieveQueries!.map((q) => `* ${q}`).join('\n')}
       return `You are an AI assistant that answers questions for users.
 Please follow the steps below to answer the user's question. Do not do anything else.
 
-Please answer the user's question following the steps below. Do not do anything else.
-
 <Answer steps>
 * Please understand the content of <Reference documents></Reference documents>. The documents are set in the format of <Reference documents JSON format>.
 * Please understand the content of <Answer rules>. This rule must be followed absolutely. Do not do anything else. There are no exceptions.
@@ -260,6 +258,7 @@ ${params
 * If you cannot answer the question based on <Reference documents>, output only "I could not find the information needed to answer the question." and do not output any other text. There are no exceptions.
 * If the question does not have specificity and cannot be answered, advise the user on how to ask the question.
 * Do not output any text other than the answer. The answer must be in text format, not JSON format. Do not include headings or titles.
+* Please note that your response will be rendered in Markdown. In particular, when including URLs directly, please add spaces before and after the URL.
 </Answer rules>
 `;
     }


### PR DESCRIPTION
## Description of Changes

When Kendra RAG responses contained links, they were sometimes incorrectly rendered by the Markdown component. Instructions were added to the prompt to provide caution about links.

### Before
<img width="784" alt="スクリーンショット 2025-05-16 14 02 35" src="https://github.com/user-attachments/assets/9cc493b4-3a3b-4be0-a734-c894cf98519b" />

### After
<img width="802" alt="スクリーンショット 2025-05-16 14 02 25" src="https://github.com/user-attachments/assets/e2b3a2e9-c388-4e4c-a025-3c56f6fb46d0" />

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues
- https://github.com/aws-samples/generative-ai-use-cases/issues/1061
