### PR TITLE
Allow users to configure settings to turn off streaming

### DIFF
--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -695,7 +695,6 @@ rag:
   retrieving: Retrieving reference documents from Kendra...
   title: RAG Chat
 setting:
-  ai: Generative AI
   ai_items:
     agent_name: Agent Name
     image_gen_model: Image Generation Model Name
@@ -703,27 +702,29 @@ setting:
     model_region: LLM & Image Generation Model Region
     video_gen_model: Video Generation Model Name
   config_message: >-
-    Settings can be changed using <0>AWS CDK</0>, not on this screen. If you
+    System settings can be changed using <0>AWS CDK</0>, not on this screen. If you
     encounter errors when running use cases, please make sure you have enabled
     the specified models in {{region}}. For details on how to do this, please
     refer to <1>generative-ai-use-cases</1>.
-  general: General
   items:
     agent_enabled: Agent Enabled
     language: Language
     language_help: Change display language
+    login_status: Login status
     rag_enabled: RAG (Amazon Kendra) Enabled
     rag_kb_enabled: RAG (Knowledge Base) Enabled
+    typing_animation: Typing Animation
     version: Version
     version_help: Referencing the version in package.json of generative-ai-use-cases
   recent_updates: Recent Updates
   signout: Sign Out
-  title: Settings
+  system: System settings
   update:
     message: >-
       Updates are available on GitHub. If you want to use the latest features,
       please pull the main branch of <0>generative-ai-use-cases</0> and
       redeploy.
+  user: User settings
   view_all_updates: View All Updates
 shared:
   contact_admin: Please contact the administrator.

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -598,7 +598,6 @@ rag:
   retrieving: Kendra から参考ドキュメントを取得しています...
   title: RAG チャット
 setting:
-  ai: 生成 AI
   ai_items:
     agent_name: Agent 名
     image_gen_model: 画像生成 モデル名
@@ -606,25 +605,27 @@ setting:
     model_region: LLM & 画像生成 モデルリージョン
     video_gen_model: 動画生成 モデル名
   config_message: >-
-    設定の変更はこの画面ではなく <0>AWS CDK</0> で行います。 また、ユースケース実行時にエラーになる場合は、必ず {{region}}
+    システム設定の変更はこの画面ではなく <0>AWS CDK</0> で行います。 また、ユースケース実行時にエラーになる場合は、必ず {{region}}
     にて指定したモデルを有効化しているか確認してください。それぞれのやり方については <1>generative-ai-use-cases</1>
     をご参照ください。
-  general: 全般
   items:
     agent_enabled: Agent 有効
     language: 言語設定
     language_help: 表示言語を変更できます
+    login_status: ログイン状態
     rag_enabled: RAG (Amazon Kendra) 有効
     rag_kb_enabled: RAG (Knowledge Base) 有効
+    typing_animation: タイピングアニメーション
     version: バージョン
     version_help: generative-ai-use-cases の package.json の version を参照しています
   recent_updates: 最近のアップデート
   signout: サインアウト
-  title: 設定情報
+  system: システム設定
   update:
     message: >-
       GitHub にアップデートがあります。最新の機能を利用したい場合は <0>generative-ai-use-cases</0> の
       main ブランチを pull して再度デプロイしてください。
+  user: ユーザー設定
   view_all_updates: 全てのアップデートを見る
 shared:
   contact_admin: 管理者に問い合わせてください。

--- a/packages/web/public/locales/translation/th.yaml
+++ b/packages/web/public/locales/translation/th.yaml
@@ -618,7 +618,6 @@ rag:
   retrieving: กำลังค้นคืนเอกสารอ้างอิงจาก Kendra...
   title: RAG Chat
 setting:
-  ai: Generative AI
   ai_items:
     agent_name: Agent Name
     image_gen_model: Image Generation Model Name
@@ -627,7 +626,6 @@ setting:
     video_gen_model: Video Generation Model Name
   config_message: >-
     การตั้งค่าสามารถเปลี่ยนแปลงได้โดยใช้ <0>AWS CDK</0> ไม่ใช่บนหน้าจอนี้ หากคุณพบข้อผิดพลาดเมื่อใช้ use cases โปรดตรวจสอบว่าคุณได้เปิดใช้งานโมเดลที่ระบุใน {{region}} สำหรับรายละเอียดเกี่ยวกับวิธีการทำเช่นนี้ โปรดดูที่ <1>generative-ai-use-cases</1>
-  general: ทั่วไป
   items:
     agent_enabled: เปิดใช้งานตัวแทน
     language: ภาษา
@@ -638,7 +636,6 @@ setting:
     version_help: อ้างอิงเวอร์ชันใน package.json ของ generative-ai-use-cases
   recent_updates: การอัปเดตล่าสุด
   signout: ออกจากระบบ
