### PR TITLE
fix: Research Agentのトークンカウントが0/0/0で表示される問題を修正

### DIFF
--- a/packages/cdk/lambda-python/research-agent-core-runtime/src/agent.py
+++ b/packages/cdk/lambda-python/research-agent-core-runtime/src/agent.py
@@ -157,7 +157,11 @@ class AgentManager:
             ) + "\n"
 
             yield json.dumps(
-                {"event": {"metadata": {"usage": {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0}}}},
+                {"event": {"metadata": {"usage": {
+                    "inputTokens": converter.total_input_tokens,
+                    "outputTokens": converter.total_output_tokens,
+                    "totalTokens": converter.total_input_tokens + converter.total_output_tokens,
+                }}}},
                 ensure_ascii=False,
             ) + "\n"
 

--- a/packages/cdk/lambda-python/research-agent-core-runtime/src/converters.py
+++ b/packages/cdk/lambda-python/research-agent-core-runtime/src/converters.py
@@ -13,6 +13,9 @@ class ContentBlockConverter:
     
     def __init__(self):
         self.current_block_index = 0
+        # トークン使用量の累計
+        self.total_input_tokens = 0
+        self.total_output_tokens = 0
     
     def convert_message_to_events(self, message: Any) -> Iterator[Dict[str, Any]]:
         """
@@ -26,11 +29,20 @@ class ContentBlockConverter:
         """
         message_type = type(message).__name__
         
-        # 内部メッセージ型（クライアントに送信しない）
-        internal_message_types = {"SystemMessage", "ResultMessage"}
-        
-        if message_type in internal_message_types:
+        # SystemMessage はスキップ
+        if message_type == "SystemMessage":
             logger.debug(f"Skipping internal message type: {message_type}")
+            return
+        
+        # ResultMessage からトークン使用量を抽出
+        if message_type == "ResultMessage":
+            usage = getattr(message, "usage", None)
+            if usage and isinstance(usage, dict):
+                self.total_input_tokens += usage.get("input_tokens", 0)
+                self.total_output_tokens += usage.get("output_tokens", 0)
+                logger.info(
+                    f"Token usage accumulated: input={self.total_input_tokens}, output={self.total_output_tokens}"
+                )
             return
         
         # AssistantMessage の場合（content 配列を持つ）


### PR DESCRIPTION
- converters.py: ResultMessageからusage dictを抽出しトークン使用量を累計
  - total_input_tokens/total_output_tokensフィールドを追加
  - ResultMessageをスキップせずusage.input_tokens/output_tokensを蓄積
- agent.py: ハードコードされた0/0/0をconverterの累計値に置き換え

## Description of Changes

修正内容
converters.py:
ContentBlockConverter に total_input_tokens/total_output_tokens フィールドを追加
ResultMessage を単純にスキップせず、usage dict から input_tokens/output_tokens を抽出して累計
複数ターンの会話でもトークン使用量が正しく蓄積される
agent.py:
ハードコードされた {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0} を converter.total_input_tokens/converter.total_output_tokens の累計値に置き換え
既存ユーザーへの影響
破壊的変更なし
UIのトークン表示が 0/0/0 から実際の使用量に変わるため、表示上の変化あり
Research Agent 以外のユースケースには影響なし

## Checklist

- [ ] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

Please list related issues as much as possible.
