### PR TITLE
Fix/configurable agent foundation model

### DIFF
--- a/docs/en/DEPLOY_OPTION.md
+++ b/docs/en/DEPLOY_OPTION.md
@@ -402,6 +402,34 @@ const envs: Record<string, Partial<StackInput>> = {
 }
 ```
 
+#### Customizing Agent Foundation Model
+
+You can customize the foundation model used by Code Interpreter and Search Agent. By default, `global.anthropic.claude-sonnet-4-6` is used.
+
+- `agentFoundationModel` : Specify the model to use for agents. Only models supported by Bedrock Agent are available.
+
+**Edit [parameter.ts](/packages/cdk/parameter.ts)**
+
+```typescript
+// parameter.ts
+const envs: Record<string, Partial<StackInput>> = {
+  dev: {
+    agentFoundationModel: 'global.anthropic.claude-sonnet-4-6',
+  },
+};
+```
+
+**Edit [packages/cdk/cdk.json](/packages/cdk/cdk.json)**
+
+```json
+// cdk.json
+{
+  "context": {
+    "agentFoundationModel": "global.anthropic.claude-sonnet-4-6"
+  }
+}
+```
+
 #### Deploying Search Agent
 
 Creates an Agent that connects to APIs to reference the latest information for responses. You can customize the Agent to add other actions and create multiple Agents to switch between.

--- a/docs/ja/DEPLOY_OPTION.md
+++ b/docs/ja/DEPLOY_OPTION.md
@@ -417,6 +417,34 @@ const envs: Record<string, Partial<StackInput>> = {
 }
 ```
 
+#### エージェントの基盤モデルのカスタマイズ
+
+Code Interpreter および検索エージェントで使用する基盤モデルをカスタマイズできます。デフォルトでは `global.anthropic.claude-sonnet-4-6` が使用されます。
+
+- `agentFoundationModel` : エージェントで利用するモデルを指定してください。Bedrock Agent がサポートするモデルのみ利用可能です。
+
+**[parameter.ts](/packages/cdk/parameter.ts) を編集**
+
+```typescript
+// parameter.ts
+const envs: Record<string, Partial<StackInput>> = {
+  dev: {
+    agentFoundationModel: 'global.anthropic.claude-sonnet-4-6',
+  },
+};
+```
+
+**[packages/cdk/cdk.json](/packages/cdk/cdk.json) を編集**
+
+```json
+// cdk.json
+{
+  "context": {
+    "agentFoundationModel": "global.anthropic.claude-sonnet-4-6"
+  }
+}
+```
+
 #### 検索エージェントのデプロイ
 
 API と連携し最新情報を参照して回答する Agent を作成します。Agent のカスタマイズを行い他のアクションを追加できるほか、複数の Agent を作成し切り替えることが可能です。

--- a/docs/ko/DEPLOY_OPTION.md
+++ b/docs/ko/DEPLOY_OPTION.md
@@ -403,6 +403,34 @@ const envs: Record<string, Partial<StackInput>> = {
 }
 ```
 
+#### 에이전트 기반 모델 사용자 정의
+
+Code Interpreter 및 Search Agent에서 사용하는 기반 모델을 사용자 정의할 수 있습니다. 기본적으로 `global.anthropic.claude-sonnet-4-6`이 사용됩니다.
+
+- `agentFoundationModel` : 에이전트에 사용할 모델을 지정합니다. Bedrock Agent가 지원하는 모델만 사용할 수 있습니다.
+
+**[parameter.ts](/packages/cdk/parameter.ts) 편집**
+
+```typescript
+// parameter.ts
+const envs: Record<string, Partial<StackInput>> = {
+  dev: {
+    agentFoundationModel: 'global.anthropic.claude-sonnet-4-6',
+  },
+};
+```
+
+**[packages/cdk/cdk.json](/packages/cdk/cdk.json) 편집**
+
+```json
+// cdk.json
+{
+  "context": {
+    "agentFoundationModel": "global.anthropic.claude-sonnet-4-6"
+  }
+}
+```
+
 #### Search Agent 배포
 
 API에 연결하여 최신 정보를 참조하여 응답하는 Agent를 생성합니다. Agent를 사용자 정의하여 다른 작업을 추가하고 여러 Agent를 생성하여 전환할 수 있습니다.

--- a/packages/cdk/cdk.json
+++ b/packages/cdk/cdk.json
@@ -59,6 +59,7 @@
     "speechToSpeechModelIds": ["amazon.nova-sonic-v1:0"],
     "endpointNames": [],
     "agentEnabled": false,
+    "agentFoundationModel": "global.anthropic.claude-sonnet-4-6",
     "searchAgentEnabled": false,
     "searchEngine": "Brave",
     "searchApiKey": "",

--- a/packages/cdk/lib/agent-stack.ts
+++ b/packages/cdk/lib/agent-stack.ts
@@ -17,13 +17,19 @@ export class AgentStack extends Stack {
   constructor(scope: Construct, id: string, props: AgentStackProps) {
     super(scope, id, props);
 
-    const { searchAgentEnabled, searchApiKey, searchEngine } = props.params;
+    const {
+      searchAgentEnabled,
+      searchApiKey,
+      searchEngine,
+      agentFoundationModel,
+    } = props.params;
 
     const agent = new Agent(this, 'Agent', {
       searchAgentEnabled,
       searchApiKey,
       searchEngine,
       vpc: props.vpc,
+      foundationModel: agentFoundationModel,
     });
 
     this.agents = agent.agents;

--- a/packages/cdk/lib/construct/agent.ts
+++ b/packages/cdk/lib/construct/agent.ts
@@ -26,6 +26,7 @@ interface AgentProps {
   readonly searchApiKey?: string | null;
   readonly searchEngine?: StackInput['searchEngine'];
   readonly vpc?: IVpc;
+  readonly foundationModel: string;
 }
 
 export class Agent extends Construct {
@@ -126,7 +127,7 @@ export class Agent extends Construct {
         idleSessionTtlInSeconds: 3600,
         autoPrepare: true,
         description: searchAgentDescription,
-        foundationModel: 'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
+        foundationModel: props.foundationModel,
         instruction: `You are an advanced assistant with the ability to search and retrieve information from the web to perform complex research tasks.
 Your main function is to solve problems and meet user requests by utilizing these capabilities.
 Your main characteristics and instructions are as follows.
@@ -171,7 +172,7 @@ Automatically detect the language of the user's request and think and answer in 
       idleSessionTtlInSeconds: 3600,
       autoPrepare: true,
       description: 'Code Interpreter',
-      foundationModel: 'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
+      foundationModel: props.foundationModel,
       instruction: `You are an advanced AI agent with the ability to execute code, generate charts, and perform complex data analysis. 
 Your main function is to solve problems and meet user requests by utilizing these capabilities.
 Your main characteristics and instructions are as follows.

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -133,6 +133,9 @@ const baseStackInputSchema = z.object({
   rerankingModelId: z.string().nullish(),
   // Agent
   agentEnabled: z.boolean().default(false),
+  agentFoundationModel: z
+    .string()
+    .default('global.anthropic.claude-sonnet-4-6'),
   searchAgentEnabled: z.boolean().default(false),
   searchApiKey: z.string().nullish(),
   searchEngine: z.enum(['Brave', 'Tavily']).default('Brave'),

--- a/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
+++ b/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
@@ -3402,7 +3402,7 @@ exports[`GenerativeAiUseCases matches the snapshot (closed network mode) 3`] = `
         },
         "AutoPrepare": true,
         "Description": "Code Interpreter",
-        "FoundationModel": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "FoundationModel": "global.anthropic.claude-sonnet-4-6",
         "IdleSessionTTLInSeconds": 3600,
         "Instruction": "You are an advanced AI agent with the ability to execute code, generate charts, and perform complex data analysis. 
 Your main function is to solve problems and meet user requests by utilizing these capabilities.
@@ -3515,7 +3515,7 @@ Automatically detect the language of the user's request and think and answer in 
         },
         "AutoPrepare": true,
         "Description": "Agent with Web Search Functionality",
-        "FoundationModel": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "FoundationModel": "global.anthropic.claude-sonnet-4-6",
         "IdleSessionTTLInSeconds": 3600,
         "Instruction": "You are an advanced assistant with the ability to search and retrieve information from the web to perform complex research tasks.
 Your main function is to solve problems and meet user requests by utilizing these capabilities.
@@ -26375,7 +26375,7 @@ exports[`GenerativeAiUseCases matches the snapshot 3`] = `
         },
         "AutoPrepare": true,
         "Description": "Code Interpreter",
-        "FoundationModel": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "FoundationModel": "global.anthropic.claude-sonnet-4-6",
         "IdleSessionTTLInSeconds": 3600,
         "Instruction": "You are an advanced AI agent with the ability to execute code, generate charts, and perform complex data analysis. 
 Your main function is to solve problems and meet user requests by utilizing these capabilities.
@@ -26488,7 +26488,7 @@ Automatically detect the language of the user's request and think and answer in 
         },
         "AutoPrepare": true,
         "Description": "Agent with Web Search Functionality",
-        "FoundationModel": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "FoundationModel": "global.anthropic.claude-sonnet-4-6",
         "IdleSessionTTLInSeconds": 3600,
         "Instruction": "You are an advanced assistant with the ability to search and retrieve information from the web to perform complex research tasks.
 Your main function is to solve problems and meet user requests by utilizing these capabilities.


### PR DESCRIPTION
## Description of Changes           
ハードコードされていたエージェントの基盤モデルを設定可能にしました。
                                          
- `agentFoundationModel` パラメータを追加（デフォルト:`global.anthropic.claude-sonnet-4-6`）                                 
- Code Interpreter と Search Agent のハードコードされた廃止予定モデルID を削除                                                              
- stack-input.ts、agent.ts、agent-stack.ts、cdk.json を更新  
- スナップショットテストを更新

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot
differences, execute `npm run cdk:test:update-snapshot` to update
snapshots

## Related Issues

#1516

以上、お手数ですがご確認お願いします。