### PR TITLE
Add CRI suffix to model display name when duplicate models exist

### DIFF
--- a/packages/cdk/lambda/utils/promptCache.ts
+++ b/packages/cdk/lambda/utils/promptCache.ts
@@ -4,7 +4,7 @@ import {
   SystemContentBlock,
 } from '@aws-sdk/client-bedrock-runtime';
 import {
-  MODEL_ID_CRI_PREFIX,
+  CRI_PREFIX_PATTERN,
   SUPPORTED_CACHE_FIELDS,
 } from '@generative-ai-use-cases/common';
 
@@ -18,7 +18,7 @@ const SYSTEM_CACHE_POINT = {
 
 const getSupportedCacheFields = (modelId: string) => {
   // Remove CRI prefix
-  const baseModelId = modelId.replace(MODEL_ID_CRI_PREFIX, '');
+  const baseModelId = modelId.replace(CRI_PREFIX_PATTERN, '');
   return SUPPORTED_CACHE_FIELDS[baseModelId] || [];
 };
 

--- a/packages/cdk/lambda/utils/promptCache.ts
+++ b/packages/cdk/lambda/utils/promptCache.ts
@@ -3,7 +3,10 @@ import {
   Message,
   SystemContentBlock,
 } from '@aws-sdk/client-bedrock-runtime';
-import { SUPPORTED_CACHE_FIELDS } from '@generative-ai-use-cases/common';
+import {
+  MODEL_ID_CRI_PREFIX,
+  SUPPORTED_CACHE_FIELDS,
+} from '@generative-ai-use-cases/common';
 
 const CACHE_POINT = {
   cachePoint: { type: 'default' },
@@ -15,7 +18,7 @@ const SYSTEM_CACHE_POINT = {
 
 const getSupportedCacheFields = (modelId: string) => {
   // Remove CRI prefix
-  const baseModelId = modelId.replace(/^(us|eu|apac)\./, '');
+  const baseModelId = modelId.replace(MODEL_ID_CRI_PREFIX, '');
   return SUPPORTED_CACHE_FIELDS[baseModelId] || [];
 };
 

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -110,16 +110,16 @@ export class Api extends Construct {
     }
 
     // We don't support using the same model ID accross multiple regions
-    const modelIdsWithDuplicates = new Set(
+    const duplicateModelIds = new Set(
       [...modelIds, ...imageGenerationModelIds, ...videoGenerationModelIds]
         .map((m) => m.modelId)
         .filter((item, index, arr) => arr.indexOf(item) !== index)
     );
-    if (modelIdsWithDuplicates.size > 0) {
+    if (duplicateModelIds.size > 0) {
       throw new Error(
         'Following model IDs have duplicates. ' +
           'Using the same model ID across multiple regions is not supported:\n' +
-          [...modelIdsWithDuplicates].map((s) => `- ${s}\n`).join('\n')
+          [...duplicateModelIds].map((s) => `- ${s}\n`).join('\n')
       );
     }
 

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -117,8 +117,7 @@ export class Api extends Construct {
     );
     if (duplicateModelIds.size > 0) {
       throw new Error(
-        'Following model IDs have duplicates. ' +
-          'Using the same model ID across multiple regions is not supported:\n' +
+        'Duplicate model IDs detected. Using the same model ID multiple times is not supported:\n' +
           [...duplicateModelIds].map((s) => `- ${s}\n`).join('\n')
       );
     }

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -109,6 +109,20 @@ export class Api extends Construct {
       throw new Error(`Unsupported Model Name: ${rerankingModelId}`);
     }
 
+    // We don't support using the same model ID accross multiple regions
+    const modelIdsWithDuplicates = new Set(
+      [...modelIds, ...imageGenerationModelIds, ...videoGenerationModelIds]
+        .map((m) => m.modelId)
+        .filter((item, index, arr) => arr.indexOf(item) !== index)
+    );
+    if (modelIdsWithDuplicates.size > 0) {
+      throw new Error(
+        'Following model IDs have duplicates. ' +
+          'Using the same model ID across multiple regions is not supported:\n' +
+          [...modelIdsWithDuplicates].map((s) => `- ${s}\n`).join('\n')
+      );
+    }
+
     // Agent Map
     const agentMap: AgentMap = {};
     for (const agent of agents) {

--- a/packages/common/src/application/model.ts
+++ b/packages/common/src/application/model.ts
@@ -528,3 +528,5 @@ export const SUPPORTED_CACHE_FIELDS: Record<string, PromptCacheField[]> = {
   'amazon.nova-lite-v1:0': ['messages', 'system'],
   'amazon.nova-micro-v1:0': ['messages', 'system'],
 };
+
+export const MODEL_ID_CRI_PREFIX = /^(us|eu|apac)\./;

--- a/packages/common/src/application/model.ts
+++ b/packages/common/src/application/model.ts
@@ -529,4 +529,4 @@ export const SUPPORTED_CACHE_FIELDS: Record<string, PromptCacheField[]> = {
   'amazon.nova-micro-v1:0': ['messages', 'system'],
 };
 
-export const MODEL_ID_CRI_PREFIX = /^(us|eu|apac)\./;
+export const CRI_PREFIX_PATTERN = /^(us|eu|apac)\./;

--- a/packages/web/src/hooks/useModel.ts
+++ b/packages/web/src/hooks/useModel.ts
@@ -1,5 +1,8 @@
 import { Model, ModelConfiguration } from 'generative-ai-use-cases';
-import { modelMetadata } from '@generative-ai-use-cases/common';
+import {
+  MODEL_ID_CRI_PREFIX,
+  modelMetadata,
+} from '@generative-ai-use-cases/common';
 
 const modelRegion = import.meta.env.VITE_APP_MODEL_REGION;
 
@@ -155,8 +158,22 @@ export const findModelByModelId = (modelId: string) => {
 
 const searchAgent = agentNames.find((name) => name.includes('Search'));
 
+const duplicateBaseModelIdSet = new Set(
+  bedrockModelIds
+    .map((modelId) => modelId.replace(MODEL_ID_CRI_PREFIX, ''))
+    .filter((item, index, arr) => arr.indexOf(item) !== index)
+);
+
 const modelDisplayName = (modelId: string): string => {
-  return modelMetadata[modelId]?.displayName ?? modelId;
+  // If there are multiple instances of the same model, add CRI suffix to the display name
+  let displayName = modelMetadata[modelId]?.displayName ?? modelId;
+  if (duplicateBaseModelIdSet.has(modelId.replace(MODEL_ID_CRI_PREFIX, ''))) {
+    const criMatch = modelId.match(MODEL_ID_CRI_PREFIX);
+    if (criMatch) {
+      displayName += ` (${criMatch[1].toUpperCase()})`;
+    }
+  }
+  return displayName;
 };
 
 export const MODELS = {

--- a/packages/web/src/hooks/useModel.ts
+++ b/packages/web/src/hooks/useModel.ts
@@ -1,6 +1,6 @@
 import { Model, ModelConfiguration } from 'generative-ai-use-cases';
 import {
-  MODEL_ID_CRI_PREFIX,
+  CRI_PREFIX_PATTERN,
   modelMetadata,
 } from '@generative-ai-use-cases/common';
 
@@ -21,7 +21,11 @@ const bedrockModelIds: string[] = bedrockModelConfigs.map(
 const modelIdsInModelRegion: string[] = bedrockModelConfigs
   .filter((model) => model.region === modelRegion)
   .map((model) => model.modelId);
-
+const duplicateBaseModelIds = new Set(
+  bedrockModelIds
+    .map((modelId) => modelId.replace(CRI_PREFIX_PATTERN, ''))
+    .filter((item, index, arr) => arr.indexOf(item) !== index)
+);
 const visionModelIds: string[] = bedrockModelIds.filter(
   (modelId) => modelMetadata[modelId].flags.image
 );
@@ -158,17 +162,11 @@ export const findModelByModelId = (modelId: string) => {
 
 const searchAgent = agentNames.find((name) => name.includes('Search'));
 
-const duplicateBaseModelIdSet = new Set(
-  bedrockModelIds
-    .map((modelId) => modelId.replace(MODEL_ID_CRI_PREFIX, ''))
-    .filter((item, index, arr) => arr.indexOf(item) !== index)
-);
-
 const modelDisplayName = (modelId: string): string => {
   // If there are multiple instances of the same model, add CRI suffix to the display name
   let displayName = modelMetadata[modelId]?.displayName ?? modelId;
-  if (duplicateBaseModelIdSet.has(modelId.replace(MODEL_ID_CRI_PREFIX, ''))) {
-    const criMatch = modelId.match(MODEL_ID_CRI_PREFIX);
+  if (duplicateBaseModelIds.has(modelId.replace(CRI_PREFIX_PATTERN, ''))) {
+    const criMatch = modelId.match(CRI_PREFIX_PATTERN);
     if (criMatch) {
       displayName += ` (${criMatch[1].toUpperCase()})`;
     }


### PR DESCRIPTION
## Description of Changes

Added functionality to append a CRI suffix to model display names when multiple instances of the same model are used. When a model is used only once, the display name remains unchanged.

<img width="446" alt="Screenshot 2025-05-26 at 11 42 38" src="https://github.com/user-attachments/assets/208b96b0-f155-4360-8b96-9ab6ac6ca436" />


## Checklist

- [ ] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

#1082 
