### PR TITLE
Add: Setting to automatically delete conversation history and uploaded files after a specified number of days

### DIFF
--- a/docs/en/DEPLOY_OPTION.md
+++ b/docs/en/DEPLOY_OPTION.md
@@ -1803,6 +1803,45 @@ After configuration, open the `GenerativeAiUseCasesDashboardStack.DashboardUrl` 
 > [!NOTE]
 > If you want to disable the monitoring dashboard after enabling it, set `dashboard: false` and redeploy. This will disable the monitoring dashboard, but the `GenerativeAiUseCasesDashboardStack` itself will remain. To completely remove it, open the management console and delete the `GenerativeAiUseCasesDashboardStack` stack from CloudFormation in the modelRegion.
 
+## Data Retention Period Configuration
+
+By setting `dataRetentionDays`, you can enable automatic deletion of chat history and uploaded files. After the specified number of days, the following data will be automatically deleted:
+
+- DynamoDB chat history data (messages, system contexts)
+- **Note**: Statistics data (model usage, token counts, etc.) is preserved for long-term analysis and is not subject to TTL
+- Files stored in S3 (images, audio files, transcription results)
+
+This feature helps control storage costs that increase with long-term usage and automates data lifecycle management.
+
+**Edit [parameter.ts](/packages/cdk/parameter.ts)**
+
+```typescript
+// parameter.ts
+const envs: Record<string, Partial<StackInput>> = {
+  dev: {
+    dataRetentionDays: 30, // Automatically delete data after 30 days
+  },
+};
+```
+
+**Edit [packages/cdk/cdk.json](/packages/cdk/cdk.json)**
+
+```json
+// cdk.json
+{
+  "context": {
+    "dataRetentionDays": 30
+  }
+}
+```
+
+> [!WARNING]
+>
+> - Deleted data cannot be recovered. Please set an appropriate retention period
+> - DynamoDB TTL deletion is executed within a few days of the specified time (not immediately)
+> - Changing this setting will not update TTL for existing data. Only newly created data will be deleted with the new setting
+> - If `dataRetentionDays` is not set, data will be retained indefinitely
+
 ## Using a Custom Domain
 
 You can use a custom domain for your website URL. A public hosted zone must already be created in Route53 in the same AWS account. For public hosted zones, please refer to: [Working with public hosted zones - Amazon Route 53](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/AboutHZWorkingWith.html)

--- a/docs/ja/DEPLOY_OPTION.md
+++ b/docs/ja/DEPLOY_OPTION.md
@@ -1810,6 +1810,45 @@ const envs: Record<string, Partial<StackInput>> = {
 > [!NOTE]
 > モニタリング用のダッシュボードを有効後に、再度無効化する場合は、`dashboard: false` にして再デプロイすればモニタリング用ダッシュボードは無効化されますが、`GenerativeAiUseCasesDashboardStack` 自体は残ります。マネージメントコンソールを開き、modelRegion の CloudFormation から `GenerativeAiUseCasesDashboardStack` というスタックを削除することで完全に消去ができます。
 
+## データ保持期間の設定
+
+`dataRetentionDays` を設定することで、チャット履歴やアップロードされたファイルの自動削除を有効にできます。指定した日数が経過すると、以下のデータが自動的に削除されます：
+
+- DynamoDB のチャット履歴データ（メッセージ、システムコンテキスト）
+- **注意**: 統計情報（モデル使用量、トークン数など）は長期分析のため保持され、TTL対象外です
+- S3 に保存されたファイル（画像、音声ファイル、文字起こし結果）
+
+この機能は、長期間の使用に伴うストレージコストの増加を抑制し、データライフサイクルの管理を自動化します。
+
+**[parameter.ts](/packages/cdk/parameter.ts) を編集**
+
+```typescript
+// parameter.ts
+const envs: Record<string, Partial<StackInput>> = {
+  dev: {
+    dataRetentionDays: 30, // 30日後にデータを自動削除
+  },
+};
+```
+
+**[packages/cdk/cdk.json](/packages/cdk/cdk.json) を編集**
+
+```json
+// cdk.json
+{
+  "context": {
+    "dataRetentionDays": 30
+  }
+}
+```
+
+> [!WARNING]
+>
+> - 削除されたデータは復旧できません。適切な保持期間を設定してください
+> - DynamoDB の TTL による削除は、指定日時から数日以内に実行されます（即座ではありません）
+> - この設定を変更しても、既存データの TTL は更新されません。新しく作成されるデータのみが新しい設定で削除されます
+> - `dataRetentionDays` を設定しない場合、データは無期限に保持されます
+
 ## カスタムドメインの使用
 
 Web サイトの URL としてカスタムドメインを使用することができます。同一 AWS アカウントの Route53 にパブリックホストゾーンが作成済みであることが必要です。パブリックホストゾーンについてはこちらをご参照ください: [パブリックホストゾーンの使用 - Amazon Route 53](https://docs.aws.amazon.com/ja_jp/Route53/latest/DeveloperGuide/AboutHZWorkingWith.html)

--- a/packages/cdk/lambda/repository.ts
+++ b/packages/cdk/lambda/repository.ts
@@ -347,12 +347,13 @@ async function updateTokenUsage(message: RecordedMessage): Promise<void> {
   }
 }
 
-// Update TTL for parent chat record
-const updateChatTTL = async (
+// Update TTL for all records with the same chatId (parent chat + all messages)
+const updateAllRecordsTTL = async (
   userId: string,
   chatId: string,
   ttl: number
 ): Promise<void> => {
+  // Update parent chat record TTL
   const chat = await findChatById(
     userId.replace('user#', ''),
     chatId.replace('chat#', '')
@@ -375,6 +376,33 @@ const updateChatTTL = async (
       })
     );
   }
+
+  // Update all existing message records TTL for this chat
+  const messages = await listMessages(chatId.replace('chat#', ''));
+  if (messages.length > 0) {
+    // Use individual UpdateCommand for each message (BatchWriteCommand doesn't support UpdateRequest)
+    const updatePromises = messages.map((message) =>
+      dynamoDbDocument.send(
+        new UpdateCommand({
+          TableName: TABLE_NAME,
+          Key: {
+            id: message.id,
+            createdDate: message.createdDate,
+          },
+          UpdateExpression: 'set #ttl = :ttl',
+          ExpressionAttributeNames: {
+            '#ttl': 'ttl',
+          },
+          ExpressionAttributeValues: {
+            ':ttl': ttl,
+          },
+        })
+      )
+    );
+
+    // Execute all updates in parallel
+    await Promise.all(updatePromises);
+  }
 };
 
 export const batchCreateMessages = async (
@@ -388,6 +416,12 @@ export const batchCreateMessages = async (
   const feedback = 'none';
 
   const ttl = calculateTTL();
+
+  // Update existing records TTL before adding new messages
+  if (ttl) {
+    await updateAllRecordsTTL(userId, chatId, ttl);
+  }
+
   const items: RecordedMessage[] = messages.map(
     (m: ToBeRecordedMessage, i: number) => {
       return {
@@ -425,11 +459,6 @@ export const batchCreateMessages = async (
 
   // Update token usage in parallel
   await Promise.all(items.map(updateTokenUsage));
-
-  // Update parent chat TTL if TTL is set for messages
-  if (ttl) {
-    await updateChatTTL(userId, chatId, ttl);
-  }
 
   return items;
 };

--- a/packages/cdk/lambda/repository.ts
+++ b/packages/cdk/lambda/repository.ts
@@ -24,12 +24,26 @@ import {
 
 const TABLE_NAME: string = process.env.TABLE_NAME!;
 const STATS_TABLE_NAME: string = process.env.STATS_TABLE_NAME!;
+const DATA_RETENTION_DAYS: string | undefined = process.env.DATA_RETENTION_DAYS;
 const dynamoDb = new DynamoDBClient({});
 const dynamoDbDocument = DynamoDBDocumentClient.from(dynamoDb);
+
+const calculateTTL = (): number | undefined => {
+  if (!DATA_RETENTION_DAYS) {
+    return undefined;
+  }
+  const retentionDays = parseInt(DATA_RETENTION_DAYS, 10);
+  if (isNaN(retentionDays)) {
+    return undefined;
+  }
+  // Calculate TTL in Unix epoch time (seconds)
+  return Math.floor(Date.now() / 1000) + retentionDays * 24 * 60 * 60;
+};
 
 export const createChat = async (_userId: string): Promise<Chat> => {
   const userId = `user#${_userId}`;
   const chatId = `chat#${crypto.randomUUID()}`;
+  const ttl = calculateTTL();
   const item = {
     id: userId,
     createdDate: `${Date.now()}`,
@@ -37,6 +51,7 @@ export const createChat = async (_userId: string): Promise<Chat> => {
     usecase: '',
     title: '',
     updatedDate: '',
+    ...(ttl && { ttl }),
   };
 
   await dynamoDbDocument.send(
@@ -166,12 +181,14 @@ export const createSystemContext = async (
 ): Promise<SystemContext> => {
   const userId = `systemContext#${_userId}`;
   const systemContextId = `systemContext#${crypto.randomUUID()}`;
+  const ttl = calculateTTL();
   const item = {
     id: userId,
     createdDate: `${Date.now()}`,
     systemContextId: systemContextId,
     systemContext: systemContext,
     systemContextTitle: title,
+    ...(ttl && { ttl }),
   };
 
   await dynamoDbDocument.send(
@@ -340,6 +357,7 @@ export const batchCreateMessages = async (
   const createdDate = Date.now();
   const feedback = 'none';
 
+  const ttl = calculateTTL();
   const items: RecordedMessage[] = messages.map(
     (m: ToBeRecordedMessage, i: number) => {
       return {
@@ -355,6 +373,7 @@ export const batchCreateMessages = async (
         usecase: m.usecase,
         llmType: m.llmType ?? '',
         metadata: m.metadata,
+        ...(ttl && { ttl }),
       };
     }
   );

--- a/packages/cdk/lambda/repository.ts
+++ b/packages/cdk/lambda/repository.ts
@@ -347,6 +347,36 @@ async function updateTokenUsage(message: RecordedMessage): Promise<void> {
   }
 }
 
+// Update TTL for parent chat record
+const updateChatTTL = async (
+  userId: string,
+  chatId: string,
+  ttl: number
+): Promise<void> => {
+  const chat = await findChatById(
+    userId.replace('user#', ''),
+    chatId.replace('chat#', '')
+  );
+  if (chat) {
+    await dynamoDbDocument.send(
+      new UpdateCommand({
+        TableName: TABLE_NAME,
+        Key: {
+          id: chat.id,
+          createdDate: chat.createdDate,
+        },
+        UpdateExpression: 'set #ttl = :ttl',
+        ExpressionAttributeNames: {
+          '#ttl': 'ttl',
+        },
+        ExpressionAttributeValues: {
+          ':ttl': ttl,
+        },
+      })
+    );
+  }
+};
+
 export const batchCreateMessages = async (
   messages: ToBeRecordedMessage[],
   _userId: string,
@@ -395,6 +425,11 @@ export const batchCreateMessages = async (
 
   // Update token usage in parallel
   await Promise.all(items.map(updateTokenUsage));
+
+  // Update parent chat TTL if TTL is set for messages
+  if (ttl) {
+    await updateChatTTL(userId, chatId, ttl);
+  }
 
   return items;
 };

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -19,6 +19,7 @@ import {
   Bucket,
   BucketEncryption,
   HttpMethods,
+  LifecycleRule,
 } from 'aws-cdk-lib/aws-s3';
 import { Agent, AgentMap, ModelConfiguration } from 'generative-ai-use-cases';
 import {
@@ -44,6 +45,7 @@ export interface BackendApiProps {
   readonly crossAccountBedrockRoleArn?: string | null;
   readonly allowedIpV4AddressRanges?: string[] | null;
   readonly allowedIpV6AddressRanges?: string[] | null;
+  readonly dataRetentionDays?: number;
 
   // Resource
   readonly userPool: UserPool;
@@ -137,12 +139,30 @@ export class Api extends Construct {
     }
 
     // S3 (File Bucket)
+    // Helper function to create lifecycle rules if retention is specified
+    const createLifecycleRules = (
+      dataRetentionDays?: number
+    ): LifecycleRule[] | undefined => {
+      if (dataRetentionDays === undefined) {
+        return undefined;
+      }
+      // Note: Positive validation is handled by zod schema
+      return [
+        {
+          id: 'DeleteObjectsAfterRetention',
+          enabled: true,
+          expiration: Duration.days(dataRetentionDays),
+        },
+      ];
+    };
+
     const fileBucket = new Bucket(this, 'FileBucket', {
       encryption: BucketEncryption.S3_MANAGED,
       removalPolicy: RemovalPolicy.DESTROY,
       autoDeleteObjects: true,
       enforceSSL: true,
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      lifecycleRules: createLifecycleRules(props.dataRetentionDays),
     });
     fileBucket.addCorsRule({
       allowedOrigins: ['*'],
@@ -249,6 +269,9 @@ export class Api extends Construct {
         ...(props.guardrailVersion
           ? { GUARDRAIL_VERSION: props.guardrailVersion }
           : {}),
+        ...(props.dataRetentionDays && {
+          DATA_RETENTION_DAYS: props.dataRetentionDays.toString(),
+        }),
       },
     });
     table.grantWriteData(predictTitleFunction);
@@ -283,6 +306,9 @@ export class Api extends Construct {
         CROSS_ACCOUNT_BEDROCK_ROLE_ARN: crossAccountBedrockRoleArn ?? '',
         BUCKET_NAME: fileBucket.bucketName,
         TABLE_NAME: table.tableName,
+        ...(props.dataRetentionDays && {
+          DATA_RETENTION_DAYS: props.dataRetentionDays.toString(),
+        }),
       },
       bundling: {
         nodeModules: ['@aws-sdk/client-bedrock-runtime'],
@@ -317,6 +343,9 @@ export class Api extends Construct {
         CROSS_ACCOUNT_BEDROCK_ROLE_ARN: crossAccountBedrockRoleArn ?? '',
         BUCKET_NAME: fileBucket.bucketName,
         TABLE_NAME: table.tableName,
+        ...(props.dataRetentionDays && {
+          DATA_RETENTION_DAYS: props.dataRetentionDays.toString(),
+        }),
       },
       bundling: {
         nodeModules: ['@aws-sdk/client-bedrock-runtime'],
@@ -352,6 +381,9 @@ export class Api extends Construct {
         BUCKET_NAME: fileBucket.bucketName,
         TABLE_NAME: table.tableName,
         COPY_VIDEO_JOB_FUNCTION_ARN: copyVideoJob.functionArn,
+        ...(props.dataRetentionDays && {
+          DATA_RETENTION_DAYS: props.dataRetentionDays.toString(),
+        }),
       },
       bundling: {
         nodeModules: ['@aws-sdk/client-bedrock-runtime'],
@@ -513,6 +545,9 @@ export class Api extends Construct {
       timeout: Duration.minutes(15),
       environment: {
         TABLE_NAME: table.tableName,
+        ...(props.dataRetentionDays && {
+          DATA_RETENTION_DAYS: props.dataRetentionDays.toString(),
+        }),
       },
     });
     table.grantWriteData(createChatFunction);
@@ -523,6 +558,9 @@ export class Api extends Construct {
       timeout: Duration.minutes(15),
       environment: {
         TABLE_NAME: table.tableName,
+        ...(props.dataRetentionDays && {
+          DATA_RETENTION_DAYS: props.dataRetentionDays.toString(),
+        }),
       },
     });
     table.grantReadWriteData(deleteChatFunction);
@@ -535,6 +573,9 @@ export class Api extends Construct {
         TABLE_NAME: table.tableName,
         STATS_TABLE_NAME: props.statsTable.tableName,
         BUCKET_NAME: fileBucket.bucketName,
+        ...(props.dataRetentionDays && {
+          DATA_RETENTION_DAYS: props.dataRetentionDays.toString(),
+        }),
       },
     });
     table.grantReadWriteData(createMessagesFunction);
@@ -560,6 +601,9 @@ export class Api extends Construct {
       timeout: Duration.minutes(15),
       environment: {
         TABLE_NAME: table.tableName,
+        ...(props.dataRetentionDays && {
+          DATA_RETENTION_DAYS: props.dataRetentionDays.toString(),
+        }),
       },
     });
     table.grantReadData(listChatsFunction);
@@ -570,6 +614,9 @@ export class Api extends Construct {
       timeout: Duration.minutes(15),
       environment: {
         TABLE_NAME: table.tableName,
+        ...(props.dataRetentionDays && {
+          DATA_RETENTION_DAYS: props.dataRetentionDays.toString(),
+        }),
       },
     });
     table.grantReadData(findChatbyIdFunction);
@@ -580,6 +627,9 @@ export class Api extends Construct {
       timeout: Duration.minutes(15),
       environment: {
         TABLE_NAME: table.tableName,
+        ...(props.dataRetentionDays && {
+          DATA_RETENTION_DAYS: props.dataRetentionDays.toString(),
+        }),
       },
     });
     table.grantReadData(listMessagesFunction);
@@ -590,6 +640,9 @@ export class Api extends Construct {
       timeout: Duration.minutes(15),
       environment: {
         TABLE_NAME: table.tableName,
+        ...(props.dataRetentionDays && {
+          DATA_RETENTION_DAYS: props.dataRetentionDays.toString(),
+        }),
       },
     });
     table.grantReadWriteData(updateFeedbackFunction);
@@ -606,6 +659,9 @@ export class Api extends Construct {
       timeout: Duration.minutes(15),
       environment: {
         TABLE_NAME: table.tableName,
+        ...(props.dataRetentionDays && {
+          DATA_RETENTION_DAYS: props.dataRetentionDays.toString(),
+        }),
       },
     });
     table.grantReadWriteData(createShareId);
@@ -616,6 +672,9 @@ export class Api extends Construct {
       timeout: Duration.minutes(15),
       environment: {
         TABLE_NAME: table.tableName,
+        ...(props.dataRetentionDays && {
+          DATA_RETENTION_DAYS: props.dataRetentionDays.toString(),
+        }),
       },
     });
     table.grantReadData(getSharedChat);
@@ -626,6 +685,9 @@ export class Api extends Construct {
       timeout: Duration.minutes(15),
       environment: {
         TABLE_NAME: table.tableName,
+        ...(props.dataRetentionDays && {
+          DATA_RETENTION_DAYS: props.dataRetentionDays.toString(),
+        }),
       },
     });
     table.grantReadData(findShareId);
@@ -636,6 +698,9 @@ export class Api extends Construct {
       timeout: Duration.minutes(15),
       environment: {
         TABLE_NAME: table.tableName,
+        ...(props.dataRetentionDays && {
+          DATA_RETENTION_DAYS: props.dataRetentionDays.toString(),
+        }),
       },
     });
     table.grantReadWriteData(deleteShareId);
@@ -713,6 +778,9 @@ export class Api extends Construct {
       environment: {
         TABLE_NAME: table.tableName,
         STATS_TABLE_NAME: props.statsTable.tableName,
+        ...(props.dataRetentionDays && {
+          DATA_RETENTION_DAYS: props.dataRetentionDays.toString(),
+        }),
       },
     });
     table.grantReadData(getTokenUsageFunction);

--- a/packages/cdk/lib/construct/database.ts
+++ b/packages/cdk/lib/construct/database.ts
@@ -6,11 +6,11 @@ export class Database extends Construct {
   public readonly statsTable: ddb.Table;
   public readonly feedbackIndexName: string;
 
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, dataRetentionDays?: number) {
     super(scope, id);
 
     const feedbackIndexName = 'FeedbackIndex';
-    const table = new ddb.Table(this, 'Table', {
+    const tableProps: ddb.TableProps = {
       partitionKey: {
         name: 'id',
         type: ddb.AttributeType.STRING,
@@ -20,7 +20,12 @@ export class Database extends Construct {
         type: ddb.AttributeType.STRING,
       },
       billingMode: ddb.BillingMode.PAY_PER_REQUEST,
-    });
+      // Add TTL configuration if dataRetentionDays is specified
+      // Note: Positive validation is handled by zod schema
+      ...(dataRetentionDays !== undefined && { timeToLiveAttribute: 'ttl' }),
+    };
+
+    const table = new ddb.Table(this, 'Table', tableProps);
 
     table.addGlobalSecondaryIndex({
       indexName: feedbackIndexName,
@@ -31,7 +36,8 @@ export class Database extends Construct {
     });
 
     // Stats table for token usage statistics
-    const statsTable = new ddb.Table(this, 'StatsTable', {
+    // Note: Statistics data is preserved for long-term analysis and is not subject to TTL
+    const statsTableProps: ddb.TableProps = {
       partitionKey: {
         name: 'id',
         type: ddb.AttributeType.STRING,
@@ -41,7 +47,9 @@ export class Database extends Construct {
         type: ddb.AttributeType.STRING,
       },
       billingMode: ddb.BillingMode.PAY_PER_REQUEST,
-    });
+    };
+
+    const statsTable = new ddb.Table(this, 'StatsTable', statsTableProps);
 
     this.table = table;
     this.statsTable = statsTable;

--- a/packages/cdk/lib/construct/transcribe.ts
+++ b/packages/cdk/lib/construct/transcribe.ts
@@ -14,6 +14,7 @@ import {
   Bucket,
   BucketEncryption,
   HttpMethods,
+  LifecycleRule,
 } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 import { allowS3AccessWithSourceIpCondition } from '../utils/s3-access-policy';
@@ -25,11 +26,28 @@ export interface TranscribeProps {
   readonly api: RestApi;
   readonly allowedIpV4AddressRanges?: string[] | null;
   readonly allowedIpV6AddressRanges?: string[] | null;
+  readonly dataRetentionDays?: number;
 }
 
 export class Transcribe extends Construct {
   constructor(scope: Construct, id: string, props: TranscribeProps) {
     super(scope, id);
+
+    // Helper function to create lifecycle rules if retention is specified
+    const createLifecycleRules = (
+      dataRetentionDays?: number
+    ): LifecycleRule[] | undefined => {
+      if (dataRetentionDays === undefined) {
+        return undefined;
+      }
+      return [
+        {
+          id: 'DeleteObjectsAfterRetention',
+          enabled: true,
+          expiration: Duration.days(dataRetentionDays),
+        },
+      ];
+    };
 
     const audioBucket = new Bucket(this, 'AudioBucket', {
       encryption: BucketEncryption.S3_MANAGED,
@@ -37,6 +55,7 @@ export class Transcribe extends Construct {
       autoDeleteObjects: true,
       enforceSSL: true,
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      lifecycleRules: createLifecycleRules(props.dataRetentionDays),
     });
     audioBucket.addCorsRule({
       allowedOrigins: ['*'],
@@ -52,6 +71,7 @@ export class Transcribe extends Construct {
       autoDeleteObjects: true,
       enforceSSL: true,
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      lifecycleRules: createLifecycleRules(props.dataRetentionDays),
     });
 
     const getSignedUrlFunction = new NodejsFunction(this, 'GetSignedUrl', {

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -64,7 +64,7 @@ export class GenerativeAiUseCasesStack extends Stack {
     });
 
     // Database
-    const database = new Database(this, 'Database');
+    const database = new Database(this, 'Database', params.dataRetentionDays);
 
     // API
     const api = new Api(this, 'API', {
@@ -80,6 +80,7 @@ export class GenerativeAiUseCasesStack extends Stack {
       crossAccountBedrockRoleArn: params.crossAccountBedrockRoleArn,
       allowedIpV4AddressRanges: params.allowedIpV4AddressRanges,
       allowedIpV6AddressRanges: params.allowedIpV6AddressRanges,
+      dataRetentionDays: params.dataRetentionDays,
       userPool: auth.userPool,
       idPool: auth.idPool,
       userPoolClient: auth.client,
@@ -254,6 +255,7 @@ export class GenerativeAiUseCasesStack extends Stack {
       api: api.api,
       allowedIpV4AddressRanges: params.allowedIpV4AddressRanges,
       allowedIpV6AddressRanges: params.allowedIpV6AddressRanges,
+      dataRetentionDays: params.dataRetentionDays,
     });
 
     // Cfn Outputs

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -163,6 +163,8 @@ const baseStackInputSchema = z.object({
   hostedZoneId: z.string().nullish(),
   // Dashboard
   dashboard: z.boolean().default(false),
+  // TTL settings (in days, must be positive)
+  dataRetentionDays: z.number().positive().optional(),
 });
 
 // Common Validator with refine

--- a/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
+++ b/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
@@ -9602,6 +9602,7 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
               "Ref": "APIFileBucket8FB29855",
             },
             "CROSS_ACCOUNT_BEDROCK_ROLE_ARN": "",
+            "DATA_RETENTION_DAYS": "30",
             "IMAGE_GENERATION_MODEL_IDS": "[{"modelId":"stability.stable-diffusion-xl-v1","region":"us-east-1"}]",
             "MODEL_IDS": "[{"modelId":"anthropic.claude-3-sonnet-20240229-v1:0","region":"us-east-1"}]",
             "MODEL_REGION": "us-east-1",
@@ -9800,6 +9801,7 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
         },
         "Environment": {
           "Variables": {
+            "DATA_RETENTION_DAYS": "30",
             "TABLE_NAME": {
               "Ref": "DatabaseTableF104A135",
             },
@@ -9917,6 +9919,7 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
             "BUCKET_NAME": {
               "Ref": "APIFileBucket8FB29855",
             },
+            "DATA_RETENTION_DAYS": "30",
             "STATS_TABLE_NAME": {
               "Ref": "DatabaseStatsTable9C709761",
             },
@@ -10069,6 +10072,7 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
         },
         "Environment": {
           "Variables": {
+            "DATA_RETENTION_DAYS": "30",
             "TABLE_NAME": {
               "Ref": "DatabaseTableF104A135",
             },
@@ -10304,6 +10308,7 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
         },
         "Environment": {
           "Variables": {
+            "DATA_RETENTION_DAYS": "30",
             "TABLE_NAME": {
               "Ref": "DatabaseTableF104A135",
             },
@@ -10525,6 +10530,7 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
         },
         "Environment": {
           "Variables": {
+            "DATA_RETENTION_DAYS": "30",
             "TABLE_NAME": {
               "Ref": "DatabaseTableF104A135",
             },
@@ -10902,6 +10908,15 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
             },
           ],
         },
+        "LifecycleConfiguration": {
+          "Rules": [
+            {
+              "ExpirationInDays": 30,
+              "Id": "DeleteObjectsAfterRetention",
+              "Status": "Enabled",
+            },
+          ],
+        },
         "PublicAccessBlockConfiguration": {
           "BlockPublicAcls": true,
           "BlockPublicPolicy": true,
@@ -11038,6 +11053,7 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
         },
         "Environment": {
           "Variables": {
+            "DATA_RETENTION_DAYS": "30",
             "TABLE_NAME": {
               "Ref": "DatabaseTableF104A135",
             },
@@ -11155,6 +11171,7 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
         },
         "Environment": {
           "Variables": {
+            "DATA_RETENTION_DAYS": "30",
             "TABLE_NAME": {
               "Ref": "DatabaseTableF104A135",
             },
@@ -11368,6 +11385,7 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
               "Ref": "APIFileBucket8FB29855",
             },
             "CROSS_ACCOUNT_BEDROCK_ROLE_ARN": "",
+            "DATA_RETENTION_DAYS": "30",
             "IMAGE_GENERATION_MODEL_IDS": "[{"modelId":"stability.stable-diffusion-xl-v1","region":"us-east-1"}]",
             "MODEL_IDS": "[{"modelId":"anthropic.claude-3-sonnet-20240229-v1:0","region":"us-east-1"}]",
             "MODEL_REGION": "us-east-1",
@@ -11715,6 +11733,7 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
         },
         "Environment": {
           "Variables": {
+            "DATA_RETENTION_DAYS": "30",
             "TABLE_NAME": {
               "Ref": "DatabaseTableF104A135",
             },
@@ -11947,6 +11966,7 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
         },
         "Environment": {
           "Variables": {
+            "DATA_RETENTION_DAYS": "30",
             "STATS_TABLE_NAME": {
               "Ref": "DatabaseStatsTable9C709761",
             },
@@ -12234,6 +12254,7 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
         },
         "Environment": {
           "Variables": {
+            "DATA_RETENTION_DAYS": "30",
             "TABLE_NAME": {
               "Ref": "DatabaseTableF104A135",
             },
@@ -12351,6 +12372,7 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
         },
         "Environment": {
           "Variables": {
+            "DATA_RETENTION_DAYS": "30",
             "TABLE_NAME": {
               "Ref": "DatabaseTableF104A135",
             },
@@ -12595,6 +12617,7 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
               ],
             },
             "CROSS_ACCOUNT_BEDROCK_ROLE_ARN": "",
+            "DATA_RETENTION_DAYS": "30",
             "IMAGE_GENERATION_MODEL_IDS": "[{"modelId":"stability.stable-diffusion-xl-v1","region":"us-east-1"}]",
             "MODEL_IDS": "[{"modelId":"anthropic.claude-3-sonnet-20240229-v1:0","region":"us-east-1"}]",
             "MODEL_REGION": "us-east-1",
@@ -13123,6 +13146,7 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
         "Environment": {
           "Variables": {
             "CROSS_ACCOUNT_BEDROCK_ROLE_ARN": "",
+            "DATA_RETENTION_DAYS": "30",
             "GUARDRAIL_IDENTIFIER": {
               "Fn::ImportValue": "GuardrailStack:ExportsOutputFnGetAttGuardrailguardrail03A76CF4GuardrailIdDBA991AF",
             },
@@ -13374,6 +13398,7 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
         },
         "Environment": {
           "Variables": {
+            "DATA_RETENTION_DAYS": "30",
             "TABLE_NAME": {
               "Ref": "DatabaseTableF104A135",
             },
@@ -15704,6 +15729,10 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
             "KeyType": "RANGE",
           },
         ],
+        "TimeToLiveSpecification": {
+          "AttributeName": "ttl",
+          "Enabled": true,
+        },
       },
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Delete",
@@ -15750,6 +15779,10 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
             "KeyType": "RANGE",
           },
         ],
+        "TimeToLiveSpecification": {
+          "AttributeName": "ttl",
+          "Enabled": true,
+        },
       },
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Delete",
@@ -17126,6 +17159,15 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
             },
           ],
         },
+        "LifecycleConfiguration": {
+          "Rules": [
+            {
+              "ExpirationInDays": 30,
+              "Id": "DeleteObjectsAfterRetention",
+              "Status": "Enabled",
+            },
+          ],
+        },
         "PublicAccessBlockConfiguration": {
           "BlockPublicAcls": true,
           "BlockPublicPolicy": true,
@@ -17697,6 +17739,15 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
               "ServerSideEncryptionByDefault": {
                 "SSEAlgorithm": "AES256",
               },
+            },
+          ],
+        },
+        "LifecycleConfiguration": {
+          "Rules": [
+            {
+              "ExpirationInDays": 30,
+              "Id": "DeleteObjectsAfterRetention",
+              "Status": "Enabled",
             },
           ],
         },

--- a/packages/cdk/test/generative-ai-use-cases.test.ts
+++ b/packages/cdk/test/generative-ai-use-cases.test.ts
@@ -62,6 +62,7 @@ describe('GenerativeAiUseCases', () => {
       guardrailEnabled: true,
       crossAccountBedrockRoleArn: '',
       useCaseBuilderEnabled: true,
+      dataRetentionDays: 30,
     });
 
     const {


### PR DESCRIPTION
## Description of Changes

コスト削減を目的として、ユーザーがユースケースを使用するとS3にアップロードされるファイル（Chat機能でアップロードした画像や文書等のファイル、Transcribeや映像分析）を自動で削除するためにライフサイクルルールを設定できるように変更しました。
cdk.jsonやparameter.tsに何も設定しない場合は今まで通りの動作です。
ただし、S3のオブジェクトは直ちにライフサイクルルールが適用され、例えばライフサイクルルールを7日に設定した時点で1年前にアップロードしたファイルがある場合、そのファイルは削除対象になりますが、
DynamoDBについては既にあるレコードが自動的に更新されることはありません。
古い会話を再開した場合、会話に紐づく（同じChatIDの）レコードのTTLは新しく更新されます。

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

#1213 