### PR TITLE
fix: add transcribe to hiddenUseCases options

### DIFF
--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -27,6 +27,7 @@ const baseStackInputSchema = z.object({
       diagram: z.boolean().optional(),
       meetingMinutes: z.boolean().optional(),
       voiceChat: z.boolean().optional(),
+      transcribe: z.boolean().optional(),
     })
     .default({}),
   // API

--- a/packages/types/src/useCases.d.ts
+++ b/packages/types/src/useCases.d.ts
@@ -10,6 +10,7 @@ export type HiddenUseCases = {
   diagram?: boolean;
   meetingMinutes?: boolean;
   voiceChat?: boolean;
+  transcribe?: boolean;
 };
 
 export type HiddenUseCasesKeys = keyof HiddenUseCases;

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -268,12 +268,14 @@ const App: React.FC = () => {
           display: 'usecase' as const,
         }
       : null,
-    {
-      label: t('navigation.speechRecognition'),
-      to: '/transcribe',
-      icon: <PiSpeakerHighBold />,
-      display: 'tool' as const,
-    },
+    enabled('transcribe')
+      ? {
+          label: t('navigation.speechRecognition'),
+          to: '/transcribe',
+          icon: <PiSpeakerHighBold />,
+          display: 'tool' as const,
+        }
+      : null,
     optimizePromptEnabled
       ? {
           label: t('navigation.promptOptimization'),


### PR DESCRIPTION
## Description of Changes

The `transcribe` (speech recognition) menu item was not controllable via `hiddenUseCases` despite other use cases being configurable through this mechanism. This fix adds `transcribe` as an option to `hiddenUseCases`, allowing users to hide the speech recognition tool from the menu via `cdk.json`.

Changes:
- Added `transcribe` to `HiddenUseCases` type (`packages/types/src/useCases.d.ts`)
- Added `transcribe` to zod schema (`packages/cdk/lib/stack-input.ts`)
- Wrapped transcribe menu item with `enabled('transcribe')` (`packages/web/src/App.tsx`)

## Checklist

- [ ] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

N/A