### PR TITLE
fix: File format errors

### DIFF
--- a/packages/cdk/lambda/utils/media.ts
+++ b/packages/cdk/lambda/utils/media.ts
@@ -1,0 +1,29 @@
+import {
+  DocumentFormat,
+  ImageFormat,
+  VideoFormat,
+} from '@aws-sdk/client-bedrock-runtime';
+import { SupportedMimeType } from '@generative-ai-use-cases/common';
+
+const SupportedFormat = {
+  ...DocumentFormat,
+  ...ImageFormat,
+  ...VideoFormat,
+};
+type SupportedFormatKey = keyof typeof SupportedFormat;
+type SupportedFormat = (typeof SupportedFormat)[SupportedFormatKey];
+
+export const mimeTypeToFormat: Record<SupportedMimeType, SupportedFormat> =
+  Object.fromEntries(
+    Object.entries(SupportedMimeType).map(([key, mimeType]) => [
+      mimeType,
+      SupportedFormat[key as SupportedFormatKey],
+    ])
+  ) as Record<SupportedMimeType, SupportedFormat>;
+
+export const getFileFormatFromMimeType = (mimeType: string) => {
+  if (mimeType in mimeTypeToFormat) {
+    return mimeTypeToFormat[mimeType as SupportedMimeType];
+  }
+  throw new Error(`Unsupported MIME type: ${mimeType}`);
+};

--- a/packages/cdk/lambda/utils/media.ts
+++ b/packages/cdk/lambda/utils/media.ts
@@ -21,7 +21,7 @@ export const mimeTypeToFormat: Record<SupportedMimeType, SupportedFormat> =
     ])
   ) as Record<SupportedMimeType, SupportedFormat>;
 
