### PR TITLE
Allow user to configure the visibility of use cases.

### DIFF
--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -331,6 +331,7 @@ diagram:
 drawer:
   ai_services: AI Services
   builder_mode: Builder Mode
+  done: Done
   generative_ai: Generative AI
   tools: Tools
   use_cases: Use Cases

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -302,6 +302,7 @@ diagram:
 drawer:
   ai_services: AI サービス
   builder_mode: ビルダーモード
+  done: 完了
   generative_ai: (生成 AI)
   tools: ツール
   use_cases: ユースケース

--- a/packages/web/src/components/Drawer.tsx
+++ b/packages/web/src/components/Drawer.tsx
@@ -1,12 +1,13 @@
 import React, { useMemo, useState } from 'react';
 import { BaseProps } from '../@types/common';
 import { useNavigate } from 'react-router-dom';
-import { PiMagnifyingGlass } from 'react-icons/pi';
+import { PiMagnifyingGlass, PiGear } from 'react-icons/pi';
 import ExpandableMenu from './ExpandableMenu';
 import ChatList from './ChatList';
 import DrawerItem, { DrawerItemProps } from './DrawerItem';
 import DrawerBase from './DrawerBase';
 import Switch from './Switch';
+import Button from './Button';
 import { useTranslation } from 'react-i18next';
 
 export type ItemProps = DrawerItemProps & {
@@ -40,6 +41,8 @@ const Drawer: React.FC<Props> = (props) => {
   const useCaseBuilderEnabled: boolean =
     import.meta.env.VITE_APP_USE_CASE_BUILDER_ENABLED === 'true';
 
+  const [settingVisibility, setSettingVisibility] = useState(false);
+
   return (
     <>
       <DrawerBase>
@@ -56,9 +59,17 @@ const Drawer: React.FC<Props> = (props) => {
             <div className="border-b" />
           </>
         )}
-        <div className="text-aws-smile mx-3 my-1 text-xs">
-          {t('drawer.use_cases')}{' '}
-          <span className="text-gray-400">{t('drawer.generative_ai')}</span>
+        <div className="text-aws-smile mx-3 my-1 flex items-center justify-between text-xs">
+          <div>
+            {t('drawer.use_cases')}{' '}
+            <span className="text-gray-400">{t('drawer.generative_ai')}</span>
+          </div>
+          <PiGear
+            className="cursor-pointer text-base text-white"
+            onClick={() => {
+              setSettingVisibility(!settingVisibility);
+            }}
+          />
         </div>
         <div className="scrollbar-thin scrollbar-thumb-white ml-2 mr-1 h-full overflow-y-auto">
           {usecases.map((item, idx) => (
@@ -68,8 +79,22 @@ const Drawer: React.FC<Props> = (props) => {
               icon={item.icon}
               to={item.to}
               sub={item.sub}
+              settingVisibility={settingVisibility}
             />
           ))}
+
+          {settingVisibility && (
+            <div className="my-2 flex w-full justify-center">
+              <Button
+                className="w-full"
+                onClick={() => {
+                  setSettingVisibility(false);
+                }}
+                outlined>
+                {t('drawer.done')}
+              </Button>
+            </div>
+          )}
         </div>
         <div className="border-b" />
         {tools.length > 0 && (

--- a/packages/web/src/components/DrawerItem.tsx
+++ b/packages/web/src/components/DrawerItem.tsx
@@ -2,17 +2,24 @@ import { Link, useLocation } from 'react-router-dom';
 import { BaseProps } from '../@types/common';
 import useDrawer from '../hooks/useDrawer';
 import { useCallback } from 'react';
+import Switch from '../components/Switch';
+import useLocalStorageBoolean from '../hooks/useLocalStorageBoolean';
 
 export type DrawerItemProps = BaseProps & {
   label: string;
   to: string;
   icon: JSX.Element;
   sub?: string;
+  settingVisibility?: boolean;
 };
 
 const DrawerItem: React.FC<DrawerItemProps> = (props) => {
   const location = useLocation();
   const { switchOpen } = useDrawer();
+  const [visibility, setVisibility] = useLocalStorageBoolean(
+    `visibility_${props.to}`,
+    true
+  );
 
   // If the screen is narrow, close the Drawer when clicked
   const onClick = useCallback(() => {
@@ -27,20 +34,33 @@ const DrawerItem: React.FC<DrawerItemProps> = (props) => {
   }, []);
 
   return (
-    <Link
-      className={`hover:bg-aws-sky mt-0.5 flex h-8 items-center rounded p-2 ${
-        location.pathname === props.to && 'bg-aws-sky'
-      } ${props.className}`}
-      to={props.to}
-      onClick={onClick}>
-      <span className="mr-2">{props.icon}</span>
-      <div className="flex w-full items-center justify-between">
-        <span>{props.label}</span>
-        {props.sub && (
-          <span className="text-xs text-gray-300">{props.sub}</span>
-        )}
-      </div>
-    </Link>
+    <>
+      {!visibility && !props.settingVisibility ? (
+        <div></div>
+      ) : (
+        <div className="mt-0.5 flex h-8 items-center">
+          {props.settingVisibility && (
+            <Switch checked={visibility} onSwitch={setVisibility} label="" />
+          )}
+          <Link
+            className={`hover:bg-aws-sky flex h-8 w-full items-center rounded p-2 ${
+              location.pathname === props.to && 'bg-aws-sky'
+            } ${props.className} ${props.settingVisibility ? 'pl-2' : ''}`}
+            to={props.to}
+            onClick={onClick}>
+            {!props.settingVisibility && (
+              <span className="mr-2">{props.icon}</span>
+            )}
+            <div className="flex w-full items-center justify-between">
+              <span>{props.label}</span>
+              {props.sub && (
+                <span className="text-xs text-gray-300">{props.sub}</span>
+              )}
+            </div>
+          </Link>
+        </div>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## Description of Changes

Currently, the display/hide of use cases can be controlled at the system level, but it should also be possible to do so at the user level.

![スクリーンショット 2025-05-26 13 22 14](https://github.com/user-attachments/assets/48e834cc-70b3-4401-9441-1bcfcdfdb79c)

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues
https://github.com/aws-samples/generative-ai-use-cases/issues/1090