### PR TITLE
Set Node.js memory limit to 1.5GB (1536MB)

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Set Node.js memory limit to 1.5GB (1536MB)
+export NODE_OPTIONS="--max-old-space-size=1536"
+
 echo "--------------------------"
 echo "  _____            _    _ "
 echo " / ____|          | |  | |"


### PR DESCRIPTION
## Description of Changes

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

N/A
