### PR TITLE
chore: skip bundling for snapshot test

### DIFF
--- a/packages/cdk/test/generative-ai-use-cases.test.ts
+++ b/packages/cdk/test/generative-ai-use-cases.test.ts
@@ -2,6 +2,15 @@ import { Template } from 'aws-cdk-lib/assertions';
 import * as cdk from 'aws-cdk-lib';
 import { processedStackInputSchema, StackInput } from '../lib/stack-input';
 import { createStacks } from '../lib/create-stacks';
+import {
+  BUNDLING_STACKS,
+  DISABLE_ASSET_STAGING_CONTEXT,
+} from 'aws-cdk-lib/cx-api';
+
+const appContext = {
+  [BUNDLING_STACKS]: [],
+  [DISABLE_ASSET_STAGING_CONTEXT]: true,
+};
 
 describe('GenerativeAiUseCases', () => {
   const stackInput: Partial<StackInput> = {
@@ -68,7 +77,9 @@ describe('GenerativeAiUseCases', () => {
   };
 
   test('matches the snapshot', () => {
-    const app = new cdk.App();
+    const app = new cdk.App({
+      context: appContext,
+    });
 
     const params = processedStackInputSchema.parse(stackInput);
 
@@ -115,7 +126,9 @@ describe('GenerativeAiUseCases', () => {
   });
 
   test('matches the snapshot (closed network mode)', () => {
-    const app = new cdk.App();
+    const app = new cdk.App({
+      context: appContext,
+    });
 
     const params = processedStackInputSchema.parse({
       ...stackInput,
@@ -166,7 +179,9 @@ describe('GenerativeAiUseCases', () => {
 
   test('tagKey functionality', () => {
     // Test with custom tagKey
-    const appWithCustomTag = new cdk.App();
+    const appWithCustomTag = new cdk.App({
+      context: appContext,
+    });
     const paramsWithCustomTag = processedStackInputSchema.parse({
       ...stackInput,
       tagKey: 'CustomTag',
@@ -179,7 +194,9 @@ describe('GenerativeAiUseCases', () => {
     );
 
     // Test without tagKey (should use default)
-    const appWithoutTagKey = new cdk.App();
+    const appWithoutTagKey = new cdk.App({
+      context: appContext,
+    });
     const paramsWithoutTagKey = processedStackInputSchema.parse({
       ...stackInput,
       tagKey: null,


### PR DESCRIPTION
## Description of Changes

- improve snapshot test speed by skipping bundling

## Checklist

- [ ] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

Please list related issues as much as possible.