-export const getFileFormatFromMimeType = (mimeType: string) => {
+export const getFormatFromMimeType = (mimeType: string) => {
   if (mimeType in mimeTypeToFormat) {
     return mimeTypeToFormat[mimeType as SupportedMimeType];
   }

--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -30,6 +30,7 @@ import {
   applyAutoCacheToMessages,
   applyAutoCacheToSystem,
 } from './promptCache';
+import { getFileFormatFromMimeType } from './media';
 
 // Default Models
 
@@ -351,7 +352,7 @@ const createConverseCommandInput = (
         if (extra.type === 'image' && extra.source.type === 'base64') {
           contentBlocks.push({
             image: {
-              format: extra.source.mediaType.split('/')[1],
+              format: getFileFormatFromMimeType(extra.source.mediaType),
               source: {
                 bytes: Buffer.from(extra.source.data, 'base64'),
               },
@@ -360,7 +361,7 @@ const createConverseCommandInput = (
         } else if (extra.type === 'file' && extra.source.type === 'base64') {
           contentBlocks.push({
             document: {
-              format: extra.name.split('.').pop(),
+              format: getFileFormatFromMimeType(extra.source.mediaType),
               name: extra.name
                 .split('.')[0]
                 .replace(/[^a-zA-Z0-9\s\-()[\]]/g, 'X'), // If the file name contains Japanese, it will cause an error, so convert it
@@ -372,7 +373,7 @@ const createConverseCommandInput = (
         } else if (extra.type === 'video' && extra.source.type === 'base64') {
           contentBlocks.push({
             video: {
-              format: extra.source.mediaType.split('/')[1],
+              format: getFileFormatFromMimeType(extra.source.mediaType),
               source: {
                 bytes: Buffer.from(extra.source.data, 'base64'),
               },
@@ -381,7 +382,7 @@ const createConverseCommandInput = (
         } else if (extra.type === 'video' && extra.source.type === 's3') {
           contentBlocks.push({
             video: {
-              format: extra.source.mediaType.split('/')[1],
+              format: getFileFormatFromMimeType(extra.source.mediaType),
               source: {
                 s3Location: {
                   uri: extra.source.data,

--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -30,7 +30,7 @@ import {
   applyAutoCacheToMessages,
   applyAutoCacheToSystem,
 } from './promptCache';
-import { getFileFormatFromMimeType } from './media';
+import { getFormatFromMimeType } from './media';
 
 // Default Models
 
@@ -352,7 +352,7 @@ const createConverseCommandInput = (
         if (extra.type === 'image' && extra.source.type === 'base64') {
           contentBlocks.push({
             image: {
-              format: getFileFormatFromMimeType(extra.source.mediaType),
+              format: getFormatFromMimeType(extra.source.mediaType),
               source: {
                 bytes: Buffer.from(extra.source.data, 'base64'),
               },
@@ -361,7 +361,7 @@ const createConverseCommandInput = (
         } else if (extra.type === 'file' && extra.source.type === 'base64') {
           contentBlocks.push({
             document: {
-              format: getFileFormatFromMimeType(extra.source.mediaType),
+              format: getFormatFromMimeType(extra.source.mediaType),
               name: extra.name
                 .split('.')[0]
                 .replace(/[^a-zA-Z0-9\s\-()[\]]/g, 'X'), // If the file name contains Japanese, it will cause an error, so convert it
@@ -373,7 +373,7 @@ const createConverseCommandInput = (
         } else if (extra.type === 'video' && extra.source.type === 'base64') {
           contentBlocks.push({
             video: {
-              format: getFileFormatFromMimeType(extra.source.mediaType),
+              format: getFormatFromMimeType(extra.source.mediaType),
               source: {
                 bytes: Buffer.from(extra.source.data, 'base64'),
               },
@@ -382,7 +382,7 @@ const createConverseCommandInput = (
         } else if (extra.type === 'video' && extra.source.type === 's3') {
           contentBlocks.push({
             video: {
-              format: getFileFormatFromMimeType(extra.source.mediaType),
+              format: getFormatFromMimeType(extra.source.mediaType),
               source: {
                 s3Location: {
                   uri: extra.source.data,

--- a/packages/cdk/test/lambda/createMessages.test.ts
+++ b/packages/cdk/test/lambda/createMessages.test.ts
@@ -168,7 +168,7 @@ describe('createMessages Lambda handler', () => {
       message: 'Internal Server Error',
     });
     expect(consoleLogSpy).toHaveBeenCalled();
-    
+
     // Restore the spy
     consoleLogSpy.mockRestore();
   });

--- a/packages/cdk/test/lambda/createShareId.test.ts
+++ b/packages/cdk/test/lambda/createShareId.test.ts
@@ -50,7 +50,7 @@ describe('createShareId Lambda handler', () => {
       createdDate,
       shareId,
     };
-    
+
     const mockUserIdAndChatId: UserIdAndChatId = {
       id: shareId,
       createdDate,
@@ -67,7 +67,7 @@ describe('createShareId Lambda handler', () => {
       title: '',
       updatedDate: '',
     });
-    
+
     mockedCreateShareId.mockResolvedValue({
       shareId: mockShareId,
       userIdAndChatId: mockUserIdAndChatId,
@@ -119,11 +119,11 @@ describe('createShareId Lambda handler', () => {
       title: '',
       updatedDate: '',
     });
-    
+
     // Mock console.log to prevent actual logging during test
     const originalConsoleLog = console.log;
     console.log = jest.fn();
-    
+
     mockedCreateShareId.mockRejectedValue(new Error('Database error'));
 
     // Execute test
@@ -142,11 +142,11 @@ describe('createShareId Lambda handler', () => {
   // Test for missing chatId parameter
   test('handles missing chatId parameter properly', async () => {
     const userId = 'testUser';
-    
+
     // Mock console.log to prevent actual logging during test
     const originalConsoleLog = console.log;
     console.log = jest.fn();
-    
+
     // No chatId provided in this test
     const event = createAPIGatewayProxyEvent(undefined, userId);
     const result = await handler(event);

--- a/packages/cdk/test/lambda/getWebText.test.ts
+++ b/packages/cdk/test/lambda/getWebText.test.ts
@@ -24,9 +24,12 @@ function createAPIGatewayProxyEvent(url?: string): APIGatewayProxyEvent {
 }
 
 // Mock global fetch
-global.fetch = jest.fn().mockImplementation(() => 
+global.fetch = jest.fn().mockImplementation(() =>
   Promise.resolve({
-    text: () => Promise.resolve('<html><body><h1>Test Title</h1><p>Test content</p></body></html>')
+    text: () =>
+      Promise.resolve(
+        '<html><body><h1>Test Title</h1><p>Test content</p></body></html>'
+      ),
   })
 );
 
@@ -40,13 +43,18 @@ describe('getWebText Lambda handler', () => {
     // Mock HTML content response
     (global.fetch as jest.Mock).mockImplementation(() =>
       Promise.resolve({
-        text: () => Promise.resolve('<html><body><h1>Test Title</h1><p>Test content</p></body></html>')
+        text: () =>
+          Promise.resolve(
+            '<html><body><h1>Test Title</h1><p>Test content</p></body></html>'
+          ),
       })
     );
-    
+
     // Execute test
-    const result = await handler(createAPIGatewayProxyEvent('https://example.com'));
-    
+    const result = await handler(
+      createAPIGatewayProxyEvent('https://example.com')
+    );
+
     // Verify results
     expect(result.statusCode).toBe(200);
     expect(JSON.parse(result.body)).toHaveProperty('text');
@@ -59,7 +67,7 @@ describe('getWebText Lambda handler', () => {
   test('returns 400 error when URL parameter is missing', async () => {
     // Execute test
     const result = await handler(createAPIGatewayProxyEvent());
-    
+
     // Verify results
     expect(result.statusCode).toBe(400);
     expect(JSON.parse(result.body)).toEqual({
@@ -71,8 +79,10 @@ describe('getWebText Lambda handler', () => {
   // Test for invalid URL scheme
   test('returns 403 error when URL scheme is not http or https', async () => {
     // Execute test
-    const result = await handler(createAPIGatewayProxyEvent('ftp://example.com'));
-    
+    const result = await handler(
+      createAPIGatewayProxyEvent('ftp://example.com')
+    );
+
     // Verify results
     expect(result.statusCode).toBe(403);
     expect(JSON.parse(result.body)).toEqual({
@@ -84,8 +94,10 @@ describe('getWebText Lambda handler', () => {
   // Test for private IP address access
   test('returns 403 error when trying to access private IP address', async () => {
     // Execute test
-    const result = await handler(createAPIGatewayProxyEvent('http://192.168.1.1'));
-    
+    const result = await handler(
+      createAPIGatewayProxyEvent('http://192.168.1.1')
+    );
+
     // Verify results
     expect(result.statusCode).toBe(403);
     expect(JSON.parse(result.body)).toEqual({
@@ -97,8 +109,10 @@ describe('getWebText Lambda handler', () => {
   // Test for localhost access
   test('returns 403 error when trying to access localhost', async () => {
     // Execute test
-    const result = await handler(createAPIGatewayProxyEvent('http://localhost'));
-    
+    const result = await handler(
+      createAPIGatewayProxyEvent('http://localhost')
+    );
+
     // Verify results
     expect(result.statusCode).toBe(403);
     expect(JSON.parse(result.body)).toEqual({
@@ -110,12 +124,15 @@ describe('getWebText Lambda handler', () => {
   // Test for domain resolving to private IP
   test('returns 403 error when domain resolves to private IP', async () => {
     // Execute test - the util.promisify mock handles giving us a private IP
-    const result = await handler(createAPIGatewayProxyEvent('http://example-internal.com'));
-    
+    const result = await handler(
+      createAPIGatewayProxyEvent('http://example-internal.com')
+    );
+
     // Verify results
     expect(result.statusCode).toBe(403);
     expect(JSON.parse(result.body)).toEqual({
-      message: 'Access to domains resolving to internal networks is not allowed.',
+      message:
+        'Access to domains resolving to internal networks is not allowed.',
     });
     expect(global.fetch).not.toHaveBeenCalled();
   });
@@ -125,13 +142,15 @@ describe('getWebText Lambda handler', () => {
     // Mock console.error to prevent actual logging during test
     const originalConsoleError = console.error;
     console.error = jest.fn();
-    
+
     // Execute test - the util.promisify mock will throw an error
-    const result = await handler(createAPIGatewayProxyEvent('http://non-existent-domain.com'));
-    
+    const result = await handler(
+      createAPIGatewayProxyEvent('http://non-existent-domain.com')
+    );
+
     // Restore console.error
     console.error = originalConsoleError;
-    
+
     // Verify results
     expect(result.statusCode).toBe(403);
     expect(JSON.parse(result.body)).toEqual({
@@ -143,20 +162,22 @@ describe('getWebText Lambda handler', () => {
   // Test for fetch error
   test('returns 500 error when fetch fails', async () => {
     // Mock fetch to throw an error
-    (global.fetch as jest.Mock).mockImplementation(() => 
+    (global.fetch as jest.Mock).mockImplementation(() =>
       Promise.reject(new Error('Network error'))
     );
-    
+
     // Mock console.log to prevent actual logging during test
     const originalConsoleLog = console.log;
     console.log = jest.fn();
-    
+
     // Execute test
-    const result = await handler(createAPIGatewayProxyEvent('https://example.com'));
-    
+    const result = await handler(
+      createAPIGatewayProxyEvent('https://example.com')
+    );
+
     // Restore console.log
     console.log = originalConsoleLog;
-    
+
     // Verify results
     expect(result.statusCode).toBe(500);
     expect(JSON.parse(result.body)).toEqual({
@@ -169,13 +190,13 @@ describe('getWebText Lambda handler', () => {
     // Mock console.error to prevent actual logging during test
     const originalConsoleError = console.error;
     console.error = jest.fn();
-    
+
     // Execute test
     const result = await handler(createAPIGatewayProxyEvent('not-a-valid-url'));
-    
+
     // Restore console.error
     console.error = originalConsoleError;
-    
+
     // Verify results
     expect(result.statusCode).toBe(403);
     expect(JSON.parse(result.body)).toEqual({

--- a/packages/cdk/test/lambda/updateFeedback.test.ts
+++ b/packages/cdk/test/lambda/updateFeedback.test.ts
@@ -1,7 +1,10 @@
 import { APIGatewayProxyEvent } from 'aws-lambda';
 import { handler } from '../../lambda/updateFeedback';
 import { listMessages, updateFeedback } from '../../lambda/repository';
-import { RecordedMessage, UpdateFeedbackRequest } from 'generative-ai-use-cases';
+import {
+  RecordedMessage,
+  UpdateFeedbackRequest,
+} from 'generative-ai-use-cases';
 
 // Mock the repository
 jest.mock('../../lambda/repository');
@@ -49,7 +52,7 @@ describe('updateFeedback Lambda handler', () => {
       createdDate,
       feedback: 'positive',
       reasons: ['helpful', 'accurate'],
-      detailedFeedback: 'This response was very helpful!'
+      detailedFeedback: 'This response was very helpful!',
     };
 
     const mockMessages: RecordedMessage[] = [
@@ -85,7 +88,10 @@ describe('updateFeedback Lambda handler', () => {
     // Verify results
     expect(result.statusCode).toBe(200);
     expect(mockedListMessages).toHaveBeenCalledWith(chatId);
-    expect(mockedUpdateFeedback).toHaveBeenCalledWith(chatId, updateFeedbackRequest);
+    expect(mockedUpdateFeedback).toHaveBeenCalledWith(
+      chatId,
+      updateFeedbackRequest
+    );
     expect(JSON.parse(result.body)).toEqual({
       message: mockUpdatedMessage,
     });
@@ -120,7 +126,8 @@ describe('updateFeedback Lambda handler', () => {
     // Verify results
     expect(result.statusCode).toBe(403);
     expect(JSON.parse(result.body)).toEqual({
-      message: 'You do not have permission to provide feedback on this message.',
+      message:
+        'You do not have permission to provide feedback on this message.',
     });
     expect(mockedUpdateFeedback).not.toHaveBeenCalled();
   });
@@ -148,7 +155,7 @@ describe('updateFeedback Lambda handler', () => {
         messageId: 'msg123',
         role: 'assistant',
         content: 'Answer to your question',
-        userId: `user#${anotherUserId}`,  // Different user
+        userId: `user#${anotherUserId}`, // Different user
         feedback: 'none',
         usecase: 'test',
       },
@@ -168,7 +175,8 @@ describe('updateFeedback Lambda handler', () => {
     // Verify results
     expect(result.statusCode).toBe(403);
     expect(JSON.parse(result.body)).toEqual({
-      message: 'You do not have permission to provide feedback on this message.',
+      message:
+        'You do not have permission to provide feedback on this message.',
     });
     expect(mockedUpdateFeedback).not.toHaveBeenCalled();
   });
@@ -186,11 +194,11 @@ describe('updateFeedback Lambda handler', () => {
 
     // Set up mock to throw error
     mockedListMessages.mockRejectedValue(new Error('Database error'));
-    
+
     // Mock console.log to prevent actual logging during test
     const originalConsoleLog = console.log;
     console.log = jest.fn();
-    
+
     // Execute test
     const result = await handler(
       createAPIGatewayProxyEvent(updateFeedbackRequest, chatId, userId)
@@ -215,9 +223,11 @@ describe('updateFeedback Lambda handler', () => {
     // Mock console.log to prevent actual logging during test
     const originalConsoleLog = console.log;
     console.log = jest.fn();
-    
+
     // No body provided in this test
-    const result = await handler(createAPIGatewayProxyEvent(null, chatId, userId));
+    const result = await handler(
+      createAPIGatewayProxyEvent(null, chatId, userId)
+    );
 
     // Restore console.log
     console.log = originalConsoleLog;

--- a/packages/common/src/application/media.ts
+++ b/packages/common/src/application/media.ts
@@ -1,0 +1,48 @@
+// Document
+// https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_DocumentBlock.html
+export const DocumentMimeType = {
+  PDF: 'application/pdf',
+  CSV: 'text/csv',
+  DOC: 'application/msword',
+  DOCX: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  XLS: 'application/vnd.ms-excel',
+  XLSX: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  HTML: 'text/html',
+  TXT: 'text/plain',
+  MD: 'text/markdown',
+} as const;
+export type DocumentMimeType =
+  (typeof DocumentMimeType)[keyof typeof DocumentMimeType];
+
+// Image
+// https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ImageBlock.html
+export const ImageMimeType = {
+  PNG: 'image/png',
+  JPEG: 'image/jpeg',
+  GIF: 'image/gif',
+  WEBP: 'image/webp',
+} as const;
+export type ImageMimeType = (typeof ImageMimeType)[keyof typeof ImageMimeType];
+
+// Video
+// https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_VideoBlock.html
+export const VideoMimeType = {
+  MKV: 'video/x-matroska',
+  MOV: 'video/quicktime',
+  MP4: 'video/mp4',
+  WEBM: 'video/webm',
+  FLV: 'video/x-flv',
+  MPEG: 'video/mpeg',
+  WMV: 'video/x-ms-wmv',
+  THREE_GP: 'video/3gpp',
+} as const;
+export type VideoMimeType = (typeof VideoMimeType)[keyof typeof VideoMimeType];
+
+// Supported MIME types for documents, images, and videos
+export const SupportedMimeType = {
+  ...DocumentMimeType,
+  ...ImageMimeType,
+  ...VideoMimeType,
+} as const;
+export type SupportedMimeType =
+  (typeof SupportedMimeType)[keyof typeof SupportedMimeType];

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,2 +1,3 @@
 export * from './application/model';
+export * from './application/media';
 export * from './custom/rag-knowledge-base';

--- a/packages/types/src/message.d.ts
+++ b/packages/types/src/message.d.ts
@@ -58,6 +58,7 @@ export type UploadedFileType = {
   file: File;
   name: string;
   type: 'image' | 'video' | 'file';
+  mimeType: string;
   base64EncodedData?: string;
   s3Url?: string;
   uploading: boolean;

--- a/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
+++ b/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
@@ -35,6 +35,7 @@ import useFiles from '../../hooks/useFiles';
 import ZoomUpImage from '../ZoomUpImage';
 import ZoomUpVideo from '../ZoomUpVideo';
 import FileCard from '../FileCard';
+import { AcceptedDotExtensions } from '../../utils/MediaUtils';
 import { PiPaperclip, PiSpinnerGap } from 'react-icons/pi';
 import { useTranslation } from 'react-i18next';
 
@@ -45,22 +46,7 @@ const ragKnowledgeBaseEnabled: boolean =
 // Match pages/ChatPage.tsx
 // If a difference occurs, update it
 const fileLimit: FileLimit = {
-  accept: {
-    doc: [
-      '.csv',
-      '.doc',
-      '.docx',
-      '.html',
-      '.md',
-      '.pdf',
-      '.txt',
-      '.xls',
-      '.xlsx',
-      '.gif',
-    ],
-    image: ['.jpg', '.jpeg', '.png', '.webp'],
-    video: ['.mkv', '.mov', '.mp4', '.webm'],
-  },
+  accept: AcceptedDotExtensions,
   maxFileCount: 5,
   maxFileSizeMB: 4.5,
   maxImageFileCount: 20,

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -704,7 +704,7 @@ const useChatState = create<{
                 name: uploadedFile.name,
                 source: {
                   type: 's3',
-                  mediaType: uploadedFile.file.type,
+                  mediaType: uploadedFile.mimeType,
                   data: uploadedFile.s3Url ?? '',
                 },
               }) as ExtraData

--- a/packages/web/src/hooks/useFiles.ts
+++ b/packages/web/src/hooks/useFiles.ts
@@ -2,10 +2,14 @@ import { create } from 'zustand';
 import useFileApi from './useFileApi';
 import { FileLimit, UploadedFileType } from 'generative-ai-use-cases';
 import { produce } from 'immer';
-import { fileTypeFromBuffer, fileTypeFromStream, MimeType } from 'file-type';
 import { useCallback } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import i18next from 'i18next';
+import {
+  getFileTypeFromMimeType,
+  getMimeTypeFromFileHeader,
+  validateMimeTypeAndExtension,
+} from '../utils/MediaUtils';
 
 export const extractBaseURL = (url: string) => {
   return url.split(/[?#]/)[0];
@@ -52,18 +56,16 @@ const useFilesState = create<{
   };
 
   // Convert JS File Object to UploadedFileType to handle file upload status
-  const convertFile2UploadedFileType = (file: File): UploadedFileType => {
-    const getFileType = (fileType: string) => {
-      if (fileType.includes('image')) return 'image';
-      if (fileType.includes('video')) return 'video';
-      return 'file';
-    };
+  const convertFile2UploadedFileType = async (file: File) => {
+    const mimeType = await getMimeTypeFromFileHeader(file);
+    const fileType = getFileTypeFromMimeType(mimeType);
     const fileId = uuidv4();
     return {
       id: fileId,
       file,
       name: file.name,
-      type: getFileType(file.type),
+      type: fileType,
+      mimeType,
       uploading: true,
       errorMessages: [],
     } as UploadedFileType;
@@ -112,62 +114,32 @@ const useFilesState = create<{
     let imageFileCount = 0;
     let videoFileCount = 0;
 
-    // filter is not available for async functions, so evaluate it first
-    const isMimeSpoofedResults = await Promise.all(
-      uploadedFiles.map(async (uploadedFile) => {
-        // file.type is based on the extension, while fileTypeFromStream checks the file header signature
-        let realMimeType: MimeType | undefined;
-        try {
-          realMimeType = (await fileTypeFromStream(uploadedFile.file.stream()))
-            ?.mime;
-        } catch (error) {
-          realMimeType = (
-            await fileTypeFromBuffer(await uploadedFile.file.arrayBuffer())
-          )?.mime;
-        }
-        if (!realMimeType) {
-          console.error('Failed to get file type:', uploadedFile.file.name);
-          return false;
-        }
-        // exception when file is doc or xls
-        const isDocOrXls =
-          ['application/msword', 'application/vnd.ms-excel'].includes(
-            uploadedFile.file.type || ''
-          ) && realMimeType === 'application/x-cfb';
-        const isMimeSpoofed =
-          uploadedFile.file.type &&
-          realMimeType &&
-          uploadedFile.file.type != realMimeType &&
-          !isDocOrXls;
-        return isMimeSpoofed;
-      })
-    );
-
     // Validate uploaded files
     const updatedFiles: UploadedFileType[] = await Promise.all(
-      uploadedFiles.map(async (uploadedFile, idx) => {
+      uploadedFiles.map(async (uploadedFile) => {
         const errorMessages: string[] = [];
+        const extension = uploadedFile.file.name.split('.').pop() as string;
+        const mediaFormat = `.${extension}`;
 
-        // If the file extension is incorrect, filter it
-        if (isMimeSpoofedResults[idx]) {
-          errorMessages.push(
-            i18next.t('files.error.mimeMismatch', {
-              fileName: uploadedFile.file.name,
-            })
-          );
-        }
-
-        // Filter allowed file types
-        const mediaFormat = ('.' +
-          uploadedFile.file.name.split('.').pop()) as string;
-        const isFileTypeAllowed = accept.includes(mediaFormat);
+        // Validate file extension and MIME type
+        const isFileExtensionAccepted = accept.includes(mediaFormat);
+        const isFileExtensionValid = validateMimeTypeAndExtension(
+          uploadedFile.mimeType,
+          mediaFormat
+        );
         if (accept && accept.length === 0) {
           errorMessages.push(i18next.t('files.error.modelNotSupported'));
-        } else if (!isFileTypeAllowed) {
+        } else if (!isFileExtensionAccepted) {
           errorMessages.push(
             i18next.t('files.error.invalidExtension', {
               fileName: uploadedFile.file.name,
               acceptedExtensions: accept.join(', '),
+            })
+          );
+        } else if (!isFileExtensionValid) {
+          errorMessages.push(
+            i18next.t('files.error.mimeMismatch', {
+              fileName: uploadedFile.file.name,
             })
           );
         }
@@ -294,9 +266,12 @@ const useFilesState = create<{
   ) => {
     // Get File
     const currentUploadedFiles = get().uploadedFilesDict[id] ?? [];
+    const uploadedFiles = await Promise.all(
+      files.map((f) => convertFile2UploadedFileType(f))
+    );
     const newUploadedFiles: UploadedFileType[] = [
       ...currentUploadedFiles,
-      ...files.map(convertFile2UploadedFileType),
+      ...uploadedFiles,
     ];
 
     // Validate File

--- a/packages/web/src/hooks/useFiles.ts
+++ b/packages/web/src/hooks/useFiles.ts
@@ -163,7 +163,7 @@ const useFilesState = create<{
 
         // Filter by file count
         let isFileNumberAllowed = false;
-        if (uploadedFile.file.type.includes('image')) {
+        if (uploadedFile.type === 'image') {
           imageFileCount += 1;
           isFileNumberAllowed =
             imageFileCount <= (fileLimit.maxImageFileCount || 0);
@@ -196,7 +196,7 @@ const useFilesState = create<{
               );
             }
           }
-        } else if (uploadedFile.file.type.includes('video')) {
+        } else if (uploadedFile.type === 'video') {
           videoFileCount += 1;
           isFileNumberAllowed =
             videoFileCount <= (fileLimit.maxVideoFileCount || 0);

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -30,25 +30,11 @@ import {
   SystemContext,
 } from 'generative-ai-use-cases';
 import ModelParameters from '../components/ModelParameters';
+import { AcceptedDotExtensions } from '../utils/MediaUtils';
 import { useTranslation } from 'react-i18next';
 
 const fileLimit: FileLimit = {
-  accept: {
-    doc: [
-      '.csv',
-      '.doc',
-      '.docx',
-      '.html',
-      '.md',
-      '.pdf',
-      '.txt',
-      '.xls',
-      '.xlsx',
-      '.gif',
-    ],
-    image: ['.jpg', '.jpeg', '.png', '.webp'],
-    video: ['.mkv', '.mov', '.mp4', '.webm'],
-  },
+  accept: AcceptedDotExtensions,
   maxFileCount: 5,
   maxFileSizeMB: 4.5,
   maxImageFileCount: 20,

--- a/packages/web/src/pages/VideoAnalyzerPage.tsx
+++ b/packages/web/src/pages/VideoAnalyzerPage.tsx
@@ -180,6 +180,7 @@ const VideoAnalyzerPage: React.FC = () => {
           file,
           name: file.name,
           type: 'image',
+          mimeType: 'image/png',
           s3Url: baseUrl,
           base64EncodedData: imageBase64,
           uploading: false,

--- a/packages/web/src/utils/MediaUtils.ts
+++ b/packages/web/src/utils/MediaUtils.ts
@@ -7,25 +7,24 @@ import {
 import { fileTypeFromBuffer, fileTypeFromStream } from 'file-type';
 
 // Map MIME types to their respective formats
-export const documentMimeTypeToExtensions: Record<DocumentMimeType, string[]> =
-  {
-    [DocumentMimeType.PDF]: ['pdf'],
-    [DocumentMimeType.CSV]: ['csv'],
-    [DocumentMimeType.DOC]: ['doc'],
-    [DocumentMimeType.DOCX]: ['docx'],
-    [DocumentMimeType.XLS]: ['xls'],
-    [DocumentMimeType.XLSX]: ['xlsx'],
-    [DocumentMimeType.HTML]: ['html'],
-    [DocumentMimeType.TXT]: ['txt'],
-    [DocumentMimeType.MD]: ['md'],
-  };
-export const imageMimeTypeToExtensions: Record<ImageMimeType, string[]> = {
+const documentMimeTypeToExtensions: Record<DocumentMimeType, string[]> = {
+  [DocumentMimeType.PDF]: ['pdf'],
+  [DocumentMimeType.CSV]: ['csv'],
+  [DocumentMimeType.DOC]: ['doc'],
+  [DocumentMimeType.DOCX]: ['docx'],
+  [DocumentMimeType.XLS]: ['xls'],
+  [DocumentMimeType.XLSX]: ['xlsx'],
+  [DocumentMimeType.HTML]: ['html'],
+  [DocumentMimeType.TXT]: ['txt'],
+  [DocumentMimeType.MD]: ['md'],
+};
+const imageMimeTypeToExtensions: Record<ImageMimeType, string[]> = {
   [ImageMimeType.PNG]: ['png'],
   [ImageMimeType.JPEG]: ['jpeg', 'jpg'],
   [ImageMimeType.GIF]: ['gif'],
   [ImageMimeType.WEBP]: ['webp'],
 };
-export const videoMimeTypeToExtensions: Record<VideoMimeType, string[]> = {
+const videoMimeTypeToExtensions: Record<VideoMimeType, string[]> = {
   [VideoMimeType.MKV]: ['mkv'],
   [VideoMimeType.MOV]: ['mov'],
   [VideoMimeType.MP4]: ['mp4'],
@@ -35,7 +34,7 @@ export const videoMimeTypeToExtensions: Record<VideoMimeType, string[]> = {
   [VideoMimeType.WMV]: [], // We don't support WMV as 'file-type' doesn't support it
   [VideoMimeType.THREE_GP]: ['3gp'],
 };
-export const mimeTypeToExtensions: Record<SupportedMimeType, string[]> = {
+const mimeTypeToExtensions: Record<SupportedMimeType, string[]> = {
   ...documentMimeTypeToExtensions,
   ...imageMimeTypeToExtensions,
   ...videoMimeTypeToExtensions,

--- a/packages/web/src/utils/MediaUtils.ts
+++ b/packages/web/src/utils/MediaUtils.ts
@@ -1,0 +1,114 @@
+import {
+  DocumentMimeType,
+  ImageMimeType,
+  VideoMimeType,
+  SupportedMimeType,
+} from '@generative-ai-use-cases/common';
+import { fileTypeFromBuffer, fileTypeFromStream } from 'file-type';
+
+// Map MIME types to their respective formats
+export const documentMimeTypeToExtensions: Record<DocumentMimeType, string[]> =
+  {
+    [DocumentMimeType.PDF]: ['pdf'],
+    [DocumentMimeType.CSV]: ['csv'],
+    [DocumentMimeType.DOC]: ['doc'],
+    [DocumentMimeType.DOCX]: ['docx'],
+    [DocumentMimeType.XLS]: ['xls'],
+    [DocumentMimeType.XLSX]: ['xlsx'],
+    [DocumentMimeType.HTML]: ['html'],
+    [DocumentMimeType.TXT]: ['txt'],
+    [DocumentMimeType.MD]: ['md'],
+  };
+export const imageMimeTypeToExtensions: Record<ImageMimeType, string[]> = {
+  [ImageMimeType.PNG]: ['png'],
+  [ImageMimeType.JPEG]: ['jpeg', 'jpg'],
+  [ImageMimeType.GIF]: ['gif'],
+  [ImageMimeType.WEBP]: ['webp'],
+};
+export const videoMimeTypeToExtensions: Record<VideoMimeType, string[]> = {
+  [VideoMimeType.MKV]: ['mkv'],
+  [VideoMimeType.MOV]: ['mov'],
+  [VideoMimeType.MP4]: ['mp4'],
+  [VideoMimeType.WEBM]: ['webm'],
+  [VideoMimeType.FLV]: ['flv'],
+  [VideoMimeType.MPEG]: ['mpeg', 'mpg'],
+  [VideoMimeType.WMV]: [], // We don't support WMV as 'file-type' doesn't support it
+  [VideoMimeType.THREE_GP]: ['3gp'],
+};
+export const mimeTypeToExtensions: Record<SupportedMimeType, string[]> = {
+  ...documentMimeTypeToExtensions,
+  ...imageMimeTypeToExtensions,
+  ...videoMimeTypeToExtensions,
+};
+
+// Sets of supported MIME types
+const imageMimeTypeSet = new Set(Object.values(ImageMimeType));
+const videoMimeTypeSet = new Set(Object.values(VideoMimeType));
+
+// Some MIME types are not accepted by file-type
+const unparsableMimeTypeSet = new Set<SupportedMimeType>([
+  'application/msword',
+  'application/vnd.ms-excel',
+  'text/plain',
+  'text/csv',
+  'text/html',
+  'text/markdown',
+]);
+
+// Some MIME types are not normalized, so we need to map them to their normalized types
+const mimeTypeAlias: Record<string, SupportedMimeType> = {
+  // mpeg
+  'video/MP1S': 'video/mpeg',
+  'video/MP2P': 'video/mpeg',
+};
+
+export const getMimeTypeFromFileHeader = async (file: File) => {
+  // Some file types (e.g. mkv) may not be properly detected by the browser,
+  // so this function detects the mime type based on the file header
+  let mimeType;
+  try {
+    mimeType = (await fileTypeFromStream(file.stream()))?.mime;
+  } catch (error) {
+    const arrayBuffer = await file.slice(0, 4096).arrayBuffer(); // Only read the first 4KB
+    mimeType = (await fileTypeFromBuffer(arrayBuffer))?.mime;
+  }
+
+  // Some file types are not accepted by file-type.
+  if (!mimeType || mimeType === 'application/x-cfb') {
+    // We accept text, doc, and xls files
+    if (unparsableMimeTypeSet.has(file.type as SupportedMimeType)) {
+      mimeType = file.type;
+    } else {
+      return ''; // Failed to detect the mime type
+    }
+  }
+  return (mimeTypeAlias[mimeType] || mimeType) as SupportedMimeType;
+};
+
+// Accepted file extensions (preceded by '.')
+const addDot = (ext: string) => `.${ext}`;
+export const AcceptedDotExtensions = {
+  doc: Object.values(documentMimeTypeToExtensions).flat().map(addDot),
+  image: Object.values(imageMimeTypeToExtensions).flat().map(addDot),
+  video: Object.values(videoMimeTypeToExtensions).flat().map(addDot),
+};
+
+// Get file type from MIME type
+export const getFileTypeFromMimeType = (mimeType?: string) => {
+  if (imageMimeTypeSet.has(mimeType as ImageMimeType)) return 'image';
+  if (videoMimeTypeSet.has(mimeType as VideoMimeType)) return 'video';
+  return 'file';
+};
+
+// Validate if MIME type and extension are compatible
+export const validateMimeTypeAndExtension = (
+  mimeType: string,
+  extension: string
+) => {
+  if (mimeType in mimeTypeToExtensions) {
+    const extensions = mimeTypeToExtensions[mimeType as SupportedMimeType];
+    const ext = extension.startsWith('.') ? extension.slice(1) : extension;
+    return extensions.includes(ext.toLowerCase()) || false;
+  }
+  return false; // MIME type is not supported
+};


### PR DESCRIPTION
## Description of Changes

This PR addresses several issues with file upload processing:
- Fixed inconsistencies between MIME types and Bedrock file formats (e.g., `video/quicktime` should map to `.mov`)
- Resolved issues with `.mkv` files where `file.type` was empty, causing format errors
- Fixed `.mpeg` file handling where `file-type` returned unexpected values (e.g., `video/MP1S` instead of `video/mpeg`)

Following changes were implemented:
- Added media utilities in `common/media.ts`
- Added mapping between MIME types and file formats (backend)
- Implemented a new validation flow instead of using `file.type`: (frontend)
  - MIME type detection using `file-type` library based on file content
  - Exception handling for MIME types which are not supported by `file-type`
  - Validation to ensure MIME type matches corresponding file extension

Tested on the following files:
- txt, pdf, doc, docx, xls, xlsx, html, csv, md
- jpg, png, gif, webp
- mkv, mov, mp4, webm, flv, mpeg, 3gp

## Checklist

- [ ] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

#927 