### PR TITLE
deploy.shで環境を指定してデプロイしたときにURLが表示されない問題の修正

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -95,7 +95,7 @@ fi
 $deploy_cmd
 
 # Get the url of the deployed CloudFront
-weburl=`aws cloudformation describe-stacks --stack-name GenerativeAiUseCasesStack --output json | jq -r ".Stacks[0].Outputs[] | select(.OutputKey==\"WebUrl\") | .OutputValue"`
+weburl=`aws cloudformation describe-stacks --stack-name GenerativeAiUseCasesStack$env_name --output json | jq -r ".Stacks[0].Outputs[] | select(.OutputKey==\"WebUrl\") | .OutputValue"`
 
 echo "*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*"
 echo "Welcome to GenU: $weburl"


### PR DESCRIPTION
## Description of Changes

[DEPLOY_ON_CLOUDSHELL.md](https://github.com/aws-samples/generative-ai-use-cases/blob/main/docs/ja/DEPLOY_ON_CLOUDSHELL.md)に従って環境を指定してデプロイしたところ、CloudFormationによるデプロイが終わったあとに`DescribeStacks API`のエラーが発生し、URLが空欄で表示されていました。

**実行したコマンド**
```shell
./deploy.sh -p ~/parameter.ts -e dev
```

**エラー内容**
<img width="2735" height="468" alt="image" src="https://github.com/user-attachments/assets/22959664-5bb7-4092-b956-7dadb71b41d9" />

コマンドのスタック名に環境が指定されていなかったのが原因です。

https://github.com/aws-samples/generative-ai-use-cases/blob/e315abbb1903f2fc56d80a3e59a858493c53c80e/deploy.sh#L58-L59

この変更はCloudFormationスタックの出力からURLを取ってくる部分なのでデプロイ自体に影響はありません。

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

なし