### PR TITLE
Add Claude 4 model to defaul models

### DIFF
--- a/packages/cdk/cdk.json
+++ b/packages/cdk/cdk.json
@@ -40,6 +40,8 @@
     "hiddenUseCases": {},
     "modelRegion": "us-east-1",
     "modelIds": [
+      "us.anthropic.claude-sonnet-4-20250514-v1:0",
+      "us.anthropic.claude-opus-4-20250514-v1:0",
       "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
       "us.anthropic.claude-3-5-haiku-20241022-v1:0",
       "us.amazon.nova-premier-v1:0",

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -41,6 +41,8 @@ export const stackInputSchema = z.object({
       ])
     )
     .default([
+      'us.anthropic.claude-sonnet-4-20250514-v1:0',
+      'us.anthropic.claude-opus-4-20250514-v1:0',
       'us.anthropic.claude-3-7-sonnet-20250219-v1:0',
       'us.anthropic.claude-3-5-haiku-20241022-v1:0',
       'us.amazon.nova-premier-v1:0',


### PR DESCRIPTION
## Description of Changes

cdk.json の初期のモデルを変更して、Claude Sonnet 4、Claude Opus 4 を追加しました。
Claude Sonnet 4 を一番上にしています。Claude 3.7 Sonnet や Claude 3.5 Haiku は引き続き利用することを考えて残しております。 

---

I have modified the initial model in cdk.json to add Claude Sonnet 4 and Claude Opus 4.
I've placed Claude Sonnet 4 at the top. I've kept Claude 3.7 Sonnet and Claude 3.5 Haiku as they will continue to be used.

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

Please list related issues as much as possible.
