### PR TITLE
RAG Knowledge Base にシステムプロンプトカスタマイズ機能を追加

### DIFF
--- a/packages/web/src/@types/navigate.d.ts
+++ b/packages/web/src/@types/navigate.d.ts
@@ -45,6 +45,7 @@ export type GenerateTextPageQueryParams = BaseQueryParams & {
 
 export type RagPageQueryParams = BaseQueryParams & {
   content?: string;
+  systemContext?: string;
 };
 
 export type AgentPageQueryParams = BaseQueryParams & {


### PR DESCRIPTION
## Description of Changes

既存のチャット機能で利用可能だったシステムプロンプトのカスタマイズ機能を、RAG Knowledge Base ページでも使えるように対応しました。

### 追加機能

- システムプロンプトの編集・適用
- プロンプトの保存・管理（タイトル付き保存、一覧表示、削除・編集）
- システムメッセージの表示切り替え（デバッグ用）

### 実装

- バックエンド (`packages/cdk/lambda/utils/bedrockKbApi.ts`): 
  - ユーザーのカスタムプロンプトを Bedrock Knowledge Base API の `generationConfiguration` に注入
  - `$search_results$` 等のプレースホルダーは [AWS公式ドキュメント](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-placeholders.html) に基づく Bedrock API の仕様
  - `$search_results$` は必須（これがないと検索結果がLLMに渡されない）
- フロントエンド (`packages/web/src/pages/RagKnowledgeBasePage.tsx`): 
  - チャットページと同じコンポーネント・フックを再利用（`ModalSystemContext`, `PromptList`, `useSystemContextApi` 等）
- 型定義 (`packages/web/src/@types/navigate.d.ts`): 
  - `RagPageQueryParams` に `systemContext` フィールドを追加

## Checklist

- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み
- [x] `npm run lint` を実行した

## Related Issues

なし

