### PR TITLE
add "cdk:diff" shortcut to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cdk:deploy": "npm -w packages/cdk run cdk deploy -- --all",
     "cdk:deploy:quick": "npm -w packages/cdk run cdk deploy -- --all --asset-parallelism --asset-prebuild=false --concurrency 3 --method=direct --require-approval never --force",
     "cdk:deploy:quick:hotswap": "npm -w packages/cdk run cdk deploy -- --all --asset-parallelism --asset-prebuild=false --concurrency 3 --method=direct --require-approval never --force --hotswap",
+    "cdk:diff": "npm -w packages/cdk run cdk diff -- --all",
     "cdk:destroy": "npm -w packages/cdk run cdk destroy -- --all",
     "cdk:lint": "npm -w packages/cdk run lint",
     "cdk:lambda-build-dryrun": "npm -w packages/cdk run lambda-build-dryrun",


### PR DESCRIPTION
## Description of Changes

Add an npm script shortcut for running `cdk diff` across all stacks.
If there is any reason we intentionally don’t provide cdk diff, please feel free to reject this PR. This change is not strictly necessary for me.

in Japanese:
意図的に`cdk:diff`を記載されていない場合、こちらのPRは必須ではありませんので却下ください。


## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

