### PR TITLE
User can configure the drawer (Setting the visibility of Use Case Builder and Tools)

### DIFF
--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -714,6 +714,8 @@ setting:
     login_status: Login status
     rag_enabled: RAG (Amazon Kendra) Enabled
     rag_kb_enabled: RAG (Knowledge Base) Enabled
+    show_tools: Show Tools
+    show_use_case_builder: Show Use Case Builder
     typing_animation: Typing Animation
     version: Version
     version_help: Referencing the version in package.json of generative-ai-use-cases

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -616,6 +616,8 @@ setting:
     login_status: ログイン状態
     rag_enabled: RAG (Amazon Kendra) 有効
     rag_kb_enabled: RAG (Knowledge Base) 有効
+    show_tools: ツールの表示
+    show_use_case_builder: ユースケースビルダーの表示
     typing_animation: タイピングアニメーション
     version: バージョン
     version_help: generative-ai-use-cases の package.json の version を参照しています

--- a/packages/web/src/components/Drawer.tsx
+++ b/packages/web/src/components/Drawer.tsx
@@ -9,6 +9,7 @@ import DrawerBase from './DrawerBase';
 import Switch from './Switch';
 import Button from './Button';
 import { useTranslation } from 'react-i18next';
+import useUserSetting from '../hooks/useUserSetting';
 
 export type ItemProps = DrawerItemProps & {
   display: 'usecase' | 'tool' | 'none';
@@ -21,6 +22,7 @@ type Props = BaseProps & {
 const Drawer: React.FC<Props> = (props) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { settingShowUseCaseBuilder, settingShowTools } = useUserSetting();
 
   const usecases = useMemo(() => {
     return props.items.filter((i) => i.display === 'usecase');
@@ -46,7 +48,7 @@ const Drawer: React.FC<Props> = (props) => {
   return (
     <>
       <DrawerBase>
-        {useCaseBuilderEnabled && (
+        {useCaseBuilderEnabled && settingShowUseCaseBuilder && (
           <>
             <Switch
               className="mx-3 my-2"
@@ -97,7 +99,7 @@ const Drawer: React.FC<Props> = (props) => {
           )}
         </div>
         <div className="border-b" />
-        {tools.length > 0 && (
+        {tools.length > 0 && settingShowTools && (
           <>
             <ExpandableMenu
               title={t('drawer.tools')}

--- a/packages/web/src/hooks/useUserSetting.ts
+++ b/packages/web/src/hooks/useUserSetting.ts
@@ -3,10 +3,20 @@ import useLocalStorageBoolean from './useLocalStorageBoolean';
 const useUserSetting = () => {
   const [settingTypingAnimation, setSettingTypingAnimation] =
     useLocalStorageBoolean('typingAnimation', true);
+  const [settingShowUseCaseBuilder, setSettingShowUseCaseBuilder] =
+    useLocalStorageBoolean('showUseCaseBuilder', true);
+  const [settingShowTools, setSettingShowTools] = useLocalStorageBoolean(
+    'showTools',
+    true
+  );
 
   return {
     settingTypingAnimation,
     setSettingTypingAnimation,
+    settingShowUseCaseBuilder,
+    setSettingShowUseCaseBuilder,
+    settingShowTools,
+    setSettingShowTools,
   };
 };
 

--- a/packages/web/src/pages/Setting.tsx
+++ b/packages/web/src/pages/Setting.tsx
@@ -56,8 +56,14 @@ const Setting = () => {
   const localVersion = getLocalVersion();
   const hasUpdate = getHasUpdate();
   const closedPullRequests = getClosedPullRequests();
-  const { settingTypingAnimation, setSettingTypingAnimation } =
-    useUserSetting();
+  const {
+    settingTypingAnimation,
+    setSettingTypingAnimation,
+    settingShowUseCaseBuilder,
+    setSettingShowUseCaseBuilder,
+    settingShowTools,
+    setSettingShowTools,
+  } = useUserSetting();
 
   const onClickSignout = useCallback(() => {
     // Delete all SWR cache
@@ -116,6 +122,26 @@ const Setting = () => {
               checked={settingTypingAnimation}
               label=""
               onSwitch={setSettingTypingAnimation}
+            />
+          }></SettingItem>
+
+        <SettingItem
+          name={t('setting.items.show_use_case_builder')}
+          value={
+            <Switch
+              checked={settingShowUseCaseBuilder}
+              label=""
+              onSwitch={setSettingShowUseCaseBuilder}
+            />
+          }></SettingItem>
+
+        <SettingItem
+          name={t('setting.items.show_tools')}
+          value={
+            <Switch
+              checked={settingShowTools}
+              label=""
+              onSwitch={setSettingShowTools}
             />
           }></SettingItem>
 


### PR DESCRIPTION
## Description of Changes

In this PR, user can configure the drawer. User can change the visibility of Use Case Builder and Tools even if system enables those mode and tools.

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues
- https://github.com/aws-samples/generative-ai-use-cases/issues/1098
- https://github.com/aws-samples/generative-ai-use-cases/issues/1097