### PR TITLE
Support container deployment from SageMaker Studio

### DIFF
--- a/packages/cdk/lib/construct/mcp-api.ts
+++ b/packages/cdk/lib/construct/mcp-api.ts
@@ -10,9 +10,11 @@ import {
 } from 'aws-cdk-lib/aws-lambda';
 import { PolicyStatement, Effect } from 'aws-cdk-lib/aws-iam';
 import { IdentityPool } from 'aws-cdk-lib/aws-cognito-identitypool';
+import { NetworkMode } from 'aws-cdk-lib/aws-ecr-assets';
 
 export interface McpApiProps {
   readonly idPool: IdentityPool;
+  readonly isSageMakerStudio: boolean;
 }
 
 export class McpApi extends Construct {
@@ -20,9 +22,12 @@ export class McpApi extends Construct {
 
   constructor(scope: Construct, id: string, props: McpApiProps) {
     super(scope, id);
-
     const mcpFunction = new DockerImageFunction(this, 'McpFunction', {
-      code: DockerImageCode.fromImageAsset('./mcp-api'),
+      code: DockerImageCode.fromImageAsset('./mcp-api', {
+        networkMode: props.isSageMakerStudio
+          ? NetworkMode.custom('sagemaker')
+          : NetworkMode.NONE,
+      }),
       memorySize: 1024,
       timeout: Duration.minutes(15),
       architecture: Architecture.ARM_64,

--- a/packages/cdk/lib/construct/mcp-api.ts
+++ b/packages/cdk/lib/construct/mcp-api.ts
@@ -26,11 +26,11 @@ export class McpApi extends Construct {
       code: DockerImageCode.fromImageAsset('./mcp-api', {
         networkMode: props.isSageMakerStudio
           ? NetworkMode.custom('sagemaker')
-          : NetworkMode.NONE,
+          : NetworkMode.DEFAULT,
       }),
       memorySize: 1024,
       timeout: Duration.minutes(15),
-      architecture: Architecture.ARM_64,
+      architecture: Architecture.X86_64,
       environment: {
         AWS_LWA_INVOKE_MODE: 'RESPONSE_STREAM',
       },

--- a/packages/cdk/lib/create-stacks.ts
+++ b/packages/cdk/lib/create-stacks.ts
@@ -105,6 +105,7 @@ export const createStacks = (app: cdk.App, params: ProcessedStackInput) => {
   }
 
   // GenU Stack
+  const isSageMakerStudio = 'SAGEMAKER_APP_TYPE_LOWERCASE' in process.env;
   const generativeAiUseCasesStack = new GenerativeAiUseCasesStack(
     app,
     `GenerativeAiUseCasesStack${params.env}`,
@@ -133,6 +134,8 @@ export const createStacks = (app: cdk.App, params: ProcessedStackInput) => {
       webAclId: cloudFrontWafStack?.webAclArn,
       // Custom Domain
       cert: cloudFrontWafStack?.cert,
+      // Image build environment
+      isSageMakerStudio,
     }
   );
 

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -36,6 +36,8 @@ export interface GenerativeAiUseCasesStackProps extends StackProps {
   readonly webAclId?: string;
   // Custom Domain
   readonly cert?: ICertificate;
+  // Image build environment
+  readonly isSageMakerStudio: boolean;
 }
 
 export class GenerativeAiUseCasesStack extends Stack {
@@ -125,6 +127,7 @@ export class GenerativeAiUseCasesStack extends Stack {
     if (params.mcpEnabled) {
       const mcpApi = new McpApi(this, 'McpApi', {
         idPool: auth.idPool,
+        isSageMakerStudio: props.isSageMakerStudio,
       });
       mcpEndpoint = mcpApi.endpoint;
     }

--- a/packages/cdk/mcp-api/Dockerfile
+++ b/packages/cdk/mcp-api/Dockerfile
@@ -2,6 +2,7 @@ FROM public.ecr.aws/docker/library/python:3.13
 
 WORKDIR /var/task
 
+RUN mkdir -p /opt/extensions
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1 /lambda-adapter /opt/extensions/lambda-adapter
 
 ENV UV_NO_CACHE=1


### PR DESCRIPTION
## Description of Changes

This PR introduces the following changes to improve compatibility with SageMaker Studio:

- Add `isSageMakerStudio` variable to control docker build networking option
- Add explicit `mkdir` commands in Dockerfile to ensure the parent directory exists even when BuildKit’s implicit-directory optimisation is active.

## Checklist

- [ ] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues


