### PR TITLE
AWS Bedrockモデル呼び出しをLiteLLM経由に変更

### DIFF
--- a/packages/cdk/lambda-python/generic-agent-core-runtime/pyproject.toml
+++ b/packages/cdk/lambda-python/generic-agent-core-runtime/pyproject.toml
@@ -11,4 +11,5 @@ dependencies = [
   "uvicorn",
   "pydantic",
   "aws-opentelemetry-distro>=0.10.1",
+  "litellm>=1.76.2",
 ]

--- a/packages/cdk/lambda-python/generic-agent-core-runtime/src/agent.py
+++ b/packages/cdk/lambda-python/generic-agent-core-runtime/src/agent.py
@@ -1,12 +1,12 @@
 """Agent management for the agent core runtime."""
 
-import boto3
 import json
 import logging
-from strands.models import BedrockModel
+import litellm
+from strands.models.litellm_model import LiteLLMModel
 from strands import Agent as StrandsAgent
 from typing import List, Dict, Union, Any, Optional, AsyncGenerator
-from .config import get_system_prompt, extract_model_info
+from .config import get_system_prompt, extract_model_info, get_aws_credentials
 from .tools import ToolManager
 from .utils import (
     create_empty_response, 
@@ -47,13 +47,18 @@ class AgentManager:
             # Get all tools
             tools = self.tool_manager.get_all_tools()
             
-            # Create boto3 session and Bedrock model
-            session = boto3.Session(region_name=region)
-            bedrock_model = BedrockModel(
-                model_id=model_id,
-                boto_session=session,
-                cache_prompt="default",
-                cache_tools="default",
+            # Setup LiteLLM with AWS credentials
+            aws_creds = get_aws_credentials()
+            litellm_model = LiteLLMModel(
+                model_id=f"bedrock/{model_id}",
+                litellm_kwargs={
+                    "aws_access_key_id": aws_creds.get("AWS_ACCESS_KEY_ID"),
+                    "aws_secret_access_key": aws_creds.get("AWS_SECRET_ACCESS_KEY"),
+                    "aws_session_token": aws_creds.get("AWS_SESSION_TOKEN"),
+                    "aws_region_name": region,
+                    "cache_prompt": "default",
+                    "cache_tools": "default",
+                },
             )
             
             # Process messages and prompt using utility functions
@@ -64,7 +69,7 @@ class AgentManager:
             agent = StrandsAgent(
                 system_prompt=combined_system_prompt,
                 messages=processed_messages,
-                model=bedrock_model,
+                model=litellm_model,
                 tools=tools,
             )
 

--- a/packages/cdk/lambda-python/generic-agent-core-runtime/src/config.py
+++ b/packages/cdk/lambda-python/generic-agent-core-runtime/src/config.py
@@ -2,6 +2,7 @@
 
 import os
 import logging
+import litellm
 from typing import Dict, Any
 
 # Configure root logger
@@ -10,6 +11,10 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
+
+# Configure LiteLLM
+litellm.drop_params = True  # Remove unnecessary parameters
+litellm.set_verbose = False  # Disable verbose logging
 
 WORKSPACE_DIR = "/tmp/ws"
 
@@ -68,8 +73,15 @@ def extract_model_info(model_info: Any) -> tuple[str, str]:
         region = aws_creds.get("AWS_REGION", "us-east-1")
     else:
         model_id = model_info.get(
-            "modelId", "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+            "modelId", "anthropic.claude-3-5-sonnet-20241022-v2:0"
         )
         region = model_info.get("region", aws_creds.get("AWS_REGION", "us-east-1"))
+    
+    # If model_id starts with "us.", remove it for compatibility with LiteLLM
+    if model_id.startswith("us."):
+        model_id = model_id[3:]
+    # For other regional prefixes like "eu.", "ap.", etc.
+    elif "." in model_id and len(model_id.split(".", 1)[0]) <= 3:
+        model_id = model_id.split(".", 1)[1]
 
     return model_id, region


### PR DESCRIPTION
## 変更内容

AWS Bedrock モデルへのアクセスを直接 boto3/BedrockModel から LiteLLM 経由に変更するための修正を行いました。これにより、様々な生成AI プロバイダーへの統一的なアクセスが可能になります。

### 主な変更点

1. **agent.py**
   - boto3/BedrockModel から litellm/LiteLLMModel に移行
   - モデル初期化コードの更新

2. **config.py**
   - LiteLLM の基本設定の追加
   - モデル ID を LiteLLM 互換形式に変換するロジックの追加

3. **pyproject.toml**
   - 依存関係に `litellm>=1.76.2` を追加

### メリット
- 複数のプロバイダー（OpenAI、Anthropic など）への容易な切り替え
- API の統一化
- モデル利用の互換性向上

### テスト方法
- 環境変数（AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION）の設定
- CDK でデプロイ後、サンプルリクエストでの動作確認

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:webapp-1757117900675 -->

---

**Open in Web UI**: https://d3fdwcze17tei3.cloudfront.net/sessions/webapp-1757117900675