### PR TITLE
fix: caching error of images with Amazon Nova

### DIFF
--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -343,10 +343,9 @@ const createConverseCommandInput = (
   // Add the string of user role and assistant role other than the system role to the conversation
   messages = messages.filter((message) => message.role !== 'system');
   const conversation = messages.map((message) => {
-    const contentBlocks: ContentBlock[] = [
-      { text: message.content } as ContentBlock.TextMember,
-    ];
+    const contentBlocks: ContentBlock[] = [];
 
+    // Put images, videos, and documents before the task, instruction, and user query
     if (message.extraData) {
       message.extraData.forEach((extra) => {
         if (extra.type === 'image' && extra.source.type === 'base64') {
@@ -394,6 +393,7 @@ const createConverseCommandInput = (
       });
     }
 
+    contentBlocks.push({ text: message.content });
     return {
       role:
         message.role === 'user'

--- a/packages/cdk/lambda/utils/promptCache.ts
+++ b/packages/cdk/lambda/utils/promptCache.ts
@@ -32,11 +32,7 @@ export const applyAutoCacheToMessages = (
   const isToolsSupported = cacheFields.includes('tools');
   const cachableIndices = messages
     .map((message, index) => ({ message, index }))
-    .filter(
-      ({ message }) =>
-        message.role === 'user' &&
-        !message.content?.some((block) => block.document || block.video)
-    )
+    .filter(({ message }) => message.role === 'user')
     .filter(
       ({ message }) =>
         isToolsSupported ||


### PR DESCRIPTION
## Description of Changes

**Issues**
- Setting a cache point just after an image with Amazon Nova models causes an error
- Currently, setting cache points just after documents or videos isn't supported, making caching inefficient

**Changes**
- Modified the order in the message from `text -> files` to `files -> text (-> cache point)`

## Checklist

- [ ] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

Please list related issues as much as possible.