-  title: ตั้งค่า
   update:
     message: >-
       มีการอัปเดตบน GitHub หากคุณต้องการใช้คุณสมบัติล่าสุด โปรดดึงสาขาหลักของ <0>generative-ai-use-cases</0> และปรับใช้ใหม่

--- a/packages/web/src/hooks/useTyping.ts
+++ b/packages/web/src/hooks/useTyping.ts
@@ -1,8 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
+import useUserSetting from './useUserSetting';
 
 const TYPING_DELAY = 10;
 
 const useTyping = (typing?: boolean) => {
+  const { settingTypingAnimation } = useUserSetting();
   const [typingTextInput, setTypingTextInput] = useState('');
   const [currentIndex, setCurrentIndex] = useState(0);
   const [animating, setAnimating] = useState(false);
@@ -64,13 +66,17 @@ const useTyping = (typing?: boolean) => {
   ]);
 
   const typingTextOutput = useMemo(() => {
+    if (!settingTypingAnimation) {
+      return typingTextInput;
+    }
+
     if (animating) {
       return typingTextInput.slice(0, currentIndex);
     } else {
       // If animating is false, return typingTextInput as is
       return typingTextInput;
     }
-  }, [typingTextInput, currentIndex, animating]);
+  }, [typingTextInput, currentIndex, animating, settingTypingAnimation]);
 
   return {
     setTypingTextInput,

--- a/packages/web/src/hooks/useUserSetting.ts
+++ b/packages/web/src/hooks/useUserSetting.ts
@@ -1,0 +1,13 @@
+import useLocalStorageBoolean from './useLocalStorageBoolean';
+
+const useUserSetting = () => {
+  const [settingTypingAnimation, setSettingTypingAnimation] =
+    useLocalStorageBoolean('typingAnimation', true);
+
+  return {
+    settingTypingAnimation,
+    setSettingTypingAnimation,
+  };
+};
+
+export default useUserSetting;

--- a/packages/web/src/pages/Setting.tsx
+++ b/packages/web/src/pages/Setting.tsx
@@ -1,8 +1,10 @@
 import useVersion from '../hooks/useVersion';
+import useUserSetting from '../hooks/useUserSetting';
 import { Link } from 'react-router-dom';
 import Help from '../components/Help';
 import Alert from '../components/Alert';
 import Button from '../components/Button';
+import Switch from '../components/Switch';
 import { MODELS } from '../hooks/useModel';
 import useGitHub, { PullRequest } from '../hooks/useGitHub';
 import { PiGithubLogoFill, PiArrowSquareOut } from 'react-icons/pi';
@@ -21,15 +23,17 @@ const SettingItem = (props: {
   name: string;
   value: string | React.ReactNode;
   helpMessage?: string;
+  top?: boolean;
 }) => {
   return (
-    <div className="border-aws-squid-ink mb-2 w-2/3 border-b-2 border-solid lg:w-1/2">
-      <div className="flex justify-between py-0.5">
-        <div className="flex items-center">
-          {props.name}
-          {props.helpMessage && <Help message={props.helpMessage} />}
-        </div>
-        <div className="text-right">{props.value}</div>
+    <div
+      className={`border-aws-squid-ink grid grid-cols-12 border-solid px-1 py-2 hover:bg-gray-200 ${props.top ? 'border-y' : 'border-b'}`}>
+      <div className="col-span-4 flex items-center justify-start">
+        {props.name}
+        {props.helpMessage && <Help message={props.helpMessage} />}
+      </div>
+      <div className="col-span-8 flex items-center justify-end">
+        {props.value}
       </div>
     </div>
   );
@@ -52,6 +56,8 @@ const Setting = () => {
   const localVersion = getLocalVersion();
   const hasUpdate = getHasUpdate();
   const closedPullRequests = getClosedPullRequests();
+  const { settingTypingAnimation, setSettingTypingAnimation } =
+    useUserSetting();
 
   const onClickSignout = useCallback(() => {
     // Delete all SWR cache
@@ -62,13 +68,9 @@ const Setting = () => {
   }, [cache, signOut]);
 
   return (
-    <div>
-      <div className="invisible my-0 flex h-0 items-center justify-center text-xl font-semibold lg:visible lg:my-5 lg:h-min print:visible print:my-5 print:h-min">
-        {t('setting.title')}
-      </div>
-
+    <div className="px-12 lg:px-32 xl:px-64">
       {hasUpdate && (
-        <div className="mt-5 flex w-full justify-center">
+        <div className="my-5 flex w-full justify-center">
           <Alert severity="info" className="flex w-fit items-center">
             <Trans
               i18nKey="setting.update.message"
@@ -85,27 +87,10 @@ const Setting = () => {
       )}
 
       <div className="my-3 flex justify-center font-semibold">
-        {t('setting.general')}
+        {t('setting.user')}
       </div>
 
-      <div className="flex w-full flex-col items-center text-sm">
-        <SettingItem
-          name={t('setting.items.version')}
-          value={localVersion || t('common.not_available')}
-          helpMessage={t('setting.items.version_help')}
-        />
-        <SettingItem
-          name={t('setting.items.rag_enabled')}
-          value={ragEnabled.toString()}
-        />
-        <SettingItem
-          name={t('setting.items.rag_kb_enabled')}
-          value={ragKnowledgeBaseEnabled.toString()}
-        />
-        <SettingItem
-          name={t('setting.items.agent_enabled')}
-          value={agentEnabled.toString()}
-        />
+      <div className="text-sm">
         <SettingItem
           name={t('setting.items.language')}
           value={
@@ -121,14 +106,49 @@ const Setting = () => {
             </select>
           }
           helpMessage={t('setting.items.language_help')}
+          top={true}
         />
+
+        <SettingItem
+          name={t('setting.items.typing_animation')}
+          value={
+            <Switch
+              checked={settingTypingAnimation}
+              label=""
+              onSwitch={setSettingTypingAnimation}
+            />
+          }></SettingItem>
+
+        <SettingItem
+          name={t('setting.items.login_status')}
+          value={
+            <Button onClick={onClickSignout}>{t('setting.signout')}</Button>
+          }></SettingItem>
       </div>
 
-      <div className="my-3 flex justify-center font-semibold">
-        {t('setting.ai')}
+      <div className="mb-3 mt-9 flex justify-center font-semibold">
+        {t('setting.system')}
       </div>
 
-      <div className="flex w-full flex-col items-center text-sm">
+      <div className="text-sm">
+        <SettingItem
+          name={t('setting.items.version')}
+          value={localVersion || t('common.not_available')}
+          helpMessage={t('setting.items.version_help')}
+          top={true}
+        />
+        <SettingItem
+          name={t('setting.items.rag_enabled')}
+          value={ragEnabled.toString()}
+        />
+        <SettingItem
+          name={t('setting.items.rag_kb_enabled')}
+          value={ragKnowledgeBaseEnabled.toString()}
+        />
+        <SettingItem
+          name={t('setting.items.agent_enabled')}
+          value={agentEnabled.toString()}
+        />
         <SettingItem
           name={t('setting.ai_items.llm_model')}
           value={modelIds.join(', ')}
@@ -149,7 +169,7 @@ const Setting = () => {
           name={t('setting.ai_items.model_region')}
           value={modelRegion}
         />
-        <div className="mt-5 w-2/3 text-xs lg:w-1/2">
+        <div className="my-2 text-xs">
           <Trans
             i18nKey="setting.config_message"
             values={{ region: modelRegion }}
@@ -169,13 +189,13 @@ const Setting = () => {
         </div>
       </div>
 
-      <div className="mb-3 mt-8 flex items-center justify-center font-semibold">
-        <PiGithubLogoFill className="mr-2 text-lg" />
+      <div className="mb-3 mt-9 flex items-center justify-center font-semibold">
+        <PiGithubLogoFill className="mr-1 text-base" />
         {t('setting.recent_updates')}
       </div>
 
-      <div className="flex flex-col items-center text-sm">
-        <ul className="h-64 w-2/3 overflow-y-scroll border border-gray-400 p-1 lg:w-1/2">
+      <div className="flex w-full flex-col items-center text-sm">
+        <ul className="h-64 w-full overflow-y-scroll border border-gray-400 p-2">
           {closedPullRequests.map((p: PullRequest, idx: number) => {
             return (
               <li key={idx} className="block truncate text-sm">
@@ -192,7 +212,7 @@ const Setting = () => {
           })}
         </ul>
 
-        <div className="mt-1 flex w-2/3 justify-end text-xs lg:w-1/2">
+        <div className="mb-3 mt-1 flex w-full justify-end text-xs">
           <a
             href="https://github.com/aws-samples/generative-ai-use-cases/pulls?q=is%3Apr+is%3Aclosed"
             className="flex items-center hover:underline"
@@ -201,12 +221,6 @@ const Setting = () => {
             {t('setting.view_all_updates')}
           </a>
         </div>
-      </div>
-
-      <div className="my-10 flex w-full justify-center">
-        <Button onClick={onClickSignout} className="text-lg">
-          {t('setting.signout')}
-        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Description of Changes

I've made it possible for users to toggle the typing animation on and off. Also, since user-specific settings will increase in the future, I've separated the items into user settings and system settings.

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

https://github.com/aws-samples/generative-ai-use-cases/issues/1089
