### PR TITLE
添付ファイルの拡張子が大文字でも動くようにする

### DIFF
--- a/packages/web/src/hooks/useFiles.ts
+++ b/packages/web/src/hooks/useFiles.ts
@@ -120,11 +120,16 @@ const useFilesState = create<{
         const errorMessages: string[] = [];
         const extension = uploadedFile.file.name.split('.').pop() as string;
 
-        // Validate file extension and MIME type
-        const isFileExtensionAccepted = accept.includes(`.${extension}`);
+        // Validate file extension and MIME type (case-insensitive)
+        const isFileExtensionAccepted = accept.includes(
+          `.${extension.toLowerCase()}`
+        );
         const isMimeTypeValid =
           uploadedFile.mimeType &&
-          validateMimeTypeAndExtension(uploadedFile.mimeType, extension);
+          validateMimeTypeAndExtension(
+            uploadedFile.mimeType,
+            extension.toLowerCase()
+          );
         if (accept && accept.length === 0) {
           errorMessages.push(i18next.t('files.error.modelNotSupported'));
         } else if (!isFileExtensionAccepted) {


### PR DESCRIPTION
## Description of Changes

添付ファイルの拡張子が大文字でもアップロードしてチャットできるようにする

## Checklist

- [] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

#1381 
