### PR TITLE
Add "View Prompt Examples" button on landing page

### DIFF
--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -32,6 +32,7 @@ chat:
   show_system_prompt: Show system prompt
   system_prompt: System Prompt
   title: Chat
+  view_prompt_examples: View Prompt Examples
 common:
   cancel: Cancel
   clear: Clear

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -30,6 +30,7 @@ chat:
   show_system_prompt: システムプロンプトの表示
   system_prompt: システムプロンプト
   title: チャット
+  view_prompt_examples: プロンプト例を見る
 common:
   cancel: キャンセル
   clear: クリア

--- a/packages/web/src/components/PromptList.tsx
+++ b/packages/web/src/components/PromptList.tsx
@@ -32,6 +32,7 @@ type Props = BaseProps & {
     systemContextId: string,
     title: string
   ) => Promise<void>;
+  forceExpand: number | null;
 };
 
 const PromptList: React.FC<Props> = (props) => {
@@ -42,10 +43,28 @@ const PromptList: React.FC<Props> = (props) => {
   // PromptList is fixed for use on the chat page
   const { getModelId } = useChat('/chat');
   const modelId = getModelId();
+  const [previousForceExpanded, setPreviousForceExpanded] = useState<
+    number | null
+  >(null);
 
   const prompter = useMemo(() => {
     return getPrompter(modelId);
   }, [modelId]);
+
+  useEffect(() => {
+    if (
+      props.forceExpand !== null &&
+      previousForceExpanded !== props.forceExpand
+    ) {
+      setPreviousForceExpanded(props.forceExpand);
+      setExpanded(true);
+    }
+  }, [
+    props.forceExpand,
+    previousForceExpanded,
+    setPreviousForceExpanded,
+    setExpanded,
+  ]);
 
   // To access the upper setExpanded, nest the component
   const Item: React.FC<PromptListItem> = (props) => {

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -157,6 +157,9 @@ const ChatPage: React.FC = () => {
   >(undefined);
   const [showSetting, setShowSetting] = useState(false);
   const { t } = useTranslation();
+  const [forceExpandPromptList, setForceExpandPromptList] = useState<
+    number | null
+  >(null);
 
   useEffect(() => {
     // On the conversation history page, do not change the system prompt even if the model is changed
@@ -433,12 +436,21 @@ const ChatPage: React.FC = () => {
         </div>
 
         {((isEmpty && !loadingMessages) || loadingMessages) && (
-          <div className="relative flex h-[calc(100vh-13rem)] flex-col items-center justify-center">
+          <div className="relative flex h-[calc(100vh-13rem)] flex-col items-center justify-center gap-y-4">
             <BedrockIcon
               className={`fill-gray-400 ${
                 loadingMessages ? 'animate-pulse' : ''
               }`}
             />
+
+            <Button
+              className="text-sm"
+              outlined
+              onClick={() => {
+                setForceExpandPromptList(Math.random());
+              }}>
+              {t('chat.view_prompt_examples')}
+            </Button>
           </div>
         )}
 
@@ -557,6 +569,7 @@ const ChatPage: React.FC = () => {
           systemContextList={systemContextList as SystemContext[]}
           onClickDeleteSystemContext={onClickDeleteSystemContext}
           onClickUpdateSystemContext={onClickUpdateSystemContext}
+          forceExpand={forceExpandPromptList}
         />
       )}
 

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -405,6 +405,11 @@ const ChatPage: React.FC = () => {
     }
   };
 
+  // Initialize forceExpandPromptList to null when the path changes
+  useEffect(() => {
+    setForceExpandPromptList(null);
+  }, [pathname, setForceExpandPromptList]);
+
   return (
     <>
       <div
@@ -443,14 +448,16 @@ const ChatPage: React.FC = () => {
               }`}
             />
 
-            <Button
-              className="text-sm"
-              outlined
-              onClick={() => {
-                setForceExpandPromptList(Math.random());
-              }}>
-              {t('chat.view_prompt_examples')}
-            </Button>
+            {!loadingMessages && (
+              <Button
+                className="text-sm"
+                outlined
+                onClick={() => {
+                  setForceExpandPromptList(Math.random());
+                }}>
+                {t('chat.view_prompt_examples')}
+              </Button>
+            )}
           </div>
         )}
 


### PR DESCRIPTION
## Description of Changes

It's hard to find the prompt list button at the right-top on the chat page.
I added the button to open the list at the center of the chat page. 

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

N/A