### PR TITLE
add model switch in extension

### DIFF
--- a/browser-extension/src/@types/settings.d.ts
+++ b/browser-extension/src/@types/settings.d.ts
@@ -4,13 +4,15 @@ export type Settings = {
   userPoolId: string;
   userPoolClientId: string;
   identityPoolId: string;
-  lambdaArn: strng;
+  lambdaArn: string;
   region: string;
   apiEndpoint: string;
   enabledSamlAuth: boolean;
   enabledSelfSignUp: boolean;
   cognitoDomain?: string;
   federatedIdentityProviderName?: string;
+  modelIds?: string;
+  modelId?: string;
 };
 
 export type PromptSetting = SystemContext & {

--- a/browser-extension/src/app/features/chat/useChat.ts
+++ b/browser-extension/src/app/features/chat/useChat.ts
@@ -8,12 +8,28 @@ import {
   replaceMessages,
 } from './chatSlice';
 import usePredict from './usePredict';
+import useSettings from '../settings/useSettings';
 import { Message } from '../../../@types/chat';
 import Browser from 'webextension-polyfill';
 import { PromptSetting } from '../../../@types/settings';
 import { StreamingChunk } from '../../../@types/backend-api';
 
+const parseFirstModelId = (modelIds: string): string => {
+  try {
+    const parsed = JSON.parse(modelIds);
+    if (Array.isArray(parsed) && parsed.length > 0) {
+      const first = parsed[0];
+      if (typeof first === 'object' && first !== null) return first.modelId?.trim() ?? '';
+      if (typeof first === 'string') return first.trim();
+    }
+  } catch {
+    // not JSON
+  }
+  return modelIds.split(',')[0]?.trim() ?? '';
+};
+
 const useChat = () => {
+  const { settings } = useSettings();
   // Keep the state for each tab because it can be launched in multiple screens
   const [tabId, setTabId] = useState<number>(-1);
   Browser.tabs?.getCurrent().then((tab) => {
@@ -59,9 +75,11 @@ const useChat = () => {
           });
         }
 
+        const effectiveModelId =
+          settings?.modelId || (settings?.modelIds ? parseFirstModelId(settings.modelIds) : '');
         const stream = predictStream({
           model: {
-            modelId: 'anthropic.claude-3-haiku-20240307-v1:0',
+            modelId: effectiveModelId,
             type: 'bedrock',
           },
           messages:

--- a/browser-extension/src/app/features/settings/Settings.tsx
+++ b/browser-extension/src/app/features/settings/Settings.tsx
@@ -7,6 +7,28 @@ import useAuth from '../common/hooks/useAuth';
 import Switch from '../common/components/Switch';
 import { IconWrapper } from '../../components/IconWrapper';
 
+const parseModelIds = (modelIds: string): string[] => {
+  try {
+    const parsed = JSON.parse(modelIds);
+    if (Array.isArray(parsed)) {
+      // ModelConfiguration[] format: [{modelId, region}, ...]
+      if (parsed.length > 0 && typeof parsed[0] === 'object' && parsed[0] !== null) {
+        return parsed
+          .map((m: { modelId?: string }) => m.modelId?.trim())
+          .filter((id): id is string => !!id);
+      }
+      // string[] format
+      return parsed.filter((id): id is string => typeof id === 'string' && !!id.trim());
+    }
+  } catch {
+    // not JSON — treat as comma-separated
+  }
+  return modelIds
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+};
+
 type Props = {
   onBack: () => void;
 };
@@ -18,6 +40,10 @@ const Settings: React.FC<Props> = (props) => {
   const enabledSamlAuth = useMemo(() => {
     return settings?.enabledSamlAuth ?? false;
   }, [settings?.enabledSamlAuth]);
+
+  const modelIdList = useMemo(() => {
+    return parseModelIds(settings?.modelIds ?? '');
+  }, [settings?.modelIds]);
 
   return (
     <div className="p-2">
@@ -98,6 +124,32 @@ const Settings: React.FC<Props> = (props) => {
               }}
             />
           </>
+        )}
+        <InputText
+          label="モデルID一覧（ModelIds）"
+          value={settings?.modelIds ?? ''}
+          onChange={(val) => {
+            setSetting('modelIds', val);
+          }}
+        />
+        {modelIdList.length > 0 && (
+          <div>
+            <div className="text-xs text-aws-font-color-gray">使用するモデル</div>
+            <select
+              className="border bg-aws-squid-ink brightness-150 rounded h-8 w-full px-1"
+              value={settings?.modelId ?? ''}
+              onChange={(e) => {
+                setSetting('modelId', e.target.value);
+              }}
+            >
+              <option value="">-- モデルを選択 --</option>
+              {modelIdList.map((id) => (
+                <option key={id} value={id}>
+                  {id}
+                </option>
+              ))}
+            </select>
+          </div>
         )}
       </div>
       <div className="flex justify-between">

--- a/browser-extension/src/app/features/settings/useSettings.ts
+++ b/browser-extension/src/app/features/settings/useSettings.ts
@@ -24,6 +24,8 @@ const useSettings = () => {
             enabledSelfSignUp: false,
             cognitoDomain: '',
             federatedIdentityProviderName: '',
+            modelIds: '',
+            modelId: '',
           };
         }
         if (key === 'enabledSamlAuth' || key === 'enabledSelfSignUp') {
@@ -65,6 +67,8 @@ const useSettings = () => {
       const federatedIdentityProviderName =
         value[SETTINGS_KEY]?.federatedIdentityProviderName ??
         import.meta.env.VITE_APP_SAML_COGNITO_FEDERATED_IDENTITY_PROVIDER_NAME;
+      const modelIds = value[SETTINGS_KEY]?.modelIds ?? import.meta.env.VITE_APP_MODEL_IDS ?? '';
+      const modelId = value[SETTINGS_KEY]?.modelId ?? import.meta.env.VITE_APP_MODEL_ID ?? '';
 
       setSettings({
         apiEndpoint: apiEndpoint ?? '',
@@ -77,6 +81,8 @@ const useSettings = () => {
         enabledSelfSignUp: enabledSelfSignUp ?? false,
         cognitoDomain: cognitoDomain ?? '',
         federatedIdentityProviderName: federatedIdentityProviderName ?? '',
+        modelIds: modelIds ?? '',
+        modelId: modelId ?? '',
       });
 
       // The required items differ depending on whether SAML authentication is enabled


### PR DESCRIPTION
## Description of Changes

- Since the extension was fixed to Claude 3 Haiku, I imported the model group defined in the backend stack to allow model selection.

## Checklist

- [ ] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

Please list related issues as much as possible.
