### PR TITLE
feat: Add S3 Vectors as alternative storage backend for Knowledge Base RAG

### DIFF
--- a/docs/en/DEPLOY_OPTION.md
+++ b/docs/en/DEPLOY_OPTION.md
@@ -163,7 +163,11 @@ arn:aws:kendra:ap-northeast-1:333333333333:index/77777777-3333-4444-aaaa-1111111
 ### Enabling RAG Chat (Knowledge Base) Use Case
 
 Set `ragKnowledgeBaseEnabled` to `true`. (Default is `false`)  
-If you have an existing Knowledge Base, set `ragKnowledgeBaseId` to the knowledge base ID. (If `null`, an OpenSearch Serverless knowledge base will be created)
+If you have an existing Knowledge Base, set `ragKnowledgeBaseId` to the knowledge base ID. (If `null`, a knowledge base will be created with the backend specified by `ragKnowledgeBaseStorageType`)
+
+Use `ragKnowledgeBaseStorageType` to select the vector store backend. (Default is `opensearch`)
+- `opensearch`: Use OpenSearch Serverless (existing behavior)
+- `s3vectors`: Use Amazon S3 Vectors (low cost, no fixed fees)
 
 **Edit [parameter.ts](/packages/cdk/parameter.ts)**
 
@@ -172,6 +176,7 @@ If you have an existing Knowledge Base, set `ragKnowledgeBaseId` to the knowledg
 const envs: Record<string, Partial<StackInput>> = {
   dev: {
     ragKnowledgeBaseEnabled: true,
+    ragKnowledgeBaseStorageType: 'opensearch', // 'opensearch' or 's3vectors'
     ragKnowledgeBaseId: 'XXXXXXXXXX',
     ragKnowledgeBaseStandbyReplicas: false,
     ragKnowledgeBaseAdvancedParsing: false,
@@ -189,6 +194,7 @@ const envs: Record<string, Partial<StackInput>> = {
 {
   "context": {
     "ragKnowledgeBaseEnabled": true,
+    "ragKnowledgeBaseStorageType": "opensearch", // "opensearch" or "s3vectors"
     "ragKnowledgeBaseId": "XXXXXXXXXX",
     "ragKnowledgeBaseStandbyReplicas": false,
     "ragKnowledgeBaseAdvancedParsing": false,

--- a/docs/ja/DEPLOY_OPTION.md
+++ b/docs/ja/DEPLOY_OPTION.md
@@ -163,7 +163,11 @@ arn:aws:kendra:ap-northeast-1:333333333333:index/77777777-3333-4444-aaaa-1111111
 ### RAG チャット (Knowledge Base) ユースケースの有効化
 
 `ragKnowledgeBaseEnabled` に `true` を指定します。(デフォルトは `false`)  
-作成ずみのKnowledge Baseがある場合、`ragKnowledgeBaseId` にナレッジベースIDを設定します。(`null`の場合、OpenSearch Serverlessのナレッジベースが作成されます)
+作成ずみのKnowledge Baseがある場合、`ragKnowledgeBaseId` にナレッジベースIDを設定します。(`null`の場合、`ragKnowledgeBaseStorageType`で指定されたバックエンドでナレッジベースが作成されます)
+
+`ragKnowledgeBaseStorageType` でベクトルストアのバックエンドを選択できます。(デフォルトは `opensearch`)
+- `opensearch`: OpenSearch Serverless を使用（従来動作）
+- `s3vectors`: Amazon S3 Vectors を使用（低コスト、固定費なし）
 
 **[parameter.ts](/packages/cdk/parameter.ts) を編集**
 
@@ -172,6 +176,7 @@ arn:aws:kendra:ap-northeast-1:333333333333:index/77777777-3333-4444-aaaa-1111111
 const envs: Record<string, Partial<StackInput>> = {
   dev: {
     ragKnowledgeBaseEnabled: true,
+    ragKnowledgeBaseStorageType: 'opensearch', // 'opensearch' or 's3vectors'
     ragKnowledgeBaseId: 'XXXXXXXXXX',
     ragKnowledgeBaseStandbyReplicas: false,
     ragKnowledgeBaseAdvancedParsing: false,
@@ -190,6 +195,7 @@ const envs: Record<string, Partial<StackInput>> = {
 {
   "context": {
     "ragKnowledgeBaseEnabled": true,
+    "ragKnowledgeBaseStorageType": "opensearch", // "opensearch" or "s3vectors"
     "ragKnowledgeBaseId": "XXXXXXXXXX",
     "ragKnowledgeBaseStandbyReplicas": false,
     "ragKnowledgeBaseAdvancedParsing": false,

--- a/docs/ko/DEPLOY_OPTION.md
+++ b/docs/ko/DEPLOY_OPTION.md
@@ -164,7 +164,11 @@ arn:aws:kendra:ap-northeast-1:333333333333:index/77777777-3333-4444-aaaa-1111111
 ### RAG Chat (Knowledge Base) 사용 사례 활성화
 
 `ragKnowledgeBaseEnabled`를 `true`로 설정합니다. (기본값은 `false`)  
-기존 Knowledge Base가 있는 경우 `ragKnowledgeBaseId`를 지식 베이스 ID로 설정합니다. (`null`인 경우 OpenSearch Serverless 지식 베이스가 생성됩니다)
+기존 Knowledge Base가 있는 경우 `ragKnowledgeBaseId`를 지식 베이스 ID로 설정합니다. (`null`인 경우 `ragKnowledgeBaseStorageType`에서 지정된 백엔드로 지식 베이스가 생성됩니다)
+
+`ragKnowledgeBaseStorageType`로 벡터 스토어 백엔드를 선택할 수 있습니다. (기본값은 `opensearch`)
+- `opensearch`: OpenSearch Serverless 사용 (기존 동작)
+- `s3vectors`: Amazon S3 Vectors 사용 (저비용, 고정 비용 없음)
 
 **[parameter.ts](/packages/cdk/parameter.ts) 편집**
 
@@ -173,6 +177,7 @@ arn:aws:kendra:ap-northeast-1:333333333333:index/77777777-3333-4444-aaaa-1111111
 const envs: Record<string, Partial<StackInput>> = {
   dev: {
     ragKnowledgeBaseEnabled: true,
+    ragKnowledgeBaseStorageType: 'opensearch', // 'opensearch' or 's3vectors'
     ragKnowledgeBaseId: 'XXXXXXXXXX',
     ragKnowledgeBaseStandbyReplicas: false,
     ragKnowledgeBaseAdvancedParsing: false,
@@ -190,6 +195,7 @@ const envs: Record<string, Partial<StackInput>> = {
 {
   "context": {
     "ragKnowledgeBaseEnabled": true,
+    "ragKnowledgeBaseStorageType": "opensearch", // "opensearch" or "s3vectors"
     "ragKnowledgeBaseId": "XXXXXXXXXX",
     "ragKnowledgeBaseStandbyReplicas": false,
     "ragKnowledgeBaseAdvancedParsing": false,

--- a/packages/cdk/cdk.json
+++ b/packages/cdk/cdk.json
@@ -27,6 +27,7 @@
     "kendraIndexScheduleDeleteCron": null,
     "ragKnowledgeBaseEnabled": false,
     "ragKnowledgeBaseId": null,
+    "ragKnowledgeBaseStorageType": "opensearch",
     "ragKnowledgeBaseStandbyReplicas": false,
     "ragKnowledgeBaseAdvancedParsing": false,
     "ragKnowledgeBaseAdvancedParsingModelId": "anthropic.claude-3-sonnet-20240229-v1:0",

--- a/packages/cdk/lib/construct/web.ts
+++ b/packages/cdk/lib/construct/web.ts
@@ -32,6 +32,7 @@ export interface WebProps {
   readonly predictStreamFunctionArn: string;
   readonly ragEnabled: boolean;
   readonly ragKnowledgeBaseEnabled: boolean;
+  readonly ragKnowledgeBaseStorageType: string;
   readonly agentEnabled: boolean;
   readonly flows?: Flow[];
   readonly flowStreamFunctionArn: string;
@@ -269,6 +270,8 @@ export class Web extends Construct {
         VITE_APP_RAG_ENABLED: props.ragEnabled.toString(),
         VITE_APP_RAG_KNOWLEDGE_BASE_ENABLED:
           props.ragKnowledgeBaseEnabled.toString(),
+        VITE_APP_RAG_KNOWLEDGE_BASE_STORAGE_TYPE:
+          props.ragKnowledgeBaseStorageType,
         VITE_APP_AGENT_ENABLED: props.agentEnabled.toString(),
         VITE_APP_FLOWS: JSON.stringify(props.flows || []),
         VITE_APP_FLOW_STREAM_FUNCTION_ARN: props.flowStreamFunctionArn,

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -340,6 +340,7 @@ export class GenerativeAiUseCasesStack extends Stack {
       predictStreamFunctionArn: api.predictStreamFunction.functionArn,
       ragEnabled: params.ragEnabled,
       ragKnowledgeBaseEnabled: params.ragKnowledgeBaseEnabled,
+      ragKnowledgeBaseStorageType: params.ragKnowledgeBaseStorageType,
       agentEnabled: params.agentEnabled || params.agents.length > 0,
       flows: params.flows,
       flowStreamFunctionArn: api.invokeFlowFunction.functionArn,
@@ -473,6 +474,10 @@ export class GenerativeAiUseCasesStack extends Stack {
 
     new CfnOutput(this, 'RagKnowledgeBaseEnabled', {
       value: params.ragKnowledgeBaseEnabled.toString(),
+    });
+
+    new CfnOutput(this, 'RagKnowledgeBaseStorageType', {
+      value: params.ragKnowledgeBaseStorageType,
     });
 
     new CfnOutput(this, 'AgentEnabled', {

--- a/packages/cdk/lib/rag-knowledge-base-stack.ts
+++ b/packages/cdk/lib/rag-knowledge-base-stack.ts
@@ -140,6 +140,7 @@ export class RagKnowledgeBaseStack extends Stack {
     const {
       env,
       embeddingModelId,
+      ragKnowledgeBaseStorageType,
       ragKnowledgeBaseStandbyReplicas,
       ragKnowledgeBaseAdvancedParsing,
       ragKnowledgeBaseAdvancedParsingModelId,
@@ -148,6 +149,8 @@ export class RagKnowledgeBaseStack extends Stack {
       tagKey,
       tagValue,
     } = props.params;
+
+    const useS3Vectors = ragKnowledgeBaseStorageType === 's3vectors';
 
     if (typeof embeddingModelId !== 'string') {
       throw new Error(
@@ -189,156 +192,192 @@ export class RagKnowledgeBaseStack extends Stack {
       );
     }
 
-    const collection = new oss.CfnCollection(this, 'Collection', {
-      name: collectionName,
-      description: 'GenU Collection',
-      type: 'VECTORSEARCH',
-      standbyReplicas: ragKnowledgeBaseStandbyReplicas ? 'ENABLED' : 'DISABLED',
-      // Do not specify tags here to avoid CloudFormation replacement errors
-    });
+    // OpenSearch resources (not needed when using S3 Vectors)
+    let collection: oss.CfnCollection | undefined;
+    let ossIndex: OpenSearchServerlessIndex | undefined;
+    let accessPolicy: oss.CfnAccessPolicy | undefined;
+    let networkPolicy: oss.CfnSecurityPolicy | undefined;
+    let encryptionPolicy: oss.CfnSecurityPolicy | undefined;
+    let tagApplier: lambda.SingletonFunction | undefined;
+    let applyTagsResource: cdk.CustomResource | undefined;
 
-    const ossIndex = new OpenSearchServerlessIndex(this, 'OssIndex', {
-      collectionId: collection.ref,
-      vectorIndexName,
-      vectorField,
-      textField,
-      metadataField,
-      vectorDimension: MODEL_VECTOR_MAPPING[embeddingModelId],
-      ragKnowledgeBaseBinaryVector,
-    });
-
-    ossIndex.customResourceHandler.addToRolePolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        resources: [cdk.Token.asString(collection.getAtt('Arn'))],
-        actions: ['aoss:APIAccessAll'],
-      })
-    );
-
-    const accessPolicy = new oss.CfnAccessPolicy(this, 'AccessPolicy', {
-      name: collectionName,
-      policy: JSON.stringify([
-        {
-          Rules: [
-            {
-              Resource: [`collection/${collectionName}`],
-              Permission: [
-                'aoss:DescribeCollectionItems',
-                'aoss:CreateCollectionItems',
-                'aoss:UpdateCollectionItems',
-              ],
-              ResourceType: 'collection',
-            },
-            {
-              Resource: [`index/${collectionName}/*`],
-              Permission: [
-                'aoss:UpdateIndex',
-                'aoss:DescribeIndex',
-                'aoss:ReadDocument',
-                'aoss:WriteDocument',
-                'aoss:CreateIndex',
-                'aoss:DeleteIndex',
-              ],
-              ResourceType: 'index',
-            },
-          ],
-          Principal: [
-            knowledgeBaseRole.roleArn,
-            ossIndex.customResourceHandler.role?.roleArn,
-          ],
-          Description: '',
-        },
-      ]),
-      type: 'data',
-    });
-
-    const networkPolicy = new oss.CfnSecurityPolicy(this, 'NetworkPolicy', {
-      name: collectionName,
-      policy: JSON.stringify([
-        {
-          Rules: [
-            {
-              Resource: [`collection/${collectionName}`],
-              ResourceType: 'collection',
-            },
-            {
-              Resource: [`collection/${collectionName}`],
-              ResourceType: 'dashboard',
-            },
-          ],
-          AllowFromPublic: true,
-        },
-      ]),
-      type: 'network',
-    });
-
-    const encryptionPolicy = new oss.CfnSecurityPolicy(
-      this,
-      'EncryptionPolicy',
-      {
+    if (!useS3Vectors) {
+      collection = new oss.CfnCollection(this, 'Collection', {
         name: collectionName,
-        policy: JSON.stringify({
-          Rules: [
-            {
-              Resource: [`collection/${collectionName}`],
-              ResourceType: 'collection',
-            },
-          ],
-          AWSOwnedKey: true,
-        }),
-        type: 'encryption',
-      }
-    );
+        description: 'GenU Collection',
+        type: 'VECTORSEARCH',
+        standbyReplicas: ragKnowledgeBaseStandbyReplicas ? 'ENABLED' : 'DISABLED',
+        // Do not specify tags here to avoid CloudFormation replacement errors
+      });
 
-    collection.node.addDependency(accessPolicy);
-    collection.node.addDependency(networkPolicy);
-    collection.node.addDependency(encryptionPolicy);
-
-    // Since we need to apply tags directly through AWS SDK instead of CloudFormation
-    // We'll use a custom resource to apply tags after the collection is created
-    // This avoids CloudFormation attempting to replace the collection when adding tags
-
-    // Always create the tag applier custom resource to handle both tag application and removal
-    const tagApplier = new lambda.SingletonFunction(this, 'TagApplier', {
-      runtime: LAMBDA_RUNTIME_NODEJS,
-      code: lambda.Code.fromAsset('custom-resources/apply-tags'),
-      handler: 'apply-tags.handler',
-      uuid: 'E2488E36-B465-4D1F-9D1C-89FB99F1CC01',
-      lambdaPurpose: 'ApplyTagsToResources',
-      timeout: cdk.Duration.minutes(5),
-    });
-
-    const applyTagsResource = new cdk.CustomResource(this, 'ApplyTags', {
-      serviceToken: tagApplier.functionArn,
-      resourceType: 'Custom::ApplyTags',
-      properties: {
-        tag: {
-          key: tagKey || TAG_KEY,
-          value: tagValue || '', // Pass empty string when tagValue is unset
-        },
+      ossIndex = new OpenSearchServerlessIndex(this, 'OssIndex', {
         collectionId: collection.ref,
-        region: this.region,
-        accountId: this.account,
-      },
-    });
+        vectorIndexName,
+        vectorField,
+        textField,
+        metadataField,
+        vectorDimension: MODEL_VECTOR_MAPPING[embeddingModelId],
+        ragKnowledgeBaseBinaryVector,
+      });
 
-    // Ensure tag application happens after collection creation
-    applyTagsResource.node.addDependency(collection);
+      ossIndex.customResourceHandler.addToRolePolicy(
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          resources: [cdk.Token.asString(collection.getAtt('Arn'))],
+          actions: ['aoss:APIAccessAll'],
+        })
+      );
 
-    // Grant permissions to apply and remove tags
-    tagApplier.addToRolePolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        resources: [
-          `arn:aws:aoss:${this.region}:${this.account}:collection/${collection.ref}`,
-        ],
-        actions: [
-          'aoss:TagResource',
-          'aoss:UntagResource',
-          'aoss:ListTagsForResource',
-        ],
-      })
-    );
+      accessPolicy = new oss.CfnAccessPolicy(this, 'AccessPolicy', {
+        name: collectionName,
+        policy: JSON.stringify([
+          {
+            Rules: [
+              {
+                Resource: [`collection/${collectionName}`],
+                Permission: [
+                  'aoss:DescribeCollectionItems',
+                  'aoss:CreateCollectionItems',
+                  'aoss:UpdateCollectionItems',
+                ],
+                ResourceType: 'collection',
+              },
+              {
+                Resource: [`index/${collectionName}/*`],
+                Permission: [
+                  'aoss:UpdateIndex',
+                  'aoss:DescribeIndex',
+                  'aoss:ReadDocument',
+                  'aoss:WriteDocument',
+                  'aoss:CreateIndex',
+                  'aoss:DeleteIndex',
+                ],
+                ResourceType: 'index',
+              },
+            ],
+            Principal: [
+              knowledgeBaseRole.roleArn,
+              ossIndex.customResourceHandler.role?.roleArn,
+            ],
+            Description: '',
+          },
+        ]),
+        type: 'data',
+      });
+
+      networkPolicy = new oss.CfnSecurityPolicy(this, 'NetworkPolicy', {
+        name: collectionName,
+        policy: JSON.stringify([
+          {
+            Rules: [
+              {
+                Resource: [`collection/${collectionName}`],
+                ResourceType: 'collection',
+              },
+              {
+                Resource: [`collection/${collectionName}`],
+                ResourceType: 'dashboard',
+              },
+            ],
+            AllowFromPublic: true,
+          },
+        ]),
+        type: 'network',
+      });
+
+      encryptionPolicy = new oss.CfnSecurityPolicy(
+        this,
+        'EncryptionPolicy',
+        {
+          name: collectionName,
+          policy: JSON.stringify({
+            Rules: [
+              {
+                Resource: [`collection/${collectionName}`],
+                ResourceType: 'collection',
+              },
+            ],
+            AWSOwnedKey: true,
+          }),
+          type: 'encryption',
+        }
+      );
+
+      collection.node.addDependency(accessPolicy);
+      collection.node.addDependency(networkPolicy);
+      collection.node.addDependency(encryptionPolicy);
+
+      // Apply tags via AWS SDK to avoid CloudFormation replacement errors
+      tagApplier = new lambda.SingletonFunction(this, 'TagApplier', {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        code: lambda.Code.fromAsset('custom-resources/apply-tags'),
+        handler: 'apply-tags.handler',
+        uuid: 'E2488E36-B465-4D1F-9D1C-89FB99F1CC01',
+        lambdaPurpose: 'ApplyTagsToResources',
+        timeout: cdk.Duration.minutes(5),
+      });
+
+      applyTagsResource = new cdk.CustomResource(this, 'ApplyTags', {
+        serviceToken: tagApplier.functionArn,
+        resourceType: 'Custom::ApplyTags',
+        properties: {
+          tag: {
+            key: tagKey || TAG_KEY,
+            value: tagValue || '', // Pass empty string when tagValue is unset
+          },
+          collectionId: collection.ref,
+          region: this.region,
+          accountId: this.account,
+        },
+      });
+
+      // Ensure tag application happens after collection creation
+      applyTagsResource.node.addDependency(collection);
+
+      // Grant permissions to apply and remove tags
+      tagApplier.addToRolePolicy(
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          resources: [
+            `arn:aws:aoss:${this.region}:${this.account}:collection/${collection.ref}`,
+          ],
+          actions: [
+            'aoss:TagResource',
+            'aoss:UntagResource',
+            'aoss:ListTagsForResource',
+          ],
+        })
+      );
+    }
+
+    // S3 Vectors resources (only created when using S3 Vectors)
+    let vectorBucket: cdk.CfnResource | undefined;
+    let vectorIndex: cdk.CfnResource | undefined;
+
+    if (useS3Vectors) {
+      vectorBucket = new cdk.CfnResource(this, 'S3VectorBucket', {
+        type: 'AWS::S3Vectors::VectorBucket',
+        properties: {
+          VectorBucketName: `genu-s3vectors-kb${env.toLowerCase()}`,
+        },
+      });
+
+      vectorIndex = new cdk.CfnResource(this, 'S3VectorIndex', {
+        type: 'AWS::S3Vectors::Index',
+        properties: {
+          VectorBucketName: `genu-s3vectors-kb${env.toLowerCase()}`,
+          IndexName: `genu-rag-kb-index${env.toLowerCase()}`,
+          DataType: 'float32',
+          Dimension: parseInt(MODEL_VECTOR_MAPPING[embeddingModelId], 10),
+          DistanceMetric: 'cosine',
+          MetadataConfiguration: {
+            NonFilterableMetadataKeys: ['AMAZON_BEDROCK_TEXT', 'AMAZON_BEDROCK_METADATA'],
+          },
+        },
+      });
+
+      vectorIndex.addDependency(vectorBucket);
+    }
 
     const accessLogsBucket = new s3.Bucket(this, 'DataSourceAccessLogsBucket', {
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
@@ -368,13 +407,38 @@ export class RagKnowledgeBaseStack extends Stack {
       })
     );
 
-    knowledgeBaseRole.addToPolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        resources: [cdk.Token.asString(collection.getAtt('Arn'))],
-        actions: ['aoss:APIAccessAll'],
-      })
-    );
+    if (!useS3Vectors && collection) {
+      knowledgeBaseRole.addToPolicy(
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          resources: [cdk.Token.asString(collection.getAtt('Arn'))],
+          actions: ['aoss:APIAccessAll'],
+        })
+      );
+    }
+
+    if (useS3Vectors) {
+      knowledgeBaseRole.addToPolicy(
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          resources: [
+            `arn:aws:s3vectors:${this.region}:${this.account}:bucket/genu-s3vectors-kb${env.toLowerCase()}`,
+            `arn:aws:s3vectors:${this.region}:${this.account}:bucket/genu-s3vectors-kb${env.toLowerCase()}/index/genu-rag-kb-index${env.toLowerCase()}`,
+          ],
+          actions: [
+            's3vectors:CreateIndex',
+            's3vectors:DeleteIndex',
+            's3vectors:GetIndex',
+            's3vectors:ListIndexes',
+            's3vectors:QueryVectors',
+            's3vectors:GetVectors',
+            's3vectors:PutVectors',
+            's3vectors:DeleteVectors',
+            's3vectors:ListVectors',
+          ],
+        })
+      );
+    }
 
     knowledgeBaseRole.addToPolicy(
       new iam.PolicyStatement({
@@ -410,18 +474,26 @@ export class RagKnowledgeBaseStack extends Stack {
             : {}),
         },
       },
-      storageConfiguration: {
-        type: 'OPENSEARCH_SERVERLESS',
-        opensearchServerlessConfiguration: {
-          collectionArn: cdk.Token.asString(collection.getAtt('Arn')),
-          fieldMapping: {
-            metadataField,
-            textField,
-            vectorField,
+      storageConfiguration: useS3Vectors
+        ? ({
+            type: 'S3_VECTORS',
+            s3VectorsConfiguration: {
+              bucketArn: `arn:aws:s3vectors:${this.region}:${this.account}:bucket/genu-s3vectors-kb${env.toLowerCase()}`,
+              indexArn: `arn:aws:s3vectors:${this.region}:${this.account}:bucket/genu-s3vectors-kb${env.toLowerCase()}/index/genu-rag-kb-index${env.toLowerCase()}`,
+            },
+          } as any)
+        : {
+            type: 'OPENSEARCH_SERVERLESS',
+            opensearchServerlessConfiguration: {
+              collectionArn: cdk.Token.asString(collection!.getAtt('Arn')),
+              fieldMapping: {
+                metadataField,
+                textField,
+                vectorField,
+              },
+              vectorIndexName,
+            },
           },
-          vectorIndexName,
-        },
-      },
     });
 
     new bedrock.CfnDataSource(this, 'DataSource', {
@@ -497,34 +569,47 @@ export class RagKnowledgeBaseStack extends Stack {
     });
 
     // Web Crawler Data Source (GenU documentation site as sample)
-    new bedrock.CfnDataSource(this, 'WebCrawlerDataSource', {
-      dataSourceConfiguration: {
-        type: 'WEB',
-        webConfiguration: {
-          sourceConfiguration: {
-            urlConfiguration: {
-              seedUrls: [
-                {
-                  url: 'https://aws-samples.github.io/generative-ai-use-cases/en/',
-                },
-              ],
+    // S3 Vectors backend does not support WEB data sources
+    if (!useS3Vectors) {
+      new bedrock.CfnDataSource(this, 'WebCrawlerDataSource', {
+        dataSourceConfiguration: {
+          type: 'WEB',
+          webConfiguration: {
+            sourceConfiguration: {
+              urlConfiguration: {
+                seedUrls: [
+                  {
+                    url: 'https://aws-samples.github.io/generative-ai-use-cases/en/',
+                  },
+                ],
+              },
             },
-          },
-          crawlerConfiguration: {
-            crawlerLimits: {
-              rateLimit: 300,
-              maxPages: 100,
+            crawlerConfiguration: {
+              crawlerLimits: {
+                rateLimit: 300,
+                maxPages: 100,
+              },
+              scope: 'HOST_ONLY',
             },
-            scope: 'HOST_ONLY',
           },
         },
-      },
-      knowledgeBaseId: knowledgeBase.ref,
-      name: 'web-crawler-data-source',
-    });
+        knowledgeBaseId: knowledgeBase.ref,
+        name: 'web-crawler-data-source',
+      });
+    }
 
-    knowledgeBase.addDependency(collection);
-    knowledgeBase.node.addDependency(ossIndex.customResource);
+    if (!useS3Vectors && collection && ossIndex) {
+      knowledgeBase.addDependency(collection);
+      knowledgeBase.node.addDependency(ossIndex.customResource);
+    }
+
+    if (useS3Vectors && vectorIndex) {
+      knowledgeBase.node.addDependency(vectorIndex);
+    }
+
+    // Ensure IAM policy is propagated before creating Knowledge Base
+    const defaultPolicy = knowledgeBaseRole.node.findChild('DefaultPolicy');
+    knowledgeBase.node.addDependency(defaultPolicy);
 
     new s3Deploy.BucketDeployment(this, 'DeployDocs', {
       sources: [s3Deploy.Source.asset('./rag-docs')],

--- a/packages/cdk/lib/rag-knowledge-base-stack.ts
+++ b/packages/cdk/lib/rag-knowledge-base-stack.ts
@@ -170,6 +170,12 @@ export class RagKnowledgeBaseStack extends Stack {
       );
     }
 
+    if (useS3Vectors && ragKnowledgeBaseBinaryVector) {
+      throw new Error(
+        'Binary vector (ragKnowledgeBaseBinaryVector) is not supported with S3 Vectors storage backend. Set ragKnowledgeBaseBinaryVector to false or use opensearch storage type.'
+      );
+    }
+
     const collectionName =
       props.collectionName ?? `generative-ai-use-cases-jp${env.toLowerCase()}`;
     const vectorIndexName =
@@ -195,11 +201,6 @@ export class RagKnowledgeBaseStack extends Stack {
     // OpenSearch resources (not needed when using S3 Vectors)
     let collection: oss.CfnCollection | undefined;
     let ossIndex: OpenSearchServerlessIndex | undefined;
-    let accessPolicy: oss.CfnAccessPolicy | undefined;
-    let networkPolicy: oss.CfnSecurityPolicy | undefined;
-    let encryptionPolicy: oss.CfnSecurityPolicy | undefined;
-    let tagApplier: lambda.SingletonFunction | undefined;
-    let applyTagsResource: cdk.CustomResource | undefined;
 
     if (!useS3Vectors) {
       collection = new oss.CfnCollection(this, 'Collection', {
@@ -230,7 +231,7 @@ export class RagKnowledgeBaseStack extends Stack {
         })
       );
 
-      accessPolicy = new oss.CfnAccessPolicy(this, 'AccessPolicy', {
+      const accessPolicy = new oss.CfnAccessPolicy(this, 'AccessPolicy', {
         name: collectionName,
         policy: JSON.stringify([
           {
@@ -267,7 +268,7 @@ export class RagKnowledgeBaseStack extends Stack {
         type: 'data',
       });
 
-      networkPolicy = new oss.CfnSecurityPolicy(this, 'NetworkPolicy', {
+      const networkPolicy = new oss.CfnSecurityPolicy(this, 'NetworkPolicy', {
         name: collectionName,
         policy: JSON.stringify([
           {
@@ -287,26 +288,30 @@ export class RagKnowledgeBaseStack extends Stack {
         type: 'network',
       });
 
-      encryptionPolicy = new oss.CfnSecurityPolicy(this, 'EncryptionPolicy', {
-        name: collectionName,
-        policy: JSON.stringify({
-          Rules: [
-            {
-              Resource: [`collection/${collectionName}`],
-              ResourceType: 'collection',
-            },
-          ],
-          AWSOwnedKey: true,
-        }),
-        type: 'encryption',
-      });
+      const encryptionPolicy = new oss.CfnSecurityPolicy(
+        this,
+        'EncryptionPolicy',
+        {
+          name: collectionName,
+          policy: JSON.stringify({
+            Rules: [
+              {
+                Resource: [`collection/${collectionName}`],
+                ResourceType: 'collection',
+              },
+            ],
+            AWSOwnedKey: true,
+          }),
+          type: 'encryption',
+        }
+      );
 
       collection.node.addDependency(accessPolicy);
       collection.node.addDependency(networkPolicy);
       collection.node.addDependency(encryptionPolicy);
 
       // Apply tags via AWS SDK to avoid CloudFormation replacement errors
-      tagApplier = new lambda.SingletonFunction(this, 'TagApplier', {
+      const tagApplier = new lambda.SingletonFunction(this, 'TagApplier', {
         runtime: LAMBDA_RUNTIME_NODEJS,
         code: lambda.Code.fromAsset('custom-resources/apply-tags'),
         handler: 'apply-tags.handler',
@@ -315,7 +320,7 @@ export class RagKnowledgeBaseStack extends Stack {
         timeout: cdk.Duration.minutes(5),
       });
 
-      applyTagsResource = new cdk.CustomResource(this, 'ApplyTags', {
+      const applyTagsResource = new cdk.CustomResource(this, 'ApplyTags', {
         serviceToken: tagApplier.functionArn,
         resourceType: 'Custom::ApplyTags',
         properties: {
@@ -349,8 +354,8 @@ export class RagKnowledgeBaseStack extends Stack {
     }
 
     // S3 Vectors resources (only created when using S3 Vectors)
-    const s3VectorBucketName = `genu-s3vectors-kb${env.toLowerCase()}`;
-    const s3VectorIndexName = `genu-rag-kb-index${env.toLowerCase()}`;
+    const s3VectorBucketName = `${collectionName}-s3vectors`;
+    const s3VectorIndexName = `${collectionName}-s3vectors-index`;
     const s3VectorBucketArn = `arn:aws:s3vectors:${this.region}:${this.account}:bucket/${s3VectorBucketName}`;
     const s3VectorIndexArn = `${s3VectorBucketArn}/index/${s3VectorIndexName}`;
 
@@ -579,6 +584,13 @@ export class RagKnowledgeBaseStack extends Stack {
 
     // Web Crawler Data Source (GenU documentation site as sample)
     // S3 Vectors backend does not support WEB data sources
+    if (useS3Vectors) {
+      cdk.Annotations.of(this).addWarningV2(
+        '@genu/s3vectors-web-datasource',
+        'S3 Vectors backend does not support WEB data sources. Only S3 data sources are available.'
+      );
+    }
+
     if (!useS3Vectors) {
       new bedrock.CfnDataSource(this, 'WebCrawlerDataSource', {
         dataSourceConfiguration: {

--- a/packages/cdk/lib/rag-knowledge-base-stack.ts
+++ b/packages/cdk/lib/rag-knowledge-base-stack.ts
@@ -206,7 +206,9 @@ export class RagKnowledgeBaseStack extends Stack {
         name: collectionName,
         description: 'GenU Collection',
         type: 'VECTORSEARCH',
-        standbyReplicas: ragKnowledgeBaseStandbyReplicas ? 'ENABLED' : 'DISABLED',
+        standbyReplicas: ragKnowledgeBaseStandbyReplicas
+          ? 'ENABLED'
+          : 'DISABLED',
         // Do not specify tags here to avoid CloudFormation replacement errors
       });
 
@@ -285,23 +287,19 @@ export class RagKnowledgeBaseStack extends Stack {
         type: 'network',
       });
 
-      encryptionPolicy = new oss.CfnSecurityPolicy(
-        this,
-        'EncryptionPolicy',
-        {
-          name: collectionName,
-          policy: JSON.stringify({
-            Rules: [
-              {
-                Resource: [`collection/${collectionName}`],
-                ResourceType: 'collection',
-              },
-            ],
-            AWSOwnedKey: true,
-          }),
-          type: 'encryption',
-        }
-      );
+      encryptionPolicy = new oss.CfnSecurityPolicy(this, 'EncryptionPolicy', {
+        name: collectionName,
+        policy: JSON.stringify({
+          Rules: [
+            {
+              Resource: [`collection/${collectionName}`],
+              ResourceType: 'collection',
+            },
+          ],
+          AWSOwnedKey: true,
+        }),
+        type: 'encryption',
+      });
 
       collection.node.addDependency(accessPolicy);
       collection.node.addDependency(networkPolicy);
@@ -351,6 +349,11 @@ export class RagKnowledgeBaseStack extends Stack {
     }
 
     // S3 Vectors resources (only created when using S3 Vectors)
+    const s3VectorBucketName = `genu-s3vectors-kb${env.toLowerCase()}`;
+    const s3VectorIndexName = `genu-rag-kb-index${env.toLowerCase()}`;
+    const s3VectorBucketArn = `arn:aws:s3vectors:${this.region}:${this.account}:bucket/${s3VectorBucketName}`;
+    const s3VectorIndexArn = `${s3VectorBucketArn}/index/${s3VectorIndexName}`;
+
     let vectorBucket: cdk.CfnResource | undefined;
     let vectorIndex: cdk.CfnResource | undefined;
 
@@ -358,20 +361,23 @@ export class RagKnowledgeBaseStack extends Stack {
       vectorBucket = new cdk.CfnResource(this, 'S3VectorBucket', {
         type: 'AWS::S3Vectors::VectorBucket',
         properties: {
-          VectorBucketName: `genu-s3vectors-kb${env.toLowerCase()}`,
+          VectorBucketName: s3VectorBucketName,
         },
       });
 
       vectorIndex = new cdk.CfnResource(this, 'S3VectorIndex', {
         type: 'AWS::S3Vectors::Index',
         properties: {
-          VectorBucketName: `genu-s3vectors-kb${env.toLowerCase()}`,
-          IndexName: `genu-rag-kb-index${env.toLowerCase()}`,
+          VectorBucketName: s3VectorBucketName,
+          IndexName: s3VectorIndexName,
           DataType: 'float32',
           Dimension: parseInt(MODEL_VECTOR_MAPPING[embeddingModelId], 10),
           DistanceMetric: 'cosine',
           MetadataConfiguration: {
-            NonFilterableMetadataKeys: ['AMAZON_BEDROCK_TEXT', 'AMAZON_BEDROCK_METADATA'],
+            NonFilterableMetadataKeys: [
+              'AMAZON_BEDROCK_TEXT',
+              'AMAZON_BEDROCK_METADATA',
+            ],
           },
         },
       });
@@ -421,10 +427,7 @@ export class RagKnowledgeBaseStack extends Stack {
       knowledgeBaseRole.addToPolicy(
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
-          resources: [
-            `arn:aws:s3vectors:${this.region}:${this.account}:bucket/genu-s3vectors-kb${env.toLowerCase()}`,
-            `arn:aws:s3vectors:${this.region}:${this.account}:bucket/genu-s3vectors-kb${env.toLowerCase()}/index/genu-rag-kb-index${env.toLowerCase()}`,
-          ],
+          resources: [s3VectorBucketArn, s3VectorIndexArn],
           actions: [
             's3vectors:CreateIndex',
             's3vectors:DeleteIndex',
@@ -456,8 +459,14 @@ export class RagKnowledgeBaseStack extends Stack {
       })
     );
 
+    // When using S3 Vectors, append suffix to KB name to avoid name collision
+    // during CloudFormation Replacement (storageConfiguration is immutable)
+    const knowledgeBaseName = useS3Vectors
+      ? `${collectionName}-s3vectors`
+      : collectionName;
+
     const knowledgeBase = new bedrock.CfnKnowledgeBase(this, 'KnowledgeBase', {
-      name: collectionName,
+      name: knowledgeBaseName,
       roleArn: knowledgeBaseRole.roleArn,
       knowledgeBaseConfiguration: {
         type: 'VECTOR',
@@ -475,13 +484,13 @@ export class RagKnowledgeBaseStack extends Stack {
         },
       },
       storageConfiguration: useS3Vectors
-        ? ({
+        ? {
             type: 'S3_VECTORS',
             s3VectorsConfiguration: {
-              bucketArn: `arn:aws:s3vectors:${this.region}:${this.account}:bucket/genu-s3vectors-kb${env.toLowerCase()}`,
-              indexArn: `arn:aws:s3vectors:${this.region}:${this.account}:bucket/genu-s3vectors-kb${env.toLowerCase()}/index/genu-rag-kb-index${env.toLowerCase()}`,
+              vectorBucketArn: s3VectorBucketArn,
+              indexArn: s3VectorIndexArn,
             },
-          } as any)
+          }
         : {
             type: 'OPENSEARCH_SERVERLESS',
             opensearchServerlessConfiguration: {

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -121,6 +121,9 @@ const baseStackInputSchema = z.object({
   // RAG KB
   ragKnowledgeBaseEnabled: z.boolean().default(false),
   ragKnowledgeBaseId: z.string().nullish(),
+  ragKnowledgeBaseStorageType: z
+    .enum(['opensearch', 's3vectors'])
+    .default('opensearch'),
   embeddingModelId: z.string().default('amazon.titan-embed-text-v2:0'),
   ragKnowledgeBaseStandbyReplicas: z.boolean().default(false),
   ragKnowledgeBaseAdvancedParsing: z.boolean().default(false),

--- a/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
+++ b/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
@@ -3350,6 +3350,7 @@ exports[`GenerativeAiUseCases matches the snapshot (closed network mode) 2`] = `
     "KnowledgeBase": {
       "DependsOn": [
         "Collection",
+        "KnowledgeBaseRoleDefaultPolicyB3F66209",
         "OssIndexCustomResourceFB9548E5",
       ],
       "Properties": {
@@ -5414,6 +5415,9 @@ exports[`GenerativeAiUseCases matches the snapshot (closed network mode) 6`] = `
     },
     "RagKnowledgeBaseEnabled": {
       "Value": "true",
+    },
+    "RagKnowledgeBaseStorageType": {
+      "Value": "opensearch",
     },
     "Region": {
       "Value": "us-east-1",
@@ -13450,6 +13454,7 @@ exports[`GenerativeAiUseCases matches the snapshot (closed network mode) 6`] = `
           },
           "VITE_APP_RAG_ENABLED": "true",
           "VITE_APP_RAG_KNOWLEDGE_BASE_ENABLED": "true",
+          "VITE_APP_RAG_KNOWLEDGE_BASE_STORAGE_TYPE": "opensearch",
           "VITE_APP_REGION": "us-east-1",
           "VITE_APP_RESEARCH_AGENT_ENABLED": "false",
           "VITE_APP_SAMLAUTH_ENABLED": "false",
@@ -17265,6 +17270,7 @@ exports[`GenerativeAiUseCases matches the snapshot 2`] = `
     "KnowledgeBase": {
       "DependsOn": [
         "Collection",
+        "KnowledgeBaseRoleDefaultPolicyB3F66209",
         "OssIndexCustomResourceFB9548E5",
       ],
       "Properties": {
@@ -19277,6 +19283,9 @@ exports[`GenerativeAiUseCases matches the snapshot 6`] = `
     },
     "RagKnowledgeBaseEnabled": {
       "Value": "true",
+    },
+    "RagKnowledgeBaseStorageType": {
+      "Value": "opensearch",
     },
     "Region": {
       "Value": "us-east-1",
@@ -27138,6 +27147,7 @@ exports[`GenerativeAiUseCases matches the snapshot 6`] = `
           },
           "VITE_APP_RAG_ENABLED": "true",
           "VITE_APP_RAG_KNOWLEDGE_BASE_ENABLED": "true",
+          "VITE_APP_RAG_KNOWLEDGE_BASE_STORAGE_TYPE": "opensearch",
           "VITE_APP_REGION": "us-east-1",
           "VITE_APP_RESEARCH_AGENT_ENABLED": "false",
           "VITE_APP_SAMLAUTH_ENABLED": "false",

--- a/packages/web/src/pages/Setting.tsx
+++ b/packages/web/src/pages/Setting.tsx
@@ -19,6 +19,8 @@ import DialogConfirmDeleteAllChats from '../components/DialogConfirmDeleteAllCha
 const ragEnabled: boolean = import.meta.env.VITE_APP_RAG_ENABLED === 'true';
 const ragKnowledgeBaseEnabled: boolean =
   import.meta.env.VITE_APP_RAG_KNOWLEDGE_BASE_ENABLED === 'true';
+const ragKnowledgeBaseStorageType: string =
+  import.meta.env.VITE_APP_RAG_KNOWLEDGE_BASE_STORAGE_TYPE || 'opensearch';
 const agentEnabled: boolean = import.meta.env.VITE_APP_AGENT_ENABLED === 'true';
 
 const SettingItem = (props: {
@@ -225,7 +227,11 @@ const Setting = () => {
         />
         <SettingItem
           name={t('setting.items.rag_kb_enabled')}
-          value={ragKnowledgeBaseEnabled.toString()}
+          value={
+            ragKnowledgeBaseEnabled
+              ? `true (${ragKnowledgeBaseStorageType === 's3vectors' ? 'Amazon S3 Vectors' : 'OpenSearch Serverless'})`
+              : 'false'
+          }
         />
         <SettingItem
           name={t('setting.items.agent_enabled')}

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -32,6 +32,7 @@ export VITE_APP_FLOW_STREAM_FUNCTION_ARN=$(extract_value "$stack_output" 'Invoke
 export VITE_APP_FLOWS=$(extract_value "$stack_output" 'Flows' | base64 -d)
 export VITE_APP_RAG_ENABLED=$(extract_value "$stack_output" RagEnabled)
 export VITE_APP_RAG_KNOWLEDGE_BASE_ENABLED=$(extract_value "$stack_output" RagKnowledgeBaseEnabled)
+export VITE_APP_RAG_KNOWLEDGE_BASE_STORAGE_TYPE=$(extract_value "$stack_output" RagKnowledgeBaseStorageType)
 export VITE_APP_AGENT_ENABLED=$(extract_value "$stack_output" AgentEnabled)
 export VITE_APP_SELF_SIGN_UP_ENABLED=$(extract_value "$stack_output" SelfSignUpEnabled)
 export VITE_APP_MODEL_REGION=$(extract_value "$stack_output" ModelRegion)

--- a/web_devw_win.ps1
+++ b/web_devw_win.ps1
@@ -65,6 +65,7 @@ $env:VITE_APP_FLOW_STREAM_FUNCTION_ARN = Extract-Value $stack_output "InvokeFlow
 $env:VITE_APP_FLOWS = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($(Extract-Value $stack_output "Flows")))
 $env:VITE_APP_RAG_ENABLED = Extract-Value $stack_output "RagEnabled"
 $env:VITE_APP_RAG_KNOWLEDGE_BASE_ENABLED = Extract-Value $stack_output "RagKnowledgeBaseEnabled"
+$env:VITE_APP_RAG_KNOWLEDGE_BASE_STORAGE_TYPE = Extract-Value $stack_output "RagKnowledgeBaseStorageType"
 $env:VITE_APP_AGENT_ENABLED = Extract-Value $stack_output "AgentEnabled"
 $env:VITE_APP_SELF_SIGN_UP_ENABLED = Extract-Value $stack_output "SelfSignUpEnabled"
 $env:VITE_APP_MODEL_REGION = Extract-Value $stack_output "ModelRegion"


### PR DESCRIPTION
--- 以下、最新の実装内容 ---

### 概要

Bedrock Knowledge Base のベクトルストアとして、既存の OpenSearch Serverless に加え、Amazon S3 Vectors を選択できるようにしました。

関連イシュー: #1189

### 背景

[メンテナーコメント](https://github.com/aws-samples/generative-ai-use-cases/pull/1471#issuecomment-4186595969)のフィードバックに基づき、別ユースケースではなく**オプションによる切り替えで既存のKBの裏側をOpenSearchとS3 Vectors切り替えられる方式**で実装しています。

### S3 Vectors の特徴

- 従量課金（固定費なし）で、ベクトルの保存・クエリコストを最大90%削減
- インフラ管理不要（プロビジョニング不要）
- サブ秒のクエリレイテンシ

### 変更内容

#### パラメータ追加

`ragKnowledgeBaseStorageType` パラメータ（`'opensearch'` | `'s3vectors'`、デフォルト: `'opensearch'`）を追加。cdk.json / parameter.ts のどちらでも指定可能。

```json
{
  "ragKnowledgeBaseEnabled": true,
  "ragKnowledgeBaseStorageType": "s3vectors"
}
```

#### CDK (`packages/cdk/lib/rag-knowledge-base-stack.ts`)

- `useS3Vectors` フラグで条件分岐
- S3 Vectors 選択時: `AWS::S3Vectors::VectorBucket` + `AWS::S3Vectors::Index` を作成し、Knowledge Base の `storageConfiguration` に `S3_VECTORS` を指定
- OpenSearch 選択時: 既存動作（変更なし）
- S3 Vectors 選択時は Web Crawler データソースをスキップ（Bedrock の制約: S3 Vectors バックエンドでは WEB データソース非対応）
- `NonFilterableMetadataKeys` に `AMAZON_BEDROCK_TEXT` と `AMAZON_BEDROCK_METADATA` を設定（AWS コンソールのクイック作成と同等）
- IAM ポリシーの依存関係を明示的に設定し、Knowledge Base 作成時の権限伝播を保証

#### フロントエンド (`packages/web/src/pages/Setting.tsx`)

- 設定画面に `true (Amazon S3 Vectors)` / `true (OpenSearch Serverless)` と表示

"ragKnowledgeBaseStorageType": false,の場合
<img width="387" height="176" alt="false" src="https://github.com/user-attachments/assets/f8f45d1e-2f29-4401-8c2b-bdf80bf8e533" />

"ragKnowledgeBaseStorageType": "opensearch",　の場合
<img width="390" height="185" alt="OpenSearchの場合" src="https://github.com/user-attachments/assets/040a65ac-cfed-4ea6-986d-dbe0a1bd4633" />

"ragKnowledgeBaseStorageType": "s3vectors", の場合
<img width="389" height="176" alt="S3 Vectorsの場合" src="https://github.com/user-attachments/assets/e14bdf25-096c-47cc-a2e6-2c89925579ee" />

#### その他

- `setup-env.sh`, `web_devw_win.ps1`: 環境変数追加
- `docs/ja/DEPLOY_OPTION.md`, `docs/en/DEPLOY_OPTION.md`, `docs/ko/DEPLOY_OPTION.md`: 設定方法を追記

### 変更しないもの

- フロントエンドの RAG チャット画面（Knowledge Base Retrieve API がストレージを抽象化するため変更不要）
- Lambda 関数（`retrieveKnowledgeBase.ts`）
- 新規ページ / ルート

### S3 Vectors へのデータ同期方法

デプロイ後、以下の手順でデータを同期します：

1. S3 データソースバケットの `docs/` プレフィックス配下に PDF 等のドキュメントをアップロード
2. [Bedrock Knowledge Bases コンソール](https://console.aws.amazon.com/bedrock/home#/knowledge-bases)で対象の Knowledge Base を開く
3. Data sources セクションの `s3-data-source` を選択し **Sync** を実行

### テスト結果

- ✅ CDK スナップショットテスト全 PASS（15 test suites, 4 snapshots updated）
- ✅ S3 Vectors バックエンドでのデプロイ成功（全スタック CREATE_COMPLETE）
- ✅ RAG チャットでの検索・回答生成動作確認
- ✅ Knowledge Base データソース同期成功
- ✅ 設定画面にストレージタイプ表示確認
- ✅ デフォルト値 `opensearch` で既存動作に影響なし（スナップショットテストで確認）

### 既知の制限事項

- S3 Vectors バックエンドでは Web Crawler データソースが利用不可（AWS の制約）
- `storageType` を切り替える場合は以下の3ステップが必要：
  1. `ragKnowledgeBaseEnabled: false` に変更してデプロイ（メインスタックから Knowledge Base 参照を外す）
  2. CloudFormation コンソールで `RagKnowledgeBaseStack` を削除（modelRegion のリージョン）
  3. `ragKnowledgeBaseEnabled: true` + 新しい `ragKnowledgeBaseStorageType` でデプロイ

### 開発環境

本 PR の開発およびテストには [Kiro](https://kiro.dev/)（AI 開発環境）を使用しています。



--- 以下、初回Draft時の説明（参考） ---

# feat: Add S3 Vectors RAG support [Draft]

## 概要

Amazon S3 Vectors Knowledge Baseを使用したサーバレスRAG機能を追加します。

関連イシュー: #1189

## 背景と目的

Amazon Bedrock Knowledge Basesでは、ベクトルデータベースとして以下の4種類が選択可能です：

- ✅ Amazon OpenSearch Serverless（既存実装）
- 🚧 **Amazon S3 Vectors**（本PR）
- ⬜ Amazon Aurora PostgreSQL Serverless
- ⬜ Amazon Neptune Analytics (GraphRAG)

現在、GenUでは OpenSearch Serverless のみが実装されていますが、ユーザーが**各ベクトルストアの特性を比較検討しやすいように**、S3 Vectorsを「S3 Vectorsチャット」として独立した機能で実装を進めています。

### S3 Vectorsの特徴
- **コスト削減**: 従来のベクトルデータベースと比較して最大90%のコスト削減
- **サーバレス**: インフラ管理不要、自動スケーリング
- **シンプル**: S3にPDFをアップロードするだけで利用可能

## Draft PRをお願いする理由

### 1. アーキテクチャ設計のフィードバック

現在、各ベクトルストアを**独立したチャット機能**として実装していますが、以下の点についてご意見をいただきたいです：

- ✅ **独立実装のメリット**:
  - ユーザーが各ベクトルストアの特性を直接比較できる
  - 既存のKnowledge Base RAG（OpenSearch）に影響を与えない
  - 設定が独立しているため、切り替えが容易

- ❓ **懸念点**:
  - コードの重複が発生する可能性
  - 将来的に4種類すべてを実装した場合の保守性
  - より良い統合方法があるか

**ご相談**: 各ベクトルストアを独立したチャット機能として実装する方針は適切でしょうか？それとも、統合的なアプローチの方が望ましいでしょうか？

### 2. 開発環境について

本PRは**Kiro（AI開発アシスタント）を活用して開発**しています。

## 実装状況

### ✅ 完成している部分

#### バックエンド
- [x] S3 Vectors Knowledge Base統合
- [x] `s3VectorsApi.ts`: Knowledge Base Retrieve/RetrieveAndGenerate APIのラッパー
- [x] `predictStream.ts`: S3 Vectors RAG対応
- [x] CDK Construct: `rag-s3-vectors.ts`
- [x] 環境変数: `S3_VECTORS_KNOWLEDGE_BASE_ID`

#### フロントエンド
- [x] S3 Vectorsチャット画面: `RagS3VectorsPage.tsx`
- [x] カスタムフック: `useRagS3Vectors.ts`
- [x] ルーティング設定
- [x] 多言語対応（ja/en/ko）

#### インフラ
- [x] CDK設定パラメータ: `ragS3VectorsEnabled`, `s3VectorsKnowledgeBaseId`
- [x] IAM権限: Knowledge Base Retrieve/RetrieveAndGenerate

#### 動作確認
- [x] 基本的なRAGチャット機能
- [x] 日本語・英語の混在文書での検索
- [x] 複数PDFファイルの検索

### ⚠️ 実装中の部分

#### PDFダウンロード機能
- [x] `stack-input.ts`: `s3VectorsDataSourceBucketName`パラメータ追加
- [ ] `generative-ai-use-cases-stack.ts`: S3読み取り権限の付与
- [ ] 動作確認

**現在の問題**: PDFリンクをクリックすると`AccessDenied`エラーが発生
```xml
<Error>
  <Code>AccessDenied</Code>
  <Message>Lambda function is not authorized to perform: s3:GetObject</Message>
</Error>
```

**解決方法**: 既存のKnowledge Base RAGと同じパターンで、`getFileDownloadSignedUrlFunction`にS3読み取り権限を付与

### ❌ 未実装の部分

#### 自動インデックス化機能
- [ ] S3イベント通知の設定
- [ ] Lambda関数: インジェストジョブの自動実行
- [ ] エラーハンドリング

**アイディア**: S3にPDFをアップロードすると自動的にKnowledge Baseのインデックスが更新される仕組み

#### ドキュメント
- [ ] `DEPLOY_OPTION.md`の更新（日本語・英語）
- [ ] セットアップ手順の追加
- [ ] 制限事項の文書化

## 既知の問題と制限事項

### 1. ファイルサイズ制限
- **制限**: セマンティックチャンキングは1MB（1,000,000バイト）まで
- **影響**: 大きなPDFファイルはインジェスト失敗
- **対応策**: ファイル分割、または別のチャンキング戦略の検討

### 2. 画像ベースPDFの非対応
- **制限**: Amazon Bedrock default parserはテキストベースPDFのみ対応
- **影響**: スキャンPDFは「no text content found」エラー
- **対応策**: BDA (Bedrock Data Automation) parserの使用（追加コスト）

### 3. PDFダウンロード機能
- **状態**: 実装中
- **問題**: AccessDeniedエラー
- **対応**: 次のコミットで修正予定

## テスト結果

### 動作確認済み
- ✅ Knowledge Base作成（us-east-1リージョン）
- ✅ PDFファイルのインジェスト（4ファイル、合計約800KB）
- ✅ 日本語クエリでの検索
- ✅ 英語クエリでの検索
- ✅ RAGチャットでの回答生成
- ✅ 引用元の表示

**Note**: このPRはDraft状態です。完成後、正式なレビュー依頼を行います。
