### PR TITLE
 Add IP restriction to S3 pre-signed URLs when allowed IP ranges are specified

### DIFF
--- a/packages/cdk/lib/construct/transcribe.ts
+++ b/packages/cdk/lib/construct/transcribe.ts
@@ -17,11 +17,14 @@ import {
   HttpMethods,
 } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
+import { allowS3AccessWithSourceIpCondition } from '../utils/s3-access-policy';
 
 export interface TranscribeProps {
   readonly userPool: UserPool;
   readonly idPool: IdentityPool;
   readonly api: RestApi;
+  readonly allowedIpV4AddressRanges?: string[] | null;
+  readonly allowedIpV6AddressRanges?: string[] | null;
 }
 
 export class Transcribe extends Construct {
@@ -59,7 +62,17 @@ export class Transcribe extends Construct {
         BUCKET_NAME: audioBucket.bucketName,
       },
     });
-    audioBucket.grantWrite(getSignedUrlFunction);
+    if (getSignedUrlFunction.role) {
+      allowS3AccessWithSourceIpCondition(
+        audioBucket.bucketName,
+        getSignedUrlFunction.role,
+        'write',
+        {
+          ipv4: props.allowedIpV4AddressRanges,
+          ipv6: props.allowedIpV6AddressRanges,
+        }
+      );
+    }
 
     const startTranscriptionFunction = new NodejsFunction(
       this,

--- a/packages/cdk/lib/utils/s3-access-policy.ts
+++ b/packages/cdk/lib/utils/s3-access-policy.ts
@@ -1,0 +1,44 @@
+import { Effect, IRole, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+
+const createSourceIpCondition = (
+  allowedIpV4AddressRanges?: string[] | null,
+  allowedIpV6AddressRanges?: string[] | null
+) =>
+  // Create a source IP condition when either IPv4 or IPv6 address ranges are specified (not null/undefined)
+  // An empty array (e.g., []) means no access is allowed for that IP version
+  // If both parameters are null/undefined, this function returns undefined
+  allowedIpV4AddressRanges || allowedIpV6AddressRanges
+    ? {
+        IpAddress: {
+          'aws:SourceIp': [
+            ...(allowedIpV4AddressRanges ?? []),
+            ...(allowedIpV6AddressRanges ?? []),
+          ],
+        },
+      }
+    : undefined;
+
+export const allowS3AccessWithSourceIpCondition = (
+  bucketName: string,
+  role: IRole,
+  accessType: 'read' | 'write',
+  ipConditions?: {
+    ipv4?: string[] | null;
+    ipv6?: string[] | null;
+  }
+) => {
+  role.addToPrincipalPolicy(
+    new PolicyStatement({
+      effect: Effect.ALLOW,
+      resources: [`arn:aws:s3:::${bucketName}`, `arn:aws:s3:::${bucketName}/*`],
+      actions:
+        accessType === 'read'
+          ? ['s3:GetBucket*', 's3:GetObject*', 's3:List*']
+          : ['s3:Abort*', 's3:DeleteObject*', 's3:PutObject*'],
+      conditions: createSourceIpCondition(
+        ipConditions?.ipv4,
+        ipConditions?.ipv6
+      ),
+    })
+  );
+};

--- a/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
+++ b/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
@@ -11385,27 +11385,30 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
           "Statement": [
             {
               "Action": [
-                "s3:GetObject*",
                 "s3:GetBucket*",
+                "s3:GetObject*",
                 "s3:List*",
               ],
               "Effect": "Allow",
               "Resource": [
                 {
-                  "Fn::GetAtt": [
-                    "APIFileBucket8FB29855",
-                    "Arn",
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "APIFileBucket8FB29855",
+                      },
+                    ],
                   ],
                 },
                 {
                   "Fn::Join": [
                     "",
                     [
+                      "arn:aws:s3:::",
                       {
-                        "Fn::GetAtt": [
-                          "APIFileBucket8FB29855",
-                          "Arn",
-                        ],
+                        "Ref": "APIFileBucket8FB29855",
                       },
                       "/*",
                     ],
@@ -11680,31 +11683,30 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
           "Statement": [
             {
               "Action": [
-                "s3:DeleteObject*",
-                "s3:PutObject",
-                "s3:PutObjectLegalHold",
-                "s3:PutObjectRetention",
-                "s3:PutObjectTagging",
-                "s3:PutObjectVersionTagging",
                 "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
               ],
               "Effect": "Allow",
               "Resource": [
                 {
-                  "Fn::GetAtt": [
-                    "APIFileBucket8FB29855",
-                    "Arn",
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "APIFileBucket8FB29855",
+                      },
+                    ],
                   ],
                 },
                 {
                   "Fn::Join": [
                     "",
                     [
+                      "arn:aws:s3:::",
                       {
-                        "Fn::GetAtt": [
-                          "APIFileBucket8FB29855",
-                          "Arn",
-                        ],
+                        "Ref": "APIFileBucket8FB29855",
                       },
                       "/*",
                     ],
@@ -16959,31 +16961,30 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
           "Statement": [
             {
               "Action": [
-                "s3:DeleteObject*",
-                "s3:PutObject",
-                "s3:PutObjectLegalHold",
-                "s3:PutObjectRetention",
-                "s3:PutObjectTagging",
-                "s3:PutObjectVersionTagging",
                 "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
               ],
               "Effect": "Allow",
               "Resource": [
                 {
-                  "Fn::GetAtt": [
-                    "TranscribeAudioBucket39DFF290",
-                    "Arn",
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "TranscribeAudioBucket39DFF290",
+                      },
+                    ],
                   ],
                 },
                 {
                   "Fn::Join": [
                     "",
                     [
+                      "arn:aws:s3:::",
                       {
-                        "Fn::GetAtt": [
-                          "TranscribeAudioBucket39DFF290",
-                          "Arn",
-                        ],
+                        "Ref": "TranscribeAudioBucket39DFF290",
                       },
                       "/*",
                     ],

--- a/packages/web/src/i18n/config.ts
+++ b/packages/web/src/i18n/config.ts
@@ -7,7 +7,6 @@ import { initReactI18next } from 'react-i18next';
 import yaml from 'js-yaml';
 
 /* eslint-disable i18nhelper/no-jp-string */
- 
 
 // Define the supported languages as an object.
 // This is for use when the user manually switches languages.


### PR DESCRIPTION
## Description of Changes

This PR implements IP restrictions for S3 pre-signed URLs when `allowedIpV4AddressRanges` or `allowedIpV6AddressRanges` are specified.

The implementation adds sourceIp conditions to the Lambda roles that generate pre-signed URLs (for RAG and Transcribe), ensuring that IP restrictions applied to the application are also enforced for S3 object access.

## Checklist

- [ ] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

#703
