### PR TITLE
Fix closed network subnet selection

### DIFF
--- a/packages/cdk/lib/construct/closedNetwork/resolver.ts
+++ b/packages/cdk/lib/construct/closedNetwork/resolver.ts
@@ -5,7 +5,7 @@ import {
   SecurityGroup,
   ISubnet,
   SubnetType,
-  SubnetFilter,
+  Subnet,
 } from 'aws-cdk-lib/aws-ec2';
 import { CfnResolverEndpoint } from 'aws-cdk-lib/aws-route53resolver';
 import { Construct } from 'constructs';
@@ -41,15 +41,13 @@ export class Resolver extends Construct {
       'DNS UDP'
     );
 
-    const subnets = props.vpc.selectSubnets(
-      props.subnetIds
-        ? {
-            subnetFilters: [SubnetFilter.byIds(props.subnetIds)],
-          }
-        : {
-            subnetType: SubnetType.PRIVATE_ISOLATED,
-          }
-    ).subnets;
+    const subnets = props.subnetIds
+      ? props.subnetIds.map((subnetId) =>
+          Subnet.fromSubnetId(this, `ResolverSubnet-${subnetId}`, subnetId)
+        )
+      : props.vpc.selectSubnets({
+          subnetType: SubnetType.PRIVATE_ISOLATED,
+        }).subnets;
 
     const ipAddresses: CfnResolverEndpoint.IpAddressRequestProperty[] =
       subnets.map((s: ISubnet) => ({ subnetId: s.subnetId }));


### PR DESCRIPTION
## Description of Changes

- props.vpc.selectSubnets()で、SubnetFilter.byIds(props.subnetIds)を使ってサブネットをフィルタしている
- しかし、props.vpcはec2.Vpc.fromLookup()で取得された既存VPCの参照
- CDKのfromLookup()では、指定されたサブネットIDの詳細情報（AZ情報など）が正しく解決されない場合がある
- 結果としてsubnets配列が空になり、58行目のif (ipAddresses.length < 2)でエラーが発生

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

https://github.com/aws-samples/generative-ai-use-cases/issues/1295
