### PR TITLE
[v5] Split agent response

### DIFF
--- a/packages/cdk/lambda/utils/bedrockAgentApi.ts
+++ b/packages/cdk/lambda/utils/bedrockAgentApi.ts
@@ -210,7 +210,12 @@ const bedrockAgentApi: ApiInterface = {
           }
 
           if (body) {
-            yield streamingChunk({ text: body });
+            // Since the Agent's output can be very large, we will send it in chunks.
+            // If sent all at once, the frontend may not be able to receive everything completely, which could result in JSON.parse errors.
+            const chunkSize = 100;
+            for (let i = 0; i < body.length; i += chunkSize) {
+              yield streamingChunk({ text: body.substring(i, i + chunkSize) });
+            }
           }
         }
 

--- a/packages/web/src/hooks/useChatApi.ts
+++ b/packages/web/src/hooks/useChatApi.ts
@@ -114,6 +114,11 @@ const useChatApi = () => {
       const providerName = `cognito-idp.${region}.amazonaws.com/${userPoolId}`;
       const lambda = new LambdaClient({
         region,
+        requestHandler: {
+          requestTimeout: 300000,
+          socketTimeout: 300000,
+          connectionTimeout: 10000,
+        },
         credentials: fromCognitoIdentityPool({
           client: cognito,
           identityPoolId: idPoolId,


### PR DESCRIPTION
## Description of Changes

The Agent's response is returned all at once. Therefore, it sometimes gets sent partially, which caused JSON.parse failures. To address this, we modified it to yield in chunks of 100 characters each.

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

N/A
