### PR TITLE
Support prompt caching for Claude 4 models

### DIFF
--- a/packages/common/src/application/model.ts
+++ b/packages/common/src/application/model.ts
@@ -522,6 +522,8 @@ export const BEDROCK_SPEECH_TO_SPEECH_MODELS = Object.keys(
 // Prompt caching
 // https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
 export const SUPPORTED_CACHE_FIELDS: Record<string, PromptCacheField[]> = {
+  'anthropic.claude-opus-4-20250514-v1:0': ['messages', 'system', 'tools'],
+  'anthropic.claude-sonnet-4-20250514-v1:0': ['messages', 'system', 'tools'],
   'anthropic.claude-3-7-sonnet-20250219-v1:0': ['messages', 'system', 'tools'],
   'anthropic.claude-3-5-haiku-20241022-v1:0': ['messages', 'system', 'tools'],
   'amazon.nova-pro-v1:0': ['messages', 'system'],


### PR DESCRIPTION
## Description of Changes

This PR implements prompt caching support for Claude Opus 4 and Claude Sonnet 4.

## Checklist

- [ ] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

Please list related issues as much as possible.
