### PR TITLE
fix: モデル変更時に RAG チャット Knowledge Base のセッションをリセットする

### DIFF
--- a/packages/web/src/pages/RagKnowledgeBasePage.tsx
+++ b/packages/web/src/pages/RagKnowledgeBasePage.tsx
@@ -390,6 +390,16 @@ const RagKnowledgeBasePage: React.FC = () => {
     [setContent, updateSystemContext]
   );
 
+  const onChangeModel = useCallback(
+    (newModelId: string) => {
+      if (newModelId !== modelId) {
+        setSessionId(undefined);
+      }
+      setModelId(newModelId);
+    },
+    [modelId, setModelId, setSessionId]
+  );
+
   return (
     <>
       <div className={`${!isEmpty ? 'screen:pb-48' : ''} relative`}>
@@ -400,7 +410,7 @@ const RagKnowledgeBasePage: React.FC = () => {
         <div className="mt-2 flex w-full items-end justify-center lg:mt-0">
           <Select
             value={modelId}
-            onChange={setModelId}
+            onChange={onChangeModel}
             options={availableModels.map((m) => {
               return { value: m, label: modelDisplayName(m) };
             })}


### PR DESCRIPTION
## Description of Changes

RAG チャット(Knowledge Base) 画面で会話の途中にモデルを変更しても、既存のBedrock `RetrieveAndGenerate` の `sessionId` をそのまま再利用していました。

進行中の `RetrieveAndGenerate` セッションは、KB構成(`modelArn` を含む)を変更して継続できません。会話の途中でモデルを変更し同じ `sessionId` を再利用すると、Bedrock はエラーを返します。
そのため、いったん会話が始まった後にモデルを変更すると応答できていませんでした。

本 PR では、モデルセレクタに `onChangeModel` を追加し、選択モデルが実際に変わったときに `sessionId` を `undefined` にリセットします。これにより、次の発話から新しく選んだモデルで新規セッションが始まり、エラーにならずに続行できます。

### 既存ユーザーへの影響

本PRではモデル変更後はチャットが「新しいKBセッション」として継続します。GenU はマルチターンの文脈を Bedrock のセッションに依存しており(送信されるのは最新メッセージの `input.text` のみ)、モデル変更後は直前までの文脈が Bedrock 側に引き継がれません。一方で本実装では画面上の履歴は表示されたまま残ります。

この部分の挙動についてご意見伺いたく、検討した選択肢はこのあたりになります。

1. そもそもRAGチャットではセッション開始後のモデル変更をさせない
2. セッション開始後にモデルが変更されたらただ新しいセッションを開始する。前セッションの会話履歴は放置（本PR）
3. 2と同様だが会話履歴はクリア
4. 3と同様でクリア前にクリアしてよいか確認 

1か4が明示的でわかりやすいかもとも思いましたがいったんこれで実装したのでこのままで相談させてください🙏

## Checklist

- [ ] 関連ドキュメントの修正(該当なし)
- [x] ローカル環境で動作確認(eslint + `tsc --noEmit` pass、dev 環境にデプロイして挙動確認)
- [x] `npm run cdk:test` 実行(35 tests / 15 snapshots が pass、スナップショット差分なし。フロントのみの変更)

## Related Issues

なし