### PR TITLE
ユースケースビルダーでモデル固定したときに PDF が読めなくなるのを修正

### DIFF
--- a/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
+++ b/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
@@ -200,13 +200,16 @@ const UseCaseBuilderView: React.FC<Props> = (props) => {
   }, [selectItems, values, setValue]);
 
   useEffect(() => {
-    setModelId(
-      availableModels.includes(props.modelId ?? '')
-        ? props.modelId!
-        : availableModels[0]
-    );
+    const targetModelId =
+      props.fixedModelId || props.modelId || availableModels[0];
+
+    if (availableModels.includes(targetModelId)) {
+      setModelId(targetModelId);
+    } else {
+      setModelId(availableModels[0]);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [availableModels, props.modelId, pathname]);
+  }, [availableModels, props.modelId, props.fixedModelId, pathname]);
 
   useEffect(() => {
     setTypingTextInput(text);


### PR DESCRIPTION
## Description of Changes

fixedModelId使用時にPDFファイルが読み込めない問題を修正

ユースケースビルダーでモデルを固定化した際に、PDF対応モデル
(Amazon Nova Proなど)でもPDFファイルが読み込めなくなる不具合を修正。

useEffectでfixedModelIdを優先的に考慮し、useChatフック内の
modelId状態を正しく同期することで、モデルの機能フラグ
(PDF読み込み機能)が正しく反映されるようにした。

元のバグの再現方法例: Claude の何かしらのモデル、Nova Pro の順番でモデルを有効化し、ユースケースビルダーでモデルを Nova Pro で固定化して PDF を添付すると PDF が読めないエラーが出る→それの修正

## Checklist

- [-] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

#1242 