### PR TITLE
[v5] Fix agent mojibake

### DIFF
--- a/packages/cdk/lambda/utils/bedrockAgentApi.ts
+++ b/packages/cdk/lambda/utils/bedrockAgentApi.ts
@@ -210,12 +210,7 @@ const bedrockAgentApi: ApiInterface = {
           }
 
           if (body) {
-            // Since the Agent's output can be very large, we will send it in chunks.
-            // If sent all at once, the frontend may not be able to receive everything completely, which could result in JSON.parse errors.
-            const chunkSize = 100;
-            for (let i = 0; i < body.length; i += chunkSize) {
-              yield streamingChunk({ text: body.substring(i, i + chunkSize) });
-            }
+            yield streamingChunk({ text: body });
           }
         }
 

--- a/packages/cdk/lambda/utils/bedrockAgentApi.ts
+++ b/packages/cdk/lambda/utils/bedrockAgentApi.ts
@@ -210,7 +210,12 @@ const bedrockAgentApi: ApiInterface = {
           }
 
           if (body) {
-            yield streamingChunk({ text: body });
+            // Since the Agent's output can be very large, we will send it in chunks.
+            // If sent all at once, the frontend may not be able to receive everything completely, which could result in JSON.parse errors.
+            const chunkSize = 100;
+            for (let i = 0; i < body.length; i += chunkSize) {
+              yield streamingChunk({ text: body.substring(i, i + chunkSize) });
+            }
           }
         }
 

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -642,7 +642,6 @@ const useChatState = create<{
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
           } catch (e: any) {
             console.warn(e);
-            console.warn(c);
             tmpBuffer = new Uint8Array([...tmpBuffer, ...c]);
             continue;
           }

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -589,7 +589,7 @@ const useChatState = create<{
       false
     );
 
-    function splitByNewlineBinary(data: Uint8Array): Uint8Array[] {
+    const splitByNewlineBinary = (data: Uint8Array): Uint8Array[] => {
       const newline = 0x0a; // '\n'
       const result: Uint8Array[] = [];
 
@@ -603,7 +603,7 @@ const useChatState = create<{
       }
 
       return result;
-    }
+    };
 
     // Update the assistant's message
     let tmpChunk = '';

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -580,14 +580,34 @@ const useChatState = create<{
       base64Cache
     );
 
-    const stream = predictStream({
-      model: model,
-      messages: formattedMessages,
-      id: id,
-    });
+    const stream = predictStream(
+      {
+        model: model,
+        messages: formattedMessages,
+        id: id,
+      },
+      false
+    );
+
+    function splitByNewlineBinary(data: Uint8Array): Uint8Array[] {
+      const newline = 0x0a; // '\n'
+      const result: Uint8Array[] = [];
+
+      let start = 0;
+
+      for (let i = 0; i <= data.length; i++) {
+        if (i === data.length || data[i] === newline) {
+          result.push(data.slice(start, i));
+          start = i + 1;
+        }
+      }
+
+      return result;
+    }
 
     // Update the assistant's message
     let tmpChunk = '';
