### PR TITLE
fix MCP chat

### DIFF
--- a/packages/cdk/lib/construct/mcp-api.ts
+++ b/packages/cdk/lib/construct/mcp-api.ts
@@ -1,4 +1,4 @@
-import { Duration } from 'aws-cdk-lib';
+import { Duration, Size } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import {
   DockerImageFunction,
@@ -31,6 +31,7 @@ export class McpApi extends Construct {
           : NetworkMode.DEFAULT,
       }),
       memorySize: 1024,
+      ephemeralStorageSize: Size.mebibytes(1024),
       timeout: Duration.minutes(15),
       architecture: Architecture.X86_64,
       environment: {

--- a/packages/cdk/mcp-api/app.py
+++ b/packages/cdk/mcp-api/app.py
@@ -168,8 +168,8 @@ def make_mcp_client(server):
                 command=server['command'],
                 args=server['args'],
                 env={
-                    **server['env'],
                     **UV_ENV,
+                    **server['env'],
                 },
             )
         )

--- a/packages/cdk/mcp-api/app.py
+++ b/packages/cdk/mcp-api/app.py
@@ -34,6 +34,7 @@ FIXED_SYSTEM_PROMPT = f"""## About File Output
 - You are running on AWS Lambda. Therefore, when writing files, always write them under `{WORKSPACE_DIR}`.
 - Similarly, if you need a workspace, please use the `{WORKSPACE_DIR}` directory. Do not ask the user about their current workspace. It's always `{WORKSPACE_DIR}`.
 - Also, users cannot directly access files written under `{WORKSPACE_DIR}`. So when submitting these files to users, *always upload them to S3 using the `upload_file_to_s3_and_retrieve_s3_url` tool and provide the S3 URL*. The S3 URL must be included in the final output.
+- If the output file is an image file, the S3 URL output must be in Markdown format.
 """
 
 def stream_chunk(text, trace):

--- a/packages/web/src/prompts/claude.ts
+++ b/packages/web/src/prompts/claude.ts
@@ -119,8 +119,6 @@ Please follow the instructions in the <input> and provide your answer.
 Output your answer in the format <output>answer</output>.
 Do not output any other text.
 Also, do not enclose your output in {} tags.`,
-  '/mcp':
-    'You are an AI agent that is good with lots of different tools. You find the answers to user questions and instructions using the right tools. The answers can be in different types of formats. If you want to make images, please use Markdown and show them.',
 };
 
 export const claudePrompter: Prompter = {

--- a/packages/web/src/prompts/claude.ts
+++ b/packages/web/src/prompts/claude.ts
@@ -119,6 +119,8 @@ Please follow the instructions in the <input> and provide your answer.
 Output your answer in the format <output>answer</output>.
 Do not output any other text.
 Also, do not enclose your output in {} tags.`,
+  '/mcp':
+    'You are an AI agent that is good with lots of different tools. You find the answers to user questions and instructions using the right tools. The answers can be in different types of formats. If you want to make images, please use Markdown and show them.',
 };
 
 export const claudePrompter: Prompter = {


### PR DESCRIPTION
## Description of Changes
Fixed the following
- Fixes an issue where Lambda fails to start due to lack of ephemeral storage
- Fixed an error when generating images from regions where Nova Canvas is not provided
- Fixed an issue where generated images sometimes did not appear on the chat screen

---

以下の点を修正
- Lambdaのエフェメラルストレージ不足で起動に失敗する問題の修正
- Nova Canvasが提供されていないリージョンから画像を生成するとエラーになる問題の修正
- 時々、生成した画像がチャット画面に表示されない問題の修正

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

Please list related issues as much as possible.
