### PR TITLE
[WIP] Safe parse json chunk and buffering the chunk if it's failed.

### DIFF
--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -587,6 +587,7 @@ const useChatState = create<{
     });
 
     // Update the assistant's message
+    let tmpBuffer = '';
     let tmpChunk = '';
 
     for await (const chunk of stream) {
@@ -603,8 +604,20 @@ const useChatState = create<{
       const chunks = chunk.split('\n');
 
       for (const c of chunks) {
+        console.log(c); // TODO: delete
+
         if (c && c.length > 0) {
-          const payload = JSON.parse(c) as StreamingChunk;
+          let payload: StreamingChunk;
+
+          try {
+            payload = JSON.parse(tmpBuffer + c) as StreamingChunk;
+            tmpBuffer = '';
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } catch (e: any) {
+            console.warn(e);
+            tmpBuffer += c;
+            continue;
+          }
 
           if (payload.text.length > 0) {
             tmpChunk += payload.text;

--- a/packages/web/src/hooks/useChatApi.ts
+++ b/packages/web/src/hooks/useChatApi.ts
@@ -114,6 +114,11 @@ const useChatApi = () => {
       const providerName = `cognito-idp.${region}.amazonaws.com/${userPoolId}`;
       const lambda = new LambdaClient({
         region,
+        requestHandler: {
+          requestTimeout: 300000,
+          socketTimeout: 300000,
+          connectionTimeout: 10000,
+        },
         credentials: fromCognitoIdentityPool({
           client: cognito,
           identityPoolId: idPoolId,


### PR DESCRIPTION
## Description of Changes

The long chunks are sometimes sent as separated chunks. JSON.parse would be failed in such cases.
Implemented safe parse method in predictStream() and buffering the previous chunk.

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

N/A
