### PR TITLE
Implementation of forced stop function for chats

### DIFF
--- a/packages/web/src/components/ButtonSend.tsx
+++ b/packages/web/src/components/ButtonSend.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { PiPaperPlaneRightFill, PiSpinnerGap } from 'react-icons/pi';
+import {
+  PiPaperPlaneRightFill,
+  PiSpinnerGap,
+  PiStopFill,
+} from 'react-icons/pi';
 import { BaseProps } from '../@types/common';
 
 type Props = BaseProps & {
@@ -7,6 +11,7 @@ type Props = BaseProps & {
   loading?: boolean;
   onClick: () => void;
   icon?: React.ReactNode;
+  canStop?: boolean;
 };
 
 const ButtonSend: React.FC<Props> = (props) => {
@@ -18,9 +23,15 @@ const ButtonSend: React.FC<Props> = (props) => {
         props.disabled ? 'bg-gray-300' : 'bg-aws-smile'
       }`}
       onClick={props.onClick}
-      disabled={props.disabled || props.loading}>
+      disabled={props.disabled}>
       {props.loading ? (
-        <PiSpinnerGap className="animate-spin" />
+        <>
+          {props.canStop ? (
+            <PiStopFill />
+          ) : (
+            <PiSpinnerGap className="animate-spin" />
+          )}
+        </>
       ) : (
         <>{props.icon ? <>{props.icon}</> : <PiPaperPlaneRightFill />}</>
       )}

--- a/packages/web/src/components/GenerateImageAssistant.tsx
+++ b/packages/web/src/components/GenerateImageAssistant.tsx
@@ -282,6 +282,7 @@ const GenerateImageAssistant: React.FC<Props> = (props) => {
             fullWidth
             hideReset
             content={props.content}
+            disabled={loading || props.isGeneratingImage}
             loading={loading || props.isGeneratingImage}
             onChangeContent={props.onChangeContent}
             onSend={onSend}

--- a/packages/web/src/components/InputChatContent.tsx
+++ b/packages/web/src/components/InputChatContent.tsx
@@ -33,6 +33,7 @@ type Props = {
   fileUpload?: boolean;
   fileLimit?: FileLimit;
   accept?: string[];
+  canStop?: boolean;
 } & (
   | {
       hideReset?: false;
@@ -102,12 +103,12 @@ const InputChatContent: React.FC<Props> = (props) => {
 
   const disabledSend = useMemo(() => {
     return (
-      props.content.trim() === '' ||
+      (!loading && props.content.trim() === '') ||
       props.disabled ||
       uploading ||
       errorMessages.length > 0
     );
-  }, [props.content, props.disabled, uploading, errorMessages]);
+  }, [props.content, props.disabled, uploading, errorMessages, loading]);
 
   return (
     <div
@@ -230,6 +231,7 @@ const InputChatContent: React.FC<Props> = (props) => {
             loading={loading || uploading}
             onClick={props.onSend}
             icon={props.sendIcon}
+            canStop={props.canStop}
           />
         </div>
 

--- a/packages/web/src/hooks/useRag.ts
+++ b/packages/web/src/hooks/useRag.ts
@@ -47,6 +47,7 @@ const useRag = (id: string) => {
     postChat,
     clear,
     loading,
+    writing,
     setLoading,
     updateSystemContext,
     popMessage,
@@ -65,6 +66,7 @@ const useRag = (id: string) => {
     isEmpty,
     clear,
     loading,
+    writing,
     messages,
     postMessage: async (content: string) => {
       const model = findModelByModelId(modelId);

--- a/packages/web/src/pages/AgentChatPage.tsx
+++ b/packages/web/src/pages/AgentChatPage.tsx
@@ -77,6 +77,7 @@ const AgentChatPage: React.FC = () => {
     getModelId,
     setModelId,
     loading,
+    writing,
     loadingMessages,
     isEmpty,
     messages,
@@ -277,7 +278,7 @@ const AgentChatPage: React.FC = () => {
         <div className="fixed bottom-0 z-0 flex w-full flex-col items-center justify-center lg:pr-64 print:hidden">
           <InputChatContent
             content={content}
-            disabled={false}
+            disabled={loading && !writing}
             onChangeContent={setContent}
             resetDisabled={false}
             onSend={() => {
@@ -291,7 +292,7 @@ const AgentChatPage: React.FC = () => {
             fileUpload={true}
             fileLimit={fileLimit}
             accept={fileLimit.accept.doc}
-            canStop={true}
+            canStop={writing}
           />
         </div>
       </div>

--- a/packages/web/src/pages/AgentChatPage.tsx
+++ b/packages/web/src/pages/AgentChatPage.tsx
@@ -84,6 +84,7 @@ const AgentChatPage: React.FC = () => {
     postChat,
     updateSystemContextByModel,
     retryGeneration,
+    forceToStop,
   } = useChat(pathname);
   const { scrollableContainer, setFollowing } = useFollow();
   const { agentNames: availableModels } = MODELS;
@@ -172,6 +173,11 @@ const AgentChatPage: React.FC = () => {
     setSessionId(uuidv4());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clear]);
+
+  const onStop = useCallback(() => {
+    forceToStop();
+    setSessionId(uuidv4());
+  }, [forceToStop, setSessionId]);
 
   const showingMessages = useMemo(() => {
     return messages;
@@ -271,16 +277,21 @@ const AgentChatPage: React.FC = () => {
         <div className="fixed bottom-0 z-0 flex w-full flex-col items-center justify-center lg:pr-64 print:hidden">
           <InputChatContent
             content={content}
-            disabled={loading}
+            disabled={false}
             onChangeContent={setContent}
             resetDisabled={false}
             onSend={() => {
-              onSend();
+              if (!loading) {
+                onSend();
+              } else {
+                onStop();
+              }
             }}
             onReset={onReset}
             fileUpload={true}
             fileLimit={fileLimit}
             accept={fileLimit.accept.doc}
+            canStop={true}
           />
         </div>
       </div>

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -127,6 +127,7 @@ const ChatPage: React.FC = () => {
     updateSystemContextByModel,
     getCurrentSystemContext,
     retryGeneration,
+    forceToStop,
   } = useChat(pathname, chatId);
   const { createShareId, findShareId, deleteShareId } = useChatApi();
   const { createSystemContext } = useSystemContextApi();
@@ -241,6 +242,10 @@ const ChatPage: React.FC = () => {
     clear();
     setContent('');
   }, [clear, setContent]);
+
+  const onStop = useCallback(() => {
+    forceToStop();
+  }, [forceToStop]);
 
   const [creatingShareId, setCreatingShareId] = useState(false);
   const [deletingShareId, setDeletingShareId] = useState(false);
@@ -538,11 +543,15 @@ const ChatPage: React.FC = () => {
           )}
           <InputChatContent
             content={content}
-            disabled={loading}
+            disabled={false}
             onChangeContent={setContent}
             resetDisabled={!!chatId}
             onSend={() => {
-              onSend();
+              if (!loading) {
+                onSend();
+              } else {
+                onStop();
+              }
             }}
             onReset={onReset}
             fileUpload={fileUpload}
@@ -552,6 +561,7 @@ const ChatPage: React.FC = () => {
             onSetting={() => {
               setShowSetting(true);
             }}
+            canStop={true}
           />
         </div>
       </div>

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -117,6 +117,7 @@ const ChatPage: React.FC = () => {
     getModelId,
     setModelId,
     loading,
+    writing,
     loadingMessages,
     isEmpty,
     messages,
@@ -543,7 +544,7 @@ const ChatPage: React.FC = () => {
           )}
           <InputChatContent
             content={content}
-            disabled={false}
+            disabled={loading && !writing}
             onChangeContent={setContent}
             resetDisabled={!!chatId}
             onSend={() => {
@@ -561,7 +562,7 @@ const ChatPage: React.FC = () => {
             onSetting={() => {
               setShowSetting(true);
             }}
-            canStop={true}
+            canStop={writing}
           />
         </div>
       </div>

--- a/packages/web/src/pages/FlowChatPage.tsx
+++ b/packages/web/src/pages/FlowChatPage.tsx
@@ -98,6 +98,7 @@ const FlowChatPage: React.FC = () => {
               <ChatMessage
                 chatContent={message}
                 loading={loading && idx === messages.length - 1}
+                hideFeedback={true}
               />
               <div className="w-full border-b border-gray-300"></div>
             </div>
@@ -118,6 +119,7 @@ const FlowChatPage: React.FC = () => {
           onSend={onSend}
           onReset={onReset}
           fileUpload={false}
+          loading={loading}
         />
       </div>
 

--- a/packages/web/src/pages/RagKnowledgeBasePage.tsx
+++ b/packages/web/src/pages/RagKnowledgeBasePage.tsx
@@ -67,6 +67,7 @@ const RagKnowledgeBasePage: React.FC = () => {
     getModelId,
     setModelId,
     loading,
+    writing,
     isEmpty,
     messages,
     clear,
@@ -264,7 +265,7 @@ const RagKnowledgeBasePage: React.FC = () => {
           className={`fixed bottom-0 z-0 flex w-full flex-col items-center justify-center lg:pr-64 print:hidden`}>
           <InputChatContent
             content={content}
-            disabled={false}
+            disabled={loading && !writing}
             onChangeContent={setContent}
             onSend={() => {
               if (!loading) {
@@ -278,7 +279,7 @@ const RagKnowledgeBasePage: React.FC = () => {
             onSetting={() => {
               setShowSetting(true);
             }}
-            canStop={true}
+            canStop={writing}
           />
         </div>
       </div>

--- a/packages/web/src/pages/RagKnowledgeBasePage.tsx
+++ b/packages/web/src/pages/RagKnowledgeBasePage.tsx
@@ -73,6 +73,7 @@ const RagKnowledgeBasePage: React.FC = () => {
     postChat,
     updateSystemContextByModel,
     retryGeneration,
+    forceToStop,
   } = useChat(pathname);
   const { scrollableContainer, setFollowing } = useFollow();
   const { modelIdsInModelRegion: availableModels, modelDisplayName } = MODELS;
@@ -212,6 +213,11 @@ const RagKnowledgeBasePage: React.FC = () => {
     setSessionId(undefined);
   }, [clear, setContent, setFilters, setSessionId]);
 
+  const onStop = useCallback(() => {
+    forceToStop();
+    setSessionId(undefined);
+  }, [forceToStop, setSessionId]);
+
   return (
     <>
       <div className={`${!isEmpty ? 'screen:pb-36' : ''} relative`}>
@@ -258,16 +264,21 @@ const RagKnowledgeBasePage: React.FC = () => {
           className={`fixed bottom-0 z-0 flex w-full flex-col items-center justify-center lg:pr-64 print:hidden`}>
           <InputChatContent
             content={content}
-            disabled={loading}
+            disabled={false}
             onChangeContent={setContent}
             onSend={() => {
-              onSend();
+              if (!loading) {
+                onSend();
+              } else {
+                onStop();
+              }
             }}
             onReset={onReset}
             setting={true}
             onSetting={() => {
               setShowSetting(true);
             }}
+            canStop={true}
           />
         </div>
       </div>

--- a/packages/web/src/pages/RagPage.tsx
+++ b/packages/web/src/pages/RagPage.tsx
@@ -36,7 +36,7 @@ const RagPage: React.FC = () => {
   const { t } = useTranslation();
   const { content, setContent } = useRagPageState();
   const { pathname, search } = useLocation();
-  const { getModelId, setModelId } = useChat(pathname);
+  const { getModelId, setModelId, forceToStop } = useChat(pathname);
   const { postMessage, clear, loading, messages, isEmpty } = useRag(pathname);
   const { scrollableContainer, setFollowing } = useFollow();
   const { modelIds: availableModels, modelDisplayName } = MODELS;
@@ -68,6 +68,10 @@ const RagPage: React.FC = () => {
     clear();
     setContent('');
   }, [clear, setContent]);
+
+  const onStop = useCallback(() => {
+    forceToStop();
+  }, [forceToStop]);
 
   return (
     <>
@@ -116,12 +120,17 @@ const RagPage: React.FC = () => {
         <div className="fixed bottom-0 z-0 flex w-full items-end justify-center lg:pr-64 print:hidden">
           <InputChatContent
             content={content}
-            disabled={loading}
+            disabled={false}
             onChangeContent={setContent}
             onSend={() => {
-              onSend();
+              if (!loading) {
+                onSend();
+              } else {
+                onStop();
+              }
             }}
             onReset={onReset}
+            canStop={true}
           />
         </div>
       </div>

--- a/packages/web/src/pages/RagPage.tsx
+++ b/packages/web/src/pages/RagPage.tsx
@@ -37,7 +37,8 @@ const RagPage: React.FC = () => {
   const { content, setContent } = useRagPageState();
   const { pathname, search } = useLocation();
   const { getModelId, setModelId, forceToStop } = useChat(pathname);
-  const { postMessage, clear, loading, messages, isEmpty } = useRag(pathname);
+  const { postMessage, clear, loading, writing, messages, isEmpty } =
+    useRag(pathname);
   const { scrollableContainer, setFollowing } = useFollow();
   const { modelIds: availableModels, modelDisplayName } = MODELS;
   const modelId = getModelId();
@@ -120,7 +121,7 @@ const RagPage: React.FC = () => {
         <div className="fixed bottom-0 z-0 flex w-full items-end justify-center lg:pr-64 print:hidden">
           <InputChatContent
             content={content}
-            disabled={false}
+            disabled={loading && !writing}
             onChangeContent={setContent}
             onSend={() => {
               if (!loading) {
@@ -130,7 +131,7 @@ const RagPage: React.FC = () => {
               }
             }}
             onReset={onReset}
-            canStop={true}
+            canStop={writing}
           />
         </div>
       </div>


### PR DESCRIPTION
## Description of Changes

I have implemented a function to forcibly stop responses during Chat, RagChat, RagKnowledgeBaseChat, and AgentChat.

## Pages affected (pages using InputChatContent)
- ./src/pages/ChatPage.tsx => Made it possible to stop
- ./src/pages/RagPage.tsx => Made it possible to stop
- ./src/pages/RagKnowledgeBasePage.tsx => Made it possible to stop
- ./src/pages/AgentChatPage.tsx => Made it possible to stop
- ./src/pages/FlowChatPage.tsx => Loading & disabled as before
- ./src/pages/VoiceChatPage.tsx => Same as before (used in system prompt settings)
- ./src/pages/VideoAnalyzerPage.tsx => Loading & disabled as before
- ./src/components/GenerateImageAssistant.tsx => Loading & disabled as before

(ButtonSend component is only used in InputChatContent.tsx.)

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

N/A