### PR TITLE
Add "Experimental" flag properly

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -134,6 +134,7 @@ const App: React.FC = () => {
           to: '/mcp',
           icon: <PiGraph />,
           display: 'usecase' as const,
+          sub: 'Experimental',
         }
       : null,
     flowChatEnabled
@@ -150,6 +151,7 @@ const App: React.FC = () => {
           to: '/voice-chat',
           icon: <PiMicrophoneBold />,
           display: 'usecase' as const,
+          sub: 'Experimental',
         }
       : null,
     enabled('generate')


### PR DESCRIPTION
## Description of Changes

The status of Voice Chat and MCP Chat is "experimental" now. The architecture would be changed in the future.
Add experimental flag on UI so that user can identify the status of them.

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

https://github.com/aws-samples/generative-ai-use-cases/issues/1146
