### PR TITLE
Adding translation functionality for Video generation use case

### DIFF
--- a/packages/web/src/hooks/useModel.ts
+++ b/packages/web/src/hooks/useModel.ts
@@ -18,6 +18,9 @@ const bedrockModelConfigs = (
 const bedrockModelIds: string[] = bedrockModelConfigs.map(
   (model) => model.modelId
 );
+const lightModelIds: string[] = bedrockModelConfigs
+  .filter((model) => modelMetadata[model.modelId].flags.light)
+  .map((model) => model.modelId);
 const modelIdsInModelRegion: string[] = bedrockModelConfigs
   .filter((model) => model.region === modelRegion)
   .map((model) => model.modelId);
@@ -180,6 +183,7 @@ export const MODELS = {
   modelIdsInModelRegion,
   modelMetadata,
   modelDisplayName,
+  lightModelIds,
   visionModelIds: visionModelIds,
   visionEnabled: visionEnabled,
   imageGenModelIds: imageGenModelIds,

--- a/packages/web/src/hooks/useOneshotTranslation.ts
+++ b/packages/web/src/hooks/useOneshotTranslation.ts
@@ -1,0 +1,68 @@
+import { useMemo, useCallback, useState } from 'react';
+import { getPrompter } from '../prompts';
+import { MODELS, findModelByModelId } from './useModel';
+import useChatApi from '../hooks/useChatApi';
+
+const useOneshotTranslation = () => {
+  const { predict } = useChatApi();
+  const { modelIds, lightModelIds } = MODELS;
+  const [translating, setTranslating] = useState(false);
+
+  const translationModelId = useMemo(() => {
+    return lightModelIds[0] ?? modelIds[0];
+  }, [modelIds, lightModelIds]);
+
+  const translate = useCallback(
+    async (sentence: string, language: string): Promise<string> => {
+      if (translating) return '';
+
+      setTranslating(true);
+
+      // Translate using the same mechanism (prompt) as the Translation use case.
+      // However, it will not remain in the conversation history.
+      const id = '/translate';
+      const prompter = getPrompter(translationModelId);
+      const systemPrompt = prompter.systemContext(id);
+      const translationPrompt = prompter.translatePrompt({
+        sentence,
+        language,
+        context: undefined,
+      });
+      const model = findModelByModelId(translationModelId);
+      const messages = [
+        {
+          role: 'system' as const,
+          content: systemPrompt,
+        },
+        {
+          role: 'user' as const,
+          content: translationPrompt,
+        },
+      ];
+
+      const translatedWithTag = await predict({
+        model,
+        messages,
+        id,
+      });
+
+      const translated = translatedWithTag.replace(
+        /(<output>|<\/output>)/g,
+        ''
+      );
+
+      setTranslating(false);
+
+      return translated;
+    },
+    [translating, setTranslating, translationModelId, predict]
+  );
+
+  return {
+    translating,
+    setTranslating,
+    translate,
+  };
+};
+
+export default useOneshotTranslation;

--- a/packages/web/src/pages/GenerateVideoPage.tsx
+++ b/packages/web/src/pages/GenerateVideoPage.tsx
@@ -21,12 +21,14 @@ import {
   PiArrowClockwise,
   PiTrash,
   PiUpload,
+  PiTranslate,
 } from 'react-icons/pi';
 import { GenerateVideoPageQueryParams } from '../@types/navigate';
 import { useLocation } from 'react-router-dom';
 import queryString from 'query-string';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
+import useOneshotTranslation from '../hooks/useOneshotTranslation';
 
 const TASK_TYPES = (modelId: string): string[] => {
   if (modelId === 'amazon.nova-reel-v1:1') {
@@ -235,6 +237,7 @@ const GenerateVideoPage: React.FC = () => {
   const [deletingJobIds, setDeletingJobIds] = useState<Record<string, boolean>>(
     {}
   );
+  const { translate, translating } = useOneshotTranslation();
 
   const onChangeFiles = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -441,6 +444,10 @@ const GenerateVideoPage: React.FC = () => {
     return date.toLocaleString();
   }, []);
 
+  const translateAndSetAsPrompt = useCallback(() => {
+    translate(prompt, 'English').then(setPrompt);
+  }, [translate, prompt, setPrompt]);
+
   return (
     <div className="grid h-screen grid-cols-12 gap-4 p-4">
       <div className="col-span-12 lg:col-span-4">
@@ -469,14 +476,26 @@ const GenerateVideoPage: React.FC = () => {
 
           {MODEL_PARAMS(videoGenModelId, taskType) && (
             <>
-              <Textarea
-                value={prompt}
-                onChange={setPrompt}
-                label={t('video.prompt.title')}
-                placeholder={t('video.prompt.placeholder')}
-                rows={3}
-                required
-              />
+              <div className="relative">
+                <Textarea
+                  value={prompt}
+                  onChange={setPrompt}
+                  label={t('video.prompt.title')}
+                  placeholder={t('video.prompt.placeholder')}
+                  rows={3}
+                  required
+                />
+                <ButtonIcon
+                  className="absolute bottom-2 right-1"
+                  onClick={translateAndSetAsPrompt}
+                  disabled={translating}>
+                  {translating ? (
+                    <PiSpinnerGap className="animate-spin" />
+                  ) : (
+                    <PiTranslate />
+                  )}
+                </ButtonIcon>
+              </div>
 
               {MODEL_PARAMS(videoGenModelId, taskType).dimension && (
                 <Select


### PR DESCRIPTION
## Description of Changes

Prompts for Video generation are in English only. Currently, users need to translate prompts using the translation use case and then input them, which is cumbersome. We have now enabled translation capability within the Video generation use case. It performs one-shot inference using the same prompt as the /translate use case, but it doesn't remain in the conversation history.

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

https://github.com/aws-samples/generative-ai-use-cases/issues/1102