### PR TITLE
fix error on non custom domain (alb domain) on closed network

### DIFF
--- a/docs/en/CLOSED_NETWORK.md
+++ b/docs/en/CLOSED_NETWORK.md
@@ -74,7 +74,7 @@ const envs: Record<string, Partial<StackInput>> = {
 ## Deployment Method
 
 After configuring the `closedNetwork...` options, deploy using the normal procedure written in [README.md](/README.md). An additional stack called ClosedNetworkStack\<environment name> will be deployed. (For convenience, \<environment name> will be omitted hereafter.)
-The URL for accessing GenU is output in the WebUrl of ClosedNetworkStack. Note that it's not the WebUrl of GenerativeAiUseCasesStack.
+The URL for accessing GenU is output in the ClosedNetworkWebUrl of ClosedNetworkStack. Note that it's not the WebUrl of GenerativeAiUseCasesStack.
 Also, GenU cannot be accessed until the deployment of GenerativeAiUseCasesStack is complete.
 
 ## Verification Method
@@ -102,7 +102,7 @@ Please copy the result of executing this command.
 
 ### Step 3. Access GenU
 
-Open the Edge browser within Windows, enter the URL displayed in the WebUrl output of ClosedNetworkStack to access GenU.
+Open the Edge browser within Windows, enter the URL displayed in the ClosedNetworkWebUrl output of ClosedNetworkStack to access GenU.
 SignUp is required on first access.
 
 ### About the Verification Instance
@@ -144,7 +144,7 @@ The endpoints that require name resolution from clients are as follows. Parts en
 
 | Service Name                | Role                        | Endpoint                                                     | How to Check Endpoint                                                                         |
 | --------------------------- | --------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
-| Application Load Balancer   | Web static file server      | Custom domain or internal-\<aaa>.\<region>.elb.amazonaws.com | Check with WebUrl output of ClosedNetworkStack                                                |
+| Application Load Balancer   | Web static file server      | Custom domain or internal-\<aaa>.\<region>.elb.amazonaws.com | Check with ClosedNetworkWebUrl output of ClosedNetworkStack                                   |
 | API Gateway                 | Main API                    | \<xxx>.execute-api.\<region>.amazonaws.com                   | Check with ApiEndpoint output of **GenerativeAiUseCasesStack**                                |
 | API Gateway                 | Cognito User Pool proxy     | \<yyy>.execute-api.\<region>.amazonaws.com                   | Check with CognitoPrivateProxyCognitoUserPoolProxyApiEndpoint... output of ClosedNetworkStack |
 | API Gateway                 | Cognito Identity Pool proxy | \<zzz>.execute-api.\<region>.amazonaws.com                   | Check with CognitoPrivateProxyCognitoIdPoolProxyApiEndpoint... output of ClosedNetworkStack   |

--- a/docs/ja/CLOSED_NETWORK.md
+++ b/docs/ja/CLOSED_NETWORK.md
@@ -75,7 +75,7 @@ const envs: Record<string, Partial<StackInput>> = {
 ## デプロイ方法
 
 `closedNetwork...` オプションを設定した上で [README.md](/README_ja.md) に記載されている通常の手順でデプロイしてください。ClosedNetworkStack\<環境名> というスタックが追加でデプロイされます。(便宜上、これ以降は \<環境名> を省略します。)
-GenU にアクセスするための URL は ClosedNetworkStack の WebUrl に出力されます。GenerativeAiUseCasesStack の WebUrl ではないことに注意してください。
+GenU にアクセスするための URL は ClosedNetworkStack の ClosedNetworkWebUrl に出力されます。GenerativeAiUseCasesStack の WebUrl ではないことに注意してください。
 また、GenerativeAiUseCasesStack のデプロイが完了するまでは GenU にアクセスできません。
 
 ## 検証方法
@@ -103,7 +103,7 @@ aws ssm get-parameter --name /ec2/keypair/key-aaaaaaaaaaaaaaaaa --region ap-nort
 
 ### 手順3. GenU にアクセス
 
-Windows 内で Edge ブラウザを開き、ClosedNetworkStack の WebUrl 出力に表示される URL を入力して GenU にアクセスします。
+Windows 内で Edge ブラウザを開き、ClosedNetworkStack の ClosedNetworkWebUrl 出力に表示される URL を入力して GenU にアクセスします。
 初回アクセス時は SignUp が必要です。
 
 ### 検証インスタンスについて
@@ -145,7 +145,7 @@ Certificate body には ssl.crt の中身、Certificate private key には ssl.k
 
 | サービス名                  | 役割                       | エンドポイント                                              | エンドポイントの確認方法                                  |
 | --------------------------- | -------------------------- | ----------------------------------------------------------- | --------------------------------------------------------- |
-| Application Load Balancer   | Web 静的ファイルのサーバー | 独自ドメイン or internal-\<aaa>.\<region>.elb.amazonaws.com | ClosedNetworkStack の出力の WebUrl で確認                 |
+| Application Load Balancer   | Web 静的ファイルのサーバー | 独自ドメイン or internal-\<aaa>.\<region>.elb.amazonaws.com | ClosedNetworkStack の出力の ClosedNetworkWebUrl で確認    |
 | API Gateway                 | メインの API               | \<xxx>.execute-api.\<region>.amazonaws.com                  | **GenerativeAiUseCasesStack** の出力の ApiEndpoint で確認 |
 | Cognito User Pool           | 認証                       | cognito-idp.\<region>.amazonaws.com                         | エンドポイントは固定                                      |
 | Cognito Identity Pool       | 一時認証情報の取得         | cognito-identity.\<region>.amazonaws.com                    | エンドポイントは固定                                      |

--- a/packages/cdk/lambda/api/index.ts
+++ b/packages/cdk/lambda/api/index.ts
@@ -5,8 +5,14 @@ const app = express();
 const port = process.env.PORT || 8080;
 
 // CORS middleware
+// Browsers lowercase the host portion of the Origin header per RFC, so we
+// compare case-insensitively — otherwise an ALB DNS name like
+// `internal-Closed-Close-...elb.amazonaws.com` (preserved from CDK construct
+// IDs) won't match the browser-sent `internal-closed-close-...` origin.
 const allowedOrigins = process.env.ALLOWED_ORIGINS
-  ? process.env.ALLOWED_ORIGINS.split(',').filter((o) => o.length > 0)
+  ? process.env.ALLOWED_ORIGINS.split(',')
+      .map((o) => o.trim().toLowerCase())
+      .filter((o) => o.length > 0)
   : [];
 app.use(
   cors({
@@ -19,7 +25,7 @@ app.use(
       if (
         !origin ||
         allowedOrigins.includes('*') ||
-        allowedOrigins.includes(origin)
+        allowedOrigins.includes(origin.toLowerCase())
       ) {
         callback(null, true);
       } else {

--- a/packages/cdk/lib/closed-network-stack.ts
+++ b/packages/cdk/lib/closed-network-stack.ts
@@ -4,6 +4,7 @@ import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import { ProcessedStackInput } from './stack-input';
 import { ClosedVpc, ClosedWeb, WindowsRdp, Resolver } from './construct';
+import { REMOTE_OUTPUT_KEYS } from './remote-output-keys';
 
 export interface ClosedNetworkStackProps extends StackProps {
   readonly params: ProcessedStackInput;
@@ -65,12 +66,23 @@ export class ClosedNetworkStack extends Stack {
       isSageMakerStudio: props.isSageMakerStudio,
     });
 
+    const albOrigin = `http://${closedWeb.alb.loadBalancerDnsName}`;
     const webUrl =
       closedVpc.hostedZone && closedNetworkCertificateArn
         ? `https://${closedVpc.hostedZone.zoneName}`
-        : `http://${closedWeb.alb.loadBalancerDnsName}`;
+        : albOrigin;
 
-    new CfnOutput(this, 'WebUrl', {
+    // Emitted unconditionally and consumed via cdk-remote-stack RemoteOutputs
+    // (not Fn::ImportValue). A plain CfnOutput has no cross-stack export
+    // constraint, so toggling closedNetworkDomainName never triggers the
+    // "Cannot delete export ... as it is in use" deadlock with the consuming
+    // GenerativeAiUseCasesStack — an ALB-DNS test env can move to a custom
+    // domain with a single deploy.
+    new CfnOutput(this, REMOTE_OUTPUT_KEYS.CLOSED_NETWORK_ALB_ORIGIN, {
+      value: albOrigin,
+    });
+
+    new CfnOutput(this, REMOTE_OUTPUT_KEYS.CLOSED_NETWORK_WEB_URL, {
       value: webUrl,
     });
 

--- a/packages/cdk/lib/create-stacks.ts
+++ b/packages/cdk/lib/create-stacks.ts
@@ -192,6 +192,7 @@ export const createStacks = (app: cdk.App, params: ProcessedStackInput) => {
       vpc: closedNetworkStack?.vpc,
       apiGatewayVpcEndpoint: closedNetworkStack?.apiGatewayVpcEndpoint,
       webBucket: closedNetworkStack?.webBucket,
+      closedNetworkStack: closedNetworkStack || undefined,
     }
   );
 
@@ -201,6 +202,9 @@ export const createStacks = (app: cdk.App, params: ProcessedStackInput) => {
   }
   if (agentCoreStack) {
     generativeAiUseCasesStack.addDependency(agentCoreStack);
+  }
+  if (closedNetworkStack) {
+    generativeAiUseCasesStack.addDependency(closedNetworkStack);
   }
 
   // Tag all resources for IAM principal-based cost allocation

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -27,6 +27,7 @@ import {
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { AgentCoreStack } from './agent-core-stack';
 import { ResearchAgentCoreStack } from './research-agent-core-stack';
+import { ClosedNetworkStack } from './closed-network-stack';
 import * as path from 'path';
 import { RemoteOutputs } from 'cdk-remote-stack';
 import { REMOTE_OUTPUT_KEYS } from './remote-output-keys';
@@ -60,6 +61,10 @@ export interface GenerativeAiUseCasesStackProps extends StackProps {
   readonly vpc?: IVpc;
   readonly apiGatewayVpcEndpoint?: InterfaceVpcEndpoint;
   readonly webBucket?: Bucket;
+  // ALB origin / web URL are read from this stack via cdk-remote-stack
+  // RemoteOutputs (no Fn::ImportValue, so no export-in-use deadlock when the
+  // custom domain is toggled).
+  readonly closedNetworkStack?: ClosedNetworkStack;
 }
 
 export class GenerativeAiUseCasesStack extends Stack {
@@ -396,8 +401,34 @@ export class GenerativeAiUseCasesStack extends Stack {
       brandingConfig: params.brandingConfig,
     });
 
-    // Update API handler with web URL for CORS
-    api.apiHandler.addEnvironment('ALLOWED_ORIGINS', web.webUrl);
+    // Update API handler with web URL for CORS.
+    // In closed network mode, web.webUrl is a placeholder ('CLOSED_NETWORK_MODE')
+    // because the real URL is owned by ClosedNetworkStack. Read it via
+    // RemoteOutputs (soft cross-stack ref, no Fn::ImportValue) and allow both
+    // the ALB DNS origin and the custom domain so an ALB-DNS test env can move
+    // to a domain with a single deploy and no CORS gap during the transition.
+    let allowedOrigins: string[] = [web.webUrl];
+    let displayWebUrl = web.webUrl;
+    if (props.closedNetworkStack) {
+      const closedNetworkOutputs = new RemoteOutputs(
+        this,
+        'ClosedNetworkRemoteOutputs',
+        {
+          stack: props.closedNetworkStack,
+          alwaysUpdate: true,
+          timeout: Duration.seconds(600),
+        }
+      );
+      const albOrigin = closedNetworkOutputs.get(
+        REMOTE_OUTPUT_KEYS.CLOSED_NETWORK_ALB_ORIGIN
+      );
+      const closedWebUrl = closedNetworkOutputs.get(
+        REMOTE_OUTPUT_KEYS.CLOSED_NETWORK_WEB_URL
+      );
+      allowedOrigins = [albOrigin, closedWebUrl];
+      displayWebUrl = closedWebUrl;
+    }
+    api.apiHandler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins.join(','));
 
     // Cfn Outputs
     new CfnOutput(this, 'Region', {
@@ -405,7 +436,7 @@ export class GenerativeAiUseCasesStack extends Stack {
     });
 
     new CfnOutput(this, 'WebUrl', {
-      value: web.webUrl,
+      value: displayWebUrl,
     });
 
     new CfnOutput(this, 'ApiEndpoint', {

--- a/packages/cdk/lib/remote-output-keys.ts
+++ b/packages/cdk/lib/remote-output-keys.ts
@@ -15,4 +15,8 @@ export const REMOTE_OUTPUT_KEYS = {
   RESEARCH_AGENT_CORE_RUNTIME_ARN: 'ResearchAgentCoreRuntimeArn',
   RESEARCH_AGENT_CORE_RUNTIME_NAME: 'ResearchAgentCoreRuntimeName',
   RESEARCH_AGENT_FILE_BUCKET_NAME: 'ResearchAgentFileBucketName',
+
+  // Closed Network Stack
+  CLOSED_NETWORK_ALB_ORIGIN: 'ClosedNetworkAlbOrigin',
+  CLOSED_NETWORK_WEB_URL: 'ClosedNetworkWebUrl',
 } as const;

--- a/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
+++ b/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
@@ -647,6 +647,38 @@ exports[`GenerativeAiUseCases matches the snapshot (AgentCore with VPC) 1`] = `
 exports[`GenerativeAiUseCases matches the snapshot (closed network mode) 1`] = `
 {
   "Outputs": {
+    "ClosedNetworkAlbOrigin": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "http://",
+            {
+              "Fn::GetAtt": [
+                "ClosedWebAlb02DA384F",
+                "DNSName",
+              ],
+            },
+          ],
+        ],
+      },
+    },
+    "ClosedNetworkWebUrl": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "http://",
+            {
+              "Fn::GetAtt": [
+                "ClosedWebAlb02DA384F",
+                "DNSName",
+              ],
+            },
+          ],
+        ],
+      },
+    },
     "ClosedWebServiceLoadBalancerDNS4C7B439A": {
       "Value": {
         "Fn::GetAtt": [
@@ -725,22 +757,6 @@ exports[`GenerativeAiUseCases matches the snapshot (closed network mode) 1`] = `
     "ResolverId": {
       "Value": {
         "Ref": "ResolverInbountEndpointA5AA48E5",
-      },
-    },
-    "WebUrl": {
-      "Value": {
-        "Fn::Join": [
-          "",
-          [
-            "http://",
-            {
-              "Fn::GetAtt": [
-                "ClosedWebAlb02DA384F",
-                "DNSName",
-              ],
-            },
-          ],
-        ],
       },
     },
     "WindowsRdpGetSSMKeyCommand20B8FDD2": {
@@ -5476,7 +5492,12 @@ exports[`GenerativeAiUseCases matches the snapshot (closed network mode) 6`] = `
       "Value": "[{"modelId":"amazon.nova-reel-v1:0","region":"us-east-1"}]",
     },
     "WebUrl": {
-      "Value": "CLOSED_NETWORK_MODE",
+      "Value": {
+        "Fn::GetAtt": [
+          "ClosedNetworkRemoteOutputs3C6891AF",
+          "ClosedNetworkWebUrl",
+        ],
+      },
     },
   },
   "Parameters": {
@@ -6013,7 +6034,26 @@ exports[`GenerativeAiUseCases matches the snapshot (closed network mode) 6`] = `
         },
         "Environment": {
           "Variables": {
-            "ALLOWED_ORIGINS": "CLOSED_NETWORK_MODE",
+            "ALLOWED_ORIGINS": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Fn::GetAtt": [
+                      "ClosedNetworkRemoteOutputs3C6891AF",
+                      "ClosedNetworkAlbOrigin",
+                    ],
+                  },
+                  ",",
+                  {
+                    "Fn::GetAtt": [
+                      "ClosedNetworkRemoteOutputs3C6891AF",
+                      "ClosedNetworkWebUrl",
+                    ],
+                  },
+                ],
+              ],
+            },
             "AUDIO_BUCKET_NAME": {
               "Ref": "TranscribeAudioBucket39DFF290",
             },
@@ -14106,6 +14146,277 @@ exports[`GenerativeAiUseCases matches the snapshot (closed network mode) 6`] = `
         },
       },
       "Type": "AWS::Cognito::UserPoolClient",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ClosedNetworkRemoteOutputs3C6891AF": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "ClosedNetworkRemoteOutputsMyProviderframeworkonEvent16B46A52",
+            "Arn",
+          ],
+        },
+        "randomString": "RANDOM-STRING-REPLACED",
+        "regionName": "us-east-1",
+        "stackName": "ClosedNetworkStack",
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ClosedNetworkRemoteOutputsMyHandlerD0F91374": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ClosedNetworkRemoteOutputsMyHandlerServiceRoleDefaultPolicy10D776F6",
+        "ClosedNetworkRemoteOutputsMyHandlerServiceRole9D1B9391",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": "cdk-hnb659fds-assets-123456890123-us-east-1",
+          "S3Key": "HASH-REPLACED.zip",
+        },
+        "Handler": "remote-outputs.on_event",
+        "Role": {
+          "Fn::GetAtt": [
+            "ClosedNetworkRemoteOutputsMyHandlerServiceRole9D1B9391",
+            "Arn",
+          ],
+        },
+        "Runtime": "python3.9",
+        "Tags": [
+          {
+            "Key": "app",
+            "Value": "genu",
+          },
+        ],
+        "Timeout": 600,
+      },
+      "Type": "AWS::Lambda::Function",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ClosedNetworkRemoteOutputsMyHandlerServiceRole9D1B9391": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "app",
+            "Value": "genu",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ClosedNetworkRemoteOutputsMyHandlerServiceRoleDefaultPolicy10D776F6": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "cloudformation:DescribeStacks",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ClosedNetworkRemoteOutputsMyHandlerServiceRoleDefaultPolicy10D776F6",
+        "Roles": [
+          {
+            "Ref": "ClosedNetworkRemoteOutputsMyHandlerServiceRole9D1B9391",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ClosedNetworkRemoteOutputsMyProviderframeworkonEvent16B46A52": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ClosedNetworkRemoteOutputsMyProviderframeworkonEventServiceRoleDefaultPolicyEE9B2FBC",
+        "ClosedNetworkRemoteOutputsMyProviderframeworkonEventServiceRole75061C4F",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": "cdk-hnb659fds-assets-123456890123-us-east-1",
+          "S3Key": "HASH-REPLACED.zip",
+        },
+        "Description": "AWS CDK resource provider framework - onEvent (GenerativeAiUseCasesStack/ClosedNetworkRemoteOutputs/MyProvider)",
+        "Environment": {
+          "Variables": {
+            "USER_ON_EVENT_FUNCTION_ARN": {
+              "Fn::GetAtt": [
+                "ClosedNetworkRemoteOutputsMyHandlerD0F91374",
+                "Arn",
+              ],
+            },
+          },
+        },
+        "Handler": "framework.onEvent",
+        "LoggingConfig": {
+          "ApplicationLogLevel": "FATAL",
+          "LogFormat": "JSON",
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "ClosedNetworkRemoteOutputsMyProviderframeworkonEventServiceRole75061C4F",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs22.x",
+        "Tags": [
+          {
+            "Key": "app",
+            "Value": "genu",
+          },
+        ],
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ClosedNetworkRemoteOutputsMyProviderframeworkonEventLogRetentionD0B10EBE": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "ClosedNetworkRemoteOutputsMyProviderframeworkonEvent16B46A52",
+              },
+            ],
+          ],
+        },
+        "RetentionInDays": 1,
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::LogRetention",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ClosedNetworkRemoteOutputsMyProviderframeworkonEventServiceRole75061C4F": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "app",
+            "Value": "genu",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ClosedNetworkRemoteOutputsMyProviderframeworkonEventServiceRoleDefaultPolicyEE9B2FBC": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "ClosedNetworkRemoteOutputsMyHandlerD0F91374",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "ClosedNetworkRemoteOutputsMyHandlerD0F91374",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "lambda:GetFunction",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "ClosedNetworkRemoteOutputsMyHandlerD0F91374",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ClosedNetworkRemoteOutputsMyProviderframeworkonEventServiceRoleDefaultPolicyEE9B2FBC",
+        "Roles": [
+          {
+            "Ref": "ClosedNetworkRemoteOutputsMyProviderframeworkonEventServiceRole75061C4F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
       "UpdateReplacePolicy": "Delete",
     },
     "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C1024MiBB049752D": {

--- a/packages/web/src/components/Mermaid/MermaidWithToggle.tsx
+++ b/packages/web/src/components/Mermaid/MermaidWithToggle.tsx
@@ -5,6 +5,7 @@ import { LuNetwork } from 'react-icons/lu';
 import { IoIosClose, IoMdDownload } from 'react-icons/io';
 import { TbSvg, TbPng } from 'react-icons/tb';
 import mermaid, { MermaidConfig } from 'mermaid';
+import { v4 as uuidv4 } from 'uuid';
 
 import ButtonCopy from '../ButtonCopy';
 import Button from '../Button';
@@ -37,7 +38,7 @@ const Mermaid: React.FC<MermaidProps> = (props) => {
   const render = useCallback(async () => {
     if (code) {
       try {
-        const { svg } = await mermaid.render(`m${crypto.randomUUID()}`, code);
+        const { svg } = await mermaid.render(`m${uuidv4()}`, code);
         const parser = new DOMParser();
         const doc = parser.parseFromString(svg, 'image/svg+xml');
         const svgElement = doc.querySelector('svg');

--- a/packages/web/src/components/Writer/ui/Button.tsx
+++ b/packages/web/src/components/Writer/ui/Button.tsx
@@ -23,8 +23,7 @@ const sizes = {
   icon: 'h-10 w-10',
 } as const;
 
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: keyof typeof variants;
   size?: keyof typeof sizes;
   asChild?: boolean;

--- a/packages/web/src/hooks/agentBuilder/useAgentBuilderList.ts
+++ b/packages/web/src/hooks/agentBuilder/useAgentBuilderList.ts
@@ -35,8 +35,8 @@ const useAgentBuilderList = () => {
   const isLoadingMyAgents = !myAgentsRaw && !myAgentsSWR.error;
   const canLoadMoreMyAgents = Boolean(
     myAgentsRaw &&
-      myAgentsRaw.length > 0 &&
-      myAgentsRaw[myAgentsRaw.length - 1]?.nextToken
+    myAgentsRaw.length > 0 &&
+    myAgentsRaw[myAgentsRaw.length - 1]?.nextToken
   );
   const loadMoreMyAgents = () => myAgentsSWR.setSize(myAgentsSWR.size + 1);
   const mutateMyAgents = myAgentsSWR.mutate;
@@ -56,8 +56,8 @@ const useAgentBuilderList = () => {
     !favoriteAgentsRaw && !favoriteAgentsSWR.error;
   const canLoadMoreFavoriteAgents = Boolean(
     favoriteAgentsRaw &&
-      favoriteAgentsRaw.length > 0 &&
-      favoriteAgentsRaw[favoriteAgentsRaw.length - 1]?.nextToken
+    favoriteAgentsRaw.length > 0 &&
+    favoriteAgentsRaw[favoriteAgentsRaw.length - 1]?.nextToken
   );
   const loadMoreFavoriteAgents = () =>
     favoriteAgentsSWR.setSize(favoriteAgentsSWR.size + 1);
@@ -77,8 +77,8 @@ const useAgentBuilderList = () => {
   const isLoadingPublicAgents = !publicAgentsRaw && !publicAgentsSWR.error;
   const canLoadMorePublicAgents = Boolean(
     publicAgentsRaw &&
-      publicAgentsRaw.length > 0 &&
-      publicAgentsRaw[publicAgentsRaw.length - 1]?.nextToken
+    publicAgentsRaw.length > 0 &&
+    publicAgentsRaw[publicAgentsRaw.length - 1]?.nextToken
   );
   const loadMorePublicAgents = () =>
     publicAgentsSWR.setSize(publicAgentsSWR.size + 1);

--- a/packages/web/src/hooks/usePromptGeneration.ts
+++ b/packages/web/src/hooks/usePromptGeneration.ts
@@ -6,6 +6,7 @@
  */
 
 import { useState, useCallback, useRef } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import { AvailableMCPServer } from 'generative-ai-use-cases';
 import useChatApi from './useChatApi';
 import { parseStreamChunk, extractTextFromChunks } from '../utils/streamParser';
@@ -141,7 +142,7 @@ export const usePromptGeneration = (
             content: prompt,
           },
         ],
-        id: crypto.randomUUID(),
+        id: uuidv4(),
       })) {
         if (abortControllerRef.current?.signal.aborted) {
           break;


### PR DESCRIPTION
## Description of Changes

- Fix CORS in closed-network HTTP environments: Closed-network deployments without a custom domain use an ALB DNS origin over HTTP. Fixed case mismatch between the CDK-generated ALB hostname and the browser-lowercased Origin header
- Fix crypto.randomUUID() requiring a secure context which does not work in ALB domain (HTTP) in closed network.

## Checklist

- [ ] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