+    let tmpBuffer: Uint8Array = new Uint8Array([]);
 
     for await (const chunk of stream) {
       if (get().chats[id].forcedStop) {
@@ -600,11 +620,32 @@ const useChatState = create<{
         setWriting(id, true);
       }
 
-      const chunks = chunk.split('\n');
+      const chunks = splitByNewlineBinary(chunk as Uint8Array);
 
       for (const c of chunks) {
         if (c && c.length > 0) {
-          const payload = JSON.parse(c) as StreamingChunk;
+          let payload: StreamingChunk;
+
+          try {
+            if (tmpBuffer.length === 0) {
+              payload = JSON.parse(
+                new TextDecoder('utf-8').decode(c)
+              ) as StreamingChunk;
+            } else {
+              payload = JSON.parse(
+                new TextDecoder('utf-8').decode(
+                  new Uint8Array([...tmpBuffer, ...c])
+                )
+              ) as StreamingChunk;
+              tmpBuffer = new Uint8Array([]);
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } catch (e: any) {
+            console.warn(e);
+            console.warn(c);
+            tmpBuffer = new Uint8Array([...tmpBuffer, ...c]);
+            continue;
+          }
 
           if (payload.text.length > 0) {
             tmpChunk += payload.text;

--- a/packages/web/src/hooks/useChatApi.ts
+++ b/packages/web/src/hooks/useChatApi.ts
@@ -114,6 +114,11 @@ const useChatApi = () => {
       const providerName = `cognito-idp.${region}.amazonaws.com/${userPoolId}`;
       const lambda = new LambdaClient({
         region,
+        requestHandler: {
+          requestTimeout: 300000,
+          socketTimeout: 300000,
+          connectionTimeout: 10000,
+        },
         credentials: fromCognitoIdentityPool({
           client: cognito,
           identityPoolId: idPoolId,

--- a/packages/web/src/hooks/useChatApi.ts
+++ b/packages/web/src/hooks/useChatApi.ts
@@ -94,7 +94,10 @@ const useChatApi = () => {
       return res.data;
     },
     // Streaming Response
-    predictStream: async function* (req: PredictRequest) {
+    predictStream: async function* (
+      req: PredictRequest,
+      decode: boolean = true
+    ) {
       const token = (await fetchAuthSession()).tokens?.idToken?.toString();
       if (!token) {
         throw new Error('Not authenticated');
@@ -141,7 +144,11 @@ const useChatApi = () => {
 
       for await (const event of events) {
         if (event.PayloadChunk) {
-          yield new TextDecoder('utf-8').decode(event.PayloadChunk.Payload);
+          if (decode) {
+            yield new TextDecoder('utf-8').decode(event.PayloadChunk.Payload);
+          } else {
+            yield event.PayloadChunk.Payload;
+          }
         }
 
         if (event.InvokeComplete) {

--- a/packages/web/src/hooks/useMeetingMinutes.ts
+++ b/packages/web/src/hooks/useMeetingMinutes.ts
@@ -77,7 +77,7 @@ export const useMeetingMinutes = (
 
         for await (const chunk of stream) {
           if (chunk) {
-            const chunks = chunk.split('\n');
+            const chunks = (chunk as string).split('\n');
 
             for (const c of chunks) {
               if (c && c.length > 0) {

--- a/packages/web/src/hooks/useWriter.ts
+++ b/packages/web/src/hooks/useWriter.ts
@@ -38,7 +38,7 @@ export const useWriter = () => {
     let tmpChunk = '';
     let tmpTrace = '';
     for await (const chunk of stream) {
-      const chunks = chunk.split('\n');
+      const chunks = (chunk as string).split('\n');
 
       for (const c of chunks) {
         if (c && c.length > 0) {


### PR DESCRIPTION
## Description of Changes

There is a bug where agent responses can be very large, and sometimes only part of the JSON is yielded, causing JSON.parse to fail. To address this, I implemented a process that temporarily saves the data (tmpBuffer) when JSON.parse fails, then combines it with the next chunk and attempts to parse again. Note that when characters become garbled after decoding with TextDecoder, they are converted to different "garbled characters," and even if you encode them again with TextEncoder, you end up with a different Uint8Array. Therefore, I added an option to predictStream to yield raw Uint8Array data. By default, it yields characters after decoding with TextDecoder, so this won't affect other existing implementations that use predictStream.

エージェントのレスポンスは非常に大きいことがあり、時々 JSON の一部のみが yield され、JSON.parse に失敗するというバグがあります。そこで、JSON.parse 失敗したら、それを一時的に保存 (tmpBuffer) し、次の chunk 時に結合して parse するという処理を組み込みました。なお、TextDecoder でデコードした後に文字化けすると、別の「文字化けした文字」に変換されてしまい、その後 TextEncoder でエンコードしても別の Uint8Array になってしまいます。そこで predictStream に生の Uint8Array を yield するオプションを設けました。デフォルトでは TextDecoder でデコードした後の文字を yield するようにしているため、predictStream を使っている既存の他の実装には影響はありません。

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

N/A