### PR TITLE
fix: Firefox textarea scrolling issues due to incorrect height calculation

### DIFF
--- a/packages/web/src/components/Textarea.tsx
+++ b/packages/web/src/components/Textarea.tsx
@@ -77,6 +77,8 @@ const Textarea: React.FC<Props> = (props) => {
         placeholder={props.placeholder || t('common.enter_text')}
         value={props.value}
         onKeyDown={(e) => {
+          // keyCode is deprecated, but used for some browsers to handle IME input
+          if (e.nativeEvent.isComposing || e.keyCode === 229) return;
           if (props.onEnter && e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault();
             props.onEnter();

--- a/packages/web/src/components/Textarea.tsx
+++ b/packages/web/src/components/Textarea.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useLayoutEffect, useRef } from 'react';
 import RowItem, { RowItemProps } from './RowItem';
 import Help from './Help';
 import { useTranslation } from 'react-i18next';
@@ -21,31 +21,30 @@ type Props = RowItemProps & {
 };
 
 const MAX_HEIGHT = 300;
-const isFirefox = navigator.userAgent.toLowerCase().includes('firefox');
 
 const Textarea: React.FC<Props> = (props) => {
   const { t } = useTranslation();
   const ref = useRef<HTMLTextAreaElement>(null);
-  const [isMax, setIsMax] = useState(false);
-  const _maxHeight = props.maxHeight || MAX_HEIGHT;
+  const maxHeight = props.maxHeight || MAX_HEIGHT;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!ref.current) return;
     // Reset the height to auto to calculate the scroll height
     ref.current.style.height = 'auto';
+    ref.current.style.overflowY = 'hidden';
 
     // Ensure the layout is updated before calculating the scroll height
     // due to the bug in Firefox:
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1795904
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1787062
-    if (isFirefox) void ref.current.scrollHeight;
+    void ref.current.scrollHeight;
 
     // Set the height to match content, up to max height
     const scrollHeight = ref.current.scrollHeight;
-    const _isMax = _maxHeight > 0 && scrollHeight > _maxHeight;
-    ref.current.style.height = (_isMax ? _maxHeight : scrollHeight) + 'px';
-    setIsMax(_isMax);
-  }, [props.value, _maxHeight]);
+    const isMax = maxHeight > 0 && scrollHeight > maxHeight;
+    ref.current.style.height = (isMax ? maxHeight : scrollHeight) + 'px';
+    ref.current.style.overflowY = isMax ? 'auto' : 'hidden';
+  }, [props.value, maxHeight]);
 
   return (
     <RowItem notItem={props.notItem}>
@@ -72,8 +71,6 @@ const Textarea: React.FC<Props> = (props) => {
         className={`${
           props.className ?? ''
         } w-full resize-none rounded p-1.5 outline-none ${
-          isMax ? 'overflow-y-auto' : 'overflow-hidden'
-        } ${
           props.noBorder ? 'border-0 focus:ring-0 ' : 'border border-black/30'
         } ${props.disabled ? 'bg-gray-200 ' : ''}`}
         rows={props.rows ?? 1}


### PR DESCRIPTION
## Description of Changes

This pull request addresses an issue with height calculation in Firefox.
- https://bugzilla.mozilla.org/show_bug.cgi?id=1795904
- https://bugzilla.mozilla.org/show_bug.cgi?id=1787062

Changes:
- Added a Firefox-specific workaround to force layout recalculation before measuring scroll height
- Improved keyboard event handling by using React's built-in onKeyDown property
- Replaced useEffect with useLayoutEffect for better synchronization with the rendering cycle

## Checklist

- [ ] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

Please list related issues as much as possible.
