### PR TITLE
Fix/agentcore docker build

### DIFF
--- a/docs/en/DEPLOY_OPTION.md
+++ b/docs/en/DEPLOY_OPTION.md
@@ -696,6 +696,25 @@ However, MCP servers that start with methods other than `uvx` require developmen
 
 With `agentCoreExternalRuntimes`, you can use externally created AgentCore Runtimes.
 
+To enable AgentCore use cases, the `docker` command must be executable.
+
+> [!WARNING]
+> On Linux machines using x86_64 CPUs (Intel, AMD, etc.), run the following command before cdk deployment:
+>
+> ```
+> docker run --privileged --rm tonistiigi/binfmt --install arm64
+> ```
+>
+> If you do not run the above command, the following error will occur:  
+> During the deployment process, ARM-based container images used by AgentCore Runtime are built. When building ARM container images on x86_64 CPUs, errors occur due to CPU architecture differences.
+>
+> ```
+> ERROR: failed to solve: process "/bin/sh -c apt-get update -y && apt-get install curl nodejs npm graphviz -y" did not complete successfully: exit code: 255
+> AgentCoreStack: fail: docker build --tag cdkasset-64ba68f71e3d29f5b84d8e8d062e841cb600c436bb68a540d6fce32fded36c08 --platform linux/arm64 . exited with error code 1: #0 building with "default" instance using docker driver
+> ```
+>
+> Running this command makes temporary configuration changes to the host Linux Kernel. It registers QEMU emulator custom handlers in Binary Format Miscellaneous (binfmt_misc), enabling ARM container image builds. The configuration returns to its original state after reboot, so the command must be re-executed before re-deployments.
+
 **Edit [parameter.ts](/packages/cdk/parameter.ts)**
 
 ```typescript

--- a/docs/ja/DEPLOY_OPTION.md
+++ b/docs/ja/DEPLOY_OPTION.md
@@ -711,6 +711,25 @@ MCP サーバーを追加する場合は上述の `mcp.json` に追記してく�
 
 `agentCoreExternalRuntimes` で外部で作成した AgentCore Runtime を利用することが可能です。
 
+AgentCore ユースケースを有効化するためには、`docker` コマンドが実行可能である必要があります。
+
+> [!WARNING]
+> x86_64 系のCPU (Intel AMD など) を利用した Linux マシンでは、以下のコマンドを実行してからデプロイを行ってください。
+>
+> ```
+> docker run --privileged --rm tonistiigi/binfmt --install arm64
+> ```
+>
+> 上記コマンドを実行しない場合、以下のエラーが発生します。  
+> デプロイプロセスで、AgentCore Runtime で利用する ARM ベースのコンテナイメージをビルドします。この際に、x86_64 系の CPU で ARM コンテナイメージをビルドすると、CPU のアーキテクチャの違いによりエラーが発生します。
+>
+> ```
+> ERROR: failed to solve: process "/bin/sh -c apt-get update -y && apt-get install curl nodejs npm graphviz -y" did not complete successfully: exit code: 255
+> AgentCoreStack: fail: docker build --tag cdkasset-64ba68f71e3d29f5b84d8e8d062e841cb600c436bb68a540d6fce32fded36c08 --platform linux/arm64 . exited with error code 1: #0 building with "default" instance using docker driver
+> ```
+>
+> このコマンドを実行することで、ホスト側の Linux Kernel に一時的な設定変更を行います。Binary Format Miscellaneous (binfmt_misc) に QEMU のカスタムハンドラを登録することで、ARM コンテナイメージをビルドできます。再起動で設定が元に戻るので、再度デプロイする際には、再実行が必要です。
+
 **[parameter.ts](/packages/cdk/parameter.ts) を編集**
 
 ```typescript

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -6,7 +6,7 @@
     "watch": "tsc -w",
     "test": "jest",
     "test:lambda:watch": "jest lambda --watchAll",
-    "precdk": "if [ \"$(uname -m)\" = \"x86_64\" ]; then docker run --privileged --rm tonistiigi/binfmt --install arm64; fi",
+    "precdk": "if [ \"$(uname -m)\" = \"x86_64\" ]; then sudo docker run --privileged --rm tonistiigi/binfmt --install arm64; fi",
     "cdk": "cdk",
     "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0",
     "lambda-build-dryrun": "tsc --noEmit --skipLibCheck",

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -6,7 +6,6 @@
     "watch": "tsc -w",
     "test": "jest",
     "test:lambda:watch": "jest lambda --watchAll",
-    "precdk": "if [ \"$(uname -m)\" = \"x86_64\" ]; then sudo docker run --privileged --rm tonistiigi/binfmt --install arm64; fi",
     "cdk": "cdk",
     "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0",
     "lambda-build-dryrun": "tsc --noEmit --skipLibCheck",

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -6,6 +6,7 @@
     "watch": "tsc -w",
     "test": "jest",
     "test:lambda:watch": "jest lambda --watchAll",
+    "precdk": "if [ \"$(uname -m)\" = \"x86_64\" ]; then docker run --privileged --rm tonistiigi/binfmt --install arm64; fi",
     "cdk": "cdk",
     "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0",
     "lambda-build-dryrun": "tsc --noEmit --skipLibCheck",


### PR DESCRIPTION
## Description of Changes

x86_64 系のCPU (Intel AMD など) を利用して、AgentCore を有効化したデプロイを行った際に、以下のエラーが発生する問題の対処です。

```
ERROR: failed to solve: process "/bin/sh -c apt-get update -y && apt-get install curl nodejs npm graphviz -y" did not complete successfully: exit code: 255
AgentCoreStack: fail: docker build --tag cdkasset-64ba68f71e3d29f5b84d8e8d062e841cb600c436bb68a540d6fce32fded36c08 --platform linux/arm64 . exited with error code 1: #0 building with "default" instance using docker driver
```

CodeBuild などの外部環境を利用したデプロイが考えられますが、クロスプラットフォームのビルドを有効化すると正常にビルドが確認できたので、まずは最低限の Document レベルでの更新をするものです。

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

#1233 