### PR TITLE
GA: Voice Chat, Deprecated: MCP Chat

### DIFF
--- a/docs/en/DEPLOY_OPTION.md
+++ b/docs/en/DEPLOY_OPTION.md
@@ -569,6 +569,9 @@ const envs: Record<string, Partial<StackInput>> = {
 
 ### Enabling MCP Chat Use Case
 
+> [!WARNING]
+> The MCP Chat use case has been deprecated. Please use the AgentCore use case for MCP utilization. The MCP chat use case is scheduled for complete removal in v6.
+
 [MCP (Model Context Protocol)](https://modelcontextprotocol.io/introduction) is a protocol that connects LLM models with external data and tools.
 In GenU, we provide chat use cases that execute MCP-compliant tools using [Strands Agents](https://strandsagents.com/latest/).
 To enable MCP chat use cases, the `docker` command must be executable.

--- a/docs/ja/DEPLOY_OPTION.md
+++ b/docs/ja/DEPLOY_OPTION.md
@@ -584,6 +584,9 @@ const envs: Record<string, Partial<StackInput>> = {
 
 ### MCP チャットユースケースの有効化
 
+> [!WARNING]
+> MCP チャットユースケースは Deprecated ステータスになりました。MCP の活用には AgentCore ユースケースをご利用ください。MCP チャットユースケースは v6 で完全削除予定です。
+
 [MCP (Model Context Protocol)](https://modelcontextprotocol.io/introduction) とは、LLM モデルと外部データやツールを繋ぐプロトコルです。
 GenU では [Strands Agents](https://strandsagents.com/latest/) を活用して MCP に準拠したツールを実行するチャットユースケースを用意しています。
 MCP チャットユースケースを有効化するためには、`docker` コマンドが実行可能である必要があります。

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -9,7 +9,7 @@
     "cdk": "cdk",
     "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0",
     "lambda-build-dryrun": "tsc --noEmit --skipLibCheck",
-    "postinstall": "npm ci --prefix custom-resources/agent-core-runtime && npm ci --prefix custom-resources/opensearch-index"
+    "postinstall": "npm ci --prefix custom-resources/agent-core-runtime && npm ci --prefix custom-resources/opensearch-index && npm ci --prefix fargate-s3-server"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.137",

--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -1283,11 +1283,6 @@ videoAnalyzer:
 voiceChat:
   close: Close session
   default_system_prompt: You are an AI assistant.
-  experimental_warning: >-
-    Voice Chat is still in an experimental stage. The architecture, etc. may be
-    changed in the future. Conversation history will not be saved. The supported
-    language is English only.
-  experimental_warning_title: About Voice Chat
   im_listening: I'm listening...
   start: Start new session
   title: Voice Chat

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -1033,8 +1033,6 @@ videoAnalyzer:
 voiceChat:
   close: セッションを終了する
   default_system_prompt: You are an AI assistant.
-  experimental_warning: 音声チャットはまだ実験的な段階です。アーキテクチャ等は今後変更される可能性があります。会話履歴は保存されません。対応言語は英語のみです。
-  experimental_warning_title: 音声チャットについて
   im_listening: 発言してください
   start: セッションを始める
   title: 音声チャット

--- a/packages/web/public/locales/translation/th.yaml
+++ b/packages/web/public/locales/translation/th.yaml
@@ -1081,9 +1081,6 @@ videoAnalyzer:
 voiceChat:
   close: ปิดเซสชั่น
   default_system_prompt: You are an AI assistant.
-  experimental_warning: >-
-    Voice Chat ยังอยู่ในระยะทดลอง สถาปัตยกรรมและอื่นๆ อาจมีการเปลี่ยนแปลงในอนาคต ประวัติการสนทนาจะไม่ได้รับการบันทึก ภาษาที่รองรับคือภาษาอังกฤษเท่านั้น
-  experimental_warning_title: เกี่ยวกับ Voice Chat
   im_listening: กำลังฟัง...
   start: เริ่มเซสชันใหม่
   title: Voice Chat

--- a/packages/web/public/locales/translation/vi.yaml
+++ b/packages/web/public/locales/translation/vi.yaml
@@ -1049,9 +1049,6 @@ videoAnalyzer:
 voiceChat:
   close: Kết thúc Phiên
   default_system_prompt: You are an AI assistant.
-  experimental_warning: >-
-    Voice chat vẫn đang trong giai đoạn thử nghiệm. Kiến trúc và các yếu tố khác có thể thay đổi trong tương lai. Lịch sử hội thoại sẽ không được lưu. Chỉ hỗ trợ tiếng Anh.
-  experimental_warning_title: Về voice chat
   im_listening: Hãy phát biểu
   start: Bắt đầu phiên
   title: Voice Chat

--- a/packages/web/public/locales/translation/zh.yaml
+++ b/packages/web/public/locales/translation/zh.yaml
@@ -896,8 +896,6 @@ videoAnalyzer:
 voiceChat:
   close: 结束会话
   default_system_prompt: 您是一个AI助手。
-  experimental_warning: 语音聊天仍处于实验阶段。架构等可能在未来发生变化。对话历史不会保存。仅支持英语。
-  experimental_warning_title: 关于语音聊天
   im_listening: 请说话
   start: 开始会话
   title: 语音聊天

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -136,7 +136,7 @@ const App: React.FC = () => {
           to: '/mcp',
           icon: <PiGraph />,
           display: 'usecase' as const,
-          sub: 'Experimental',
+          sub: 'Deprecated',
         }
       : null,
     agentCoreEnabled
@@ -162,7 +162,6 @@ const App: React.FC = () => {
           to: '/voice-chat',
           icon: <PiMicrophoneBold />,
           display: 'usecase' as const,
-          sub: 'Experimental',
         }
       : null,
     enabled('generate')

--- a/packages/web/src/pages/VoiceChatPage.tsx
+++ b/packages/web/src/pages/VoiceChatPage.tsx
@@ -13,7 +13,6 @@ import ExpandableField from '../components/ExpandableField';
 import Button from '../components/Button';
 import InputChatContent from '../components/InputChatContent';
 import ScrollTopBottom from '../components/ScrollTopBottom';
-import Alert from '../components/Alert.tsx';
 import Select from '../components/Select';
 import useFollow from '../hooks/useFollow';
 import BedrockIcon from '../assets/bedrock.svg?react';
@@ -101,12 +100,6 @@ const VoiceChatPage: React.FC = () => {
 
         {isEmpty && !isLoading && !isActive && (
           <div className="flex h-[calc(100vh-9rem)] flex-col items-center justify-center">
-            <Alert
-              title={t('voiceChat.experimental_warning_title')}
-              severity="warning"
-              className="w-11/12 md:w-10/12 lg:w-4/6 xl:w-3/6">
-              {t('voiceChat.experimental_warning')}
-            </Alert>
             <div className="relative flex h-full flex-col items-center justify-center">
               <BedrockIcon className="fill-gray-400" />
             </div>


### PR DESCRIPTION
## Description of Changes

As title, change status of the following use cases
- Voice Chat => GA
- MCP Chat => Deprecated (Will be removed v6)

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

N/A
