### PR TITLE
fix: RAG ナレッジベースのフィルタ(JSON extraData)をメッセージ検証で許可する

### DIFF
--- a/packages/cdk/lambda/createMessages.ts
+++ b/packages/cdk/lambda/createMessages.ts
@@ -24,16 +24,22 @@ const isRecord = (value: unknown): value is Record<string, unknown> => {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 };
 
-const isFilterValue = (value: unknown): boolean => {
-  if (
+const isScalarFilterValue = (value: unknown): boolean => {
+  return (
     typeof value === 'string' ||
     typeof value === 'number' ||
     typeof value === 'boolean'
-  ) {
+  );
+};
+
+const isFilterValue = (value: unknown): boolean => {
+  if (isScalarFilterValue(value)) {
     return true;
   }
 
-  return Array.isArray(value) && value.every(isFilterValue);
+  return (
+    Array.isArray(value) && value.length > 0 && value.every(isScalarFilterValue)
+  );
 };
 
 const isFilterAttribute = (value: unknown): boolean => {

--- a/packages/cdk/lambda/createMessages.ts
+++ b/packages/cdk/lambda/createMessages.ts
@@ -4,7 +4,97 @@ import { batchCreateMessages, findChatById } from './repository';
 
 const FILE_UPLOAD_BUCKET_NAME = process.env.BUCKET_NAME!;
 
+const FILTER_OPERATORS = new Set([
+  'equals',
+  'notEquals',
+  'greaterThan',
+  'greaterThanOrEquals',
+  'lessThan',
+  'lessThanOrEquals',
+  'in',
+  'notIn',
+  'startsWith',
+  'listContains',
+  'stringContains',
+]);
+
+const LOGICAL_FILTER_OPERATORS = new Set(['andAll', 'orAll']);
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const isFilterValue = (value: unknown): boolean => {
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return true;
+  }
+
+  return Array.isArray(value) && value.every(isFilterValue);
+};
+
+const isFilterAttribute = (value: unknown): boolean => {
+  return (
+    isRecord(value) &&
+    typeof value.key === 'string' &&
+    value.key.length > 0 &&
+    isFilterValue(value.value)
+  );
+};
+
+const isRetrievalFilter = (value: unknown, depth = 0): boolean => {
+  if (!isRecord(value) || depth > 5) return false;
+
+  const entries = Object.entries(value);
+  if (entries.length !== 1) return false;
+
+  const [operator, filterValue] = entries[0];
+  if (FILTER_OPERATORS.has(operator)) {
+    return isFilterAttribute(filterValue);
+  }
+
+  if (LOGICAL_FILTER_OPERATORS.has(operator)) {
+    return (
+      Array.isArray(filterValue) &&
+      filterValue.length > 0 &&
+      filterValue.every((nestedFilter) =>
+        isRetrievalFilter(nestedFilter, depth + 1)
+      )
+    );
+  }
+
+  return false;
+};
+
+const isValidFilterExtraData = (extra: ExtraData): boolean => {
+  if (
+    extra.type !== 'json' ||
+    extra.name !== 'filter' ||
+    extra.source.type !== 'json' ||
+    extra.source.mediaType !== 'application/json'
+  ) {
+    return false;
+  }
+
+  try {
+    return isRetrievalFilter(JSON.parse(extra.source.data));
+  } catch {
+    return false;
+  }
+};
+
 const isValidExtraData = (extra: ExtraData, bucketName: string): boolean => {
+  if (extra.source.type === 'json') {
+    return isValidFilterExtraData(extra);
+  }
+
+  if (extra.source.type !== 's3') {
+    return false;
+  }
+
   return extra.source.data.startsWith(
     `https://${bucketName}.s3.${process.env.AWS_REGION}.amazonaws.com/`
   );

--- a/packages/cdk/test/lambda/createMessages.test.ts
+++ b/packages/cdk/test/lambda/createMessages.test.ts
@@ -107,6 +107,154 @@ describe('createMessages Lambda handler', () => {
     });
   });
 
+  test('allows JSON extraData for RAG Knowledge Base filters', async () => {
+    const messages: ToBeRecordedMessage[] = [
+      {
+        messageId: 'msg123',
+        role: 'user',
+        content: 'Hello, world!',
+        usecase: 'rag-knowledge-base',
+        extraData: [
+          {
+            type: 'json',
+            name: 'filter',
+            source: {
+              type: 'json',
+              mediaType: 'application/json',
+              data: JSON.stringify({
+                in: { key: 'tag', value: ['Amazon Bedrock'] },
+              }),
+            },
+          },
+        ],
+      },
+    ];
+
+    const userId = 'testUser';
+    const chatId = 'chat123';
+    const expectedRecordedMessages: RecordedMessage[] = [
+      {
+        id: `chat#${chatId}`,
+        createdDate: '1234567890',
+        messageId: 'msg123',
+        role: 'user',
+        content: 'Hello, world!',
+        userId: `user#${userId}`,
+        feedback: 'none',
+        usecase: 'rag-knowledge-base',
+      },
+    ];
+
+    mockedFindChatById.mockResolvedValue({
+      id: `user#${userId}`,
+      createdDate: '1234567890',
+      chatId: `chat#${chatId}`,
+      usecase: '',
+      title: '',
+      updatedDate: '',
+    });
+    mockedBatchCreateMessages.mockResolvedValue(expectedRecordedMessages);
+
+    const result = await handler(
+      createAPIGatewayProxyEvent({ messages }, chatId, userId)
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(mockedBatchCreateMessages).toHaveBeenCalledWith(
+      messages,
+      userId,
+      chatId
+    );
+  });
+
+  test('returns 400 error when JSON filter extraData is malformed', async () => {
+    const messages: ToBeRecordedMessage[] = [
+      {
+        messageId: 'msg123',
+        role: 'user',
+        content: 'Hello, world!',
+        usecase: 'rag-knowledge-base',
+        extraData: [
+          {
+            type: 'json',
+            name: 'filter',
+            source: {
+              type: 'json',
+              mediaType: 'application/json',
+              data: '{invalid-json',
+            },
+          },
+        ],
+      },
+    ];
+
+    const userId = 'testUser';
+    const chatId = 'chat123';
+
+    mockedFindChatById.mockResolvedValue({
+      id: `user#${userId}`,
+      createdDate: '1234567890',
+      chatId: `chat#${chatId}`,
+      usecase: '',
+      title: '',
+      updatedDate: '',
+    });
+
+    const result = await handler(
+      createAPIGatewayProxyEvent({ messages }, chatId, userId)
+    );
+
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body)).toEqual({
+      message: 'Invalid extraData',
+    });
+    expect(mockedBatchCreateMessages).not.toHaveBeenCalled();
+  });
+
+  test('returns 400 error when JSON filter extraData does not match RetrievalFilter shape', async () => {
+    const messages: ToBeRecordedMessage[] = [
+      {
+        messageId: 'msg123',
+        role: 'user',
+        content: 'Hello, world!',
+        usecase: 'rag-knowledge-base',
+        extraData: [
+          {
+            type: 'json',
+            name: 'filter',
+            source: {
+              type: 'json',
+              mediaType: 'application/json',
+              data: JSON.stringify({ unexpected: 'filter' }),
+            },
+          },
+        ],
+      },
+    ];
+
+    const userId = 'testUser';
+    const chatId = 'chat123';
+
+    mockedFindChatById.mockResolvedValue({
+      id: `user#${userId}`,
+      createdDate: '1234567890',
+      chatId: `chat#${chatId}`,
+      usecase: '',
+      title: '',
+      updatedDate: '',
+    });
+
+    const result = await handler(
+      createAPIGatewayProxyEvent({ messages }, chatId, userId)
+    );
+
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body)).toEqual({
+      message: 'Invalid extraData',
+    });
+    expect(mockedBatchCreateMessages).not.toHaveBeenCalled();
+  });
+
   // Test for unauthorized access
   test('returns 403 error when user does not have access to chat', async () => {
     const messages: ToBeRecordedMessage[] = [

--- a/packages/cdk/test/lambda/createMessages.test.ts
+++ b/packages/cdk/test/lambda/createMessages.test.ts
@@ -255,6 +255,55 @@ describe('createMessages Lambda handler', () => {
     expect(mockedBatchCreateMessages).not.toHaveBeenCalled();
   });
 
+  test('returns 400 error when JSON filter value is a nested or empty array', async () => {
+    const userId = 'testUser';
+    const chatId = 'chat123';
+
+    mockedFindChatById.mockResolvedValue({
+      id: `user#${userId}`,
+      createdDate: '1234567890',
+      chatId: `chat#${chatId}`,
+      usecase: '',
+      title: '',
+      updatedDate: '',
+    });
+
+    const invalidValues = [[['Amazon Bedrock']], []];
+
+    for (const value of invalidValues) {
+      const messages: ToBeRecordedMessage[] = [
+        {
+          messageId: 'msg123',
+          role: 'user',
+          content: 'Hello, world!',
+          usecase: 'rag-knowledge-base',
+          extraData: [
+            {
+              type: 'json',
+              name: 'filter',
+              source: {
+                type: 'json',
+                mediaType: 'application/json',
+                data: JSON.stringify({ in: { key: 'tag', value } }),
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = await handler(
+        createAPIGatewayProxyEvent({ messages }, chatId, userId)
+      );
+
+      expect(result.statusCode).toBe(400);
+      expect(JSON.parse(result.body)).toEqual({
+        message: 'Invalid extraData',
+      });
+    }
+
+    expect(mockedBatchCreateMessages).not.toHaveBeenCalled();
+  });
+
   // Test for unauthorized access
   test('returns 403 error when user does not have access to chat', async () => {
     const messages: ToBeRecordedMessage[] = [


### PR DESCRIPTION
## Description of Changes

RAG チャットでナレッジベースのフィルタを適用すると、フィルタは `type: 'json'` (`source.type: 'json'`, `mediaType: 'application/json'`)の `extraData` として送信されます。

`createMessages` Lambda は各 `extraData` を「`source.data` がアプリの S3 バケット URL で始まること」で検証していたため、JSON フィルタの `extraData` は `400 Invalid extraData` で弾かれ、フィルタを伴うメッセージが記録できませんでした。

本 PR で `createMessages` の検証を JSON フィルタに対応させます。

- `source.type === 'json'` の場合、ペイロードを `JSON.parse` し、Bedrock の  `RetrievalFilter` として構造を検証します。
  - 比較演算子(`equals` / `notEquals` / `greaterThan` / `lessThan` / `in` / `notIn` / `startsWith` / `listContains` / `stringContains`)+ `FilterAttribute`(`{ key, value }`)、または
  - 論理演算子(`andAll` / `orAll`)+ 非空の入れ子フィルタ配列(深いネスト対策として再帰の深さを制限)。
  - 値はスカラー(string / number / boolean)か、非空のスカラー配列のみ許可。入れ子配列・空配列は拒否(現行 UI はこれらを生成しないため UI 動作への影響はなく、API の直接呼び出し等に対する防御的検証です)。
- `source.type === 's3'` は従来の URL チェックのまま。
- それ以外は従来どおり拒否。

`createMessages.test.ts` に、正常な KB フィルタ / 不正な JSON / `RetrievalFilter` 形に合わないペイロード / 入れ子・空配列の値、を網羅するユニットテストを追加しています。

### 既存ユーザーへの影響

バグ修正のみで破壊的変更はありません。RAG ナレッジベースのフィルタを伴うメッセージが正しく記録され、セッションを続けることができます。JSON ペイロードは保存前に構造検証(演算子のホワイトリスト + 再帰の深さ制限)を行います。

## Checklist

- [ ] 関連ドキュメントの修正(該当なし)
- [x] ローカル環境で動作確認(ユニットテスト pass、ローカル確認済み)
- [x] `npm run cdk:test` 実行(39 tests / 15 snapshots が pass、スナップショット差分なし)

## Related Issues

なし
