### PR TITLE
fix: remove invalid maxHeight prop from ModalSystemContext input #1171

### DIFF
--- a/packages/web/src/components/ModalSystemContext.tsx
+++ b/packages/web/src/components/ModalSystemContext.tsx
@@ -32,7 +32,6 @@ const ModalSystemContext: React.FC<Props> = (props) => {
           placeholder={t('common.enter_text')}
           value={props.saveSystemContextTitle}
           onChange={props.setSaveSystemContextTitle}
-          maxHeight={-1}
           className="text-aws-font-color"
         />
 


### PR DESCRIPTION
Remove maxHeight={-1} prop from text input component as negative height values are invalid and unnecessary for the component's functionality.

## Description of Changes

Please explain the changes in detail.
If there is any impact on existing users (compatibility, degradation, breaking changes, etc.), be sure to include it in the explanation.

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

#1171

## Screenshot

<img width="720" height="401" alt="image" src="https://github.com/user-attachments/assets/23a9673c-5e01-4050-9ed7-16a8c1213a45" />

