### PR TITLE
fix(web): tolerate code-fenced JSON in Image Generation assistant

### DIFF
--- a/packages/web/src/components/GenerateImageAssistant.tsx
+++ b/packages/web/src/components/GenerateImageAssistant.tsx
@@ -9,6 +9,7 @@ import { BaseProps } from '../@types/common';
 import Button from './Button';
 import { useTranslation } from 'react-i18next';
 import { MODELS } from '../hooks/useModel';
+import { parseImageAssistantContent } from './parseImageAssistantContent';
 
 type Props = BaseProps & {
   modelId: string;
@@ -67,24 +68,10 @@ const GenerateImageAssistant: React.FC<Props> = (props) => {
             },
           };
         }
-        try {
-          return {
-            role: 'assistant',
-            content: JSON.parse(m.content),
-          };
-        } catch (e) {
-          console.error(e);
-          return {
-            role: 'assistant',
-            content: {
-              prompt: null,
-              negativePrompt: null,
-              comment: '',
-              error: true,
-              recommendedStylePreset: [],
-            },
-          };
-        }
+        return {
+          role: 'assistant',
+          content: parseImageAssistantContent(m.content),
+        };
       }
     });
   }, [loading, messages]);

--- a/packages/web/src/components/parseImageAssistantContent.ts
+++ b/packages/web/src/components/parseImageAssistantContent.ts
@@ -1,0 +1,75 @@
+// Parses an Image Generation assistant message into its structured payload.
+//
+// The assistant is prompted to return only a JSON object
+// ({ prompt, negativePrompt, comment, recommendedStylePreset }), but in
+// multi-turn sessions the model frequently wraps the 2nd+ response in a
+// Markdown code fence (```json ... ```) or surrounds it with prose. A bare
+// JSON.parse then throws, the prompt/preset are lost, and the UI shows an
+// error on the second turn even though the response is otherwise valid.
+//
+// This helper strips such fences/prose defensively before parsing. On
+// genuinely unparseable output it returns the same error shape the call site
+// previously produced in its catch block, so truly-bad output still degrades
+// gracefully. See aws-samples/generative-ai-use-cases#1392.
+
+export type ImageAssistantContent = {
+  prompt: string | null;
+  negativePrompt: string | null;
+  comment: string;
+  recommendedStylePreset: string[];
+  error?: boolean;
+};
+
+const errorContent = (): ImageAssistantContent => ({
+  prompt: null,
+  negativePrompt: null,
+  comment: '',
+  error: true,
+  recommendedStylePreset: [],
+});
+
+// Strip a single leading ```/```json fence and a trailing ``` fence, if present.
+const stripCodeFence = (text: string): string => {
+  const fenced = text.match(/^```(?:[a-zA-Z0-9_-]+)?\s*\n?([\s\S]*?)\n?```$/);
+  return fenced ? fenced[1].trim() : text;
+};
+
+const tryParseObject = (text: string): ImageAssistantContent | null => {
+  try {
+    const parsed = JSON.parse(text);
+    // The call site reads object fields (e.g. recommendedStylePreset.flatMap),
+    // so only a plain object is a usable payload — reject primitives/arrays.
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as ImageAssistantContent;
+    }
+  } catch {
+    // fall through
+  }
+  return null;
+};
+
+export const parseImageAssistantContent = (
+  raw: string
+): ImageAssistantContent => {
+  const trimmed = (raw ?? '').trim();
+
+  // 1. Direct parse (the common, well-formed case).
+  // 2. After stripping a surrounding Markdown code fence.
+  const unfenced = stripCodeFence(trimmed);
+  const direct = tryParseObject(unfenced) ?? tryParseObject(trimmed);
+  if (direct) {
+    return direct;
+  }
+
+  // 3. Last resort: extract the outermost {...} when prose surrounds the JSON.
+  const start = unfenced.indexOf('{');
+  const end = unfenced.lastIndexOf('}');
+  if (start !== -1 && end > start) {
+    const extracted = tryParseObject(unfenced.slice(start, end + 1));
+    if (extracted) {
+      return extracted;
+    }
+  }
+
+  return errorContent();
+};

--- a/packages/web/tests/components/GenerateImageAssistant/parseImageAssistantContent.test.ts
+++ b/packages/web/tests/components/GenerateImageAssistant/parseImageAssistantContent.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { parseImageAssistantContent } from '../../../src/components/parseImageAssistantContent';
+
+// The Image Generation assistant asks the LLM to return a JSON object
+// ({ prompt, negativePrompt, comment, recommendedStylePreset }). In multi-turn
+// sessions the model frequently wraps the 2nd+ response in a Markdown code
+// fence (```json ... ```), which makes a bare JSON.parse throw and loses the
+// prompt/preset. parseImageAssistantContent strips such fences defensively
+// before parsing, while preserving the existing error shape on truly-bad output.
+// See aws-samples/generative-ai-use-cases#1392.
+
+const payload = {
+  prompt: 'a serene mountain lake at dawn',
+  negativePrompt: 'blurry, low quality',
+  comment: 'A calm landscape scene.',
+  recommendedStylePreset: ['photographic', 'anime'],
+};
+
+const errorShape = {
+  prompt: null,
+  negativePrompt: null,
+  comment: '',
+  error: true,
+  recommendedStylePreset: [],
+};
+
+describe('parseImageAssistantContent', () => {
+  it('parses a plain JSON object', () => {
+    expect(parseImageAssistantContent(JSON.stringify(payload))).toEqual(
+      payload
+    );
+  });
+
+  it('parses a ```json-fenced object to the same result as the unfenced one', () => {
+    const fenced = '```json\n' + JSON.stringify(payload, null, 2) + '\n```';
+    expect(parseImageAssistantContent(fenced)).toEqual(payload);
+  });
+
+  it('parses a bare ```-fenced object (no language tag)', () => {
+    const fenced = '```\n' + JSON.stringify(payload) + '\n```';
+    expect(parseImageAssistantContent(fenced)).toEqual(payload);
+  });
+
+  it('tolerates leading/trailing whitespace around the fence', () => {
+    const fenced =
+      '\n\n  ```json\n' + JSON.stringify(payload) + '\n```  \n\n';
+    expect(parseImageAssistantContent(fenced)).toEqual(payload);
+  });
+
+  it('extracts the outermost {...} when prose surrounds the JSON', () => {
+    const prose =
+      'Sure! Here is the prompt you asked for:\n' +
+      JSON.stringify(payload) +
+      '\nLet me know if you want changes.';
+    expect(parseImageAssistantContent(prose)).toEqual(payload);
+  });
+
+  it('returns the error shape for genuinely invalid output', () => {
+    expect(parseImageAssistantContent('not json at all')).toEqual(errorShape);
+  });
+
+  it('returns the error shape for an empty string', () => {
+    expect(parseImageAssistantContent('')).toEqual(errorShape);
+  });
+
+  it('returns the error shape when the JSON is a bare primitive', () => {
+    // A valid-JSON primitive is not a usable assistant payload; the component
+    // expects an object and would crash on content.recommendedStylePreset.
+    expect(parseImageAssistantContent('42')).toEqual(errorShape);
+  });
+
+  it('returns the error shape when the JSON is an array', () => {
+    expect(parseImageAssistantContent('[1, 2, 3]')).toEqual(errorShape);
+  });
+});


### PR DESCRIPTION
## Description of Changes

Fixes #1392 — Image Generation fails on the second prompt because a ` ```json ` code-block prefix causes a JSON parse error.

**Root cause.** The Image Generation assistant prompts the model to return *only* a JSON object (`prompt` / `negativePrompt` / `comment` / `recommendedStylePreset`), and the call site parsed each assistant message with a bare `JSON.parse(m.content)` (`packages/web/src/components/GenerateImageAssistant.tsx`). In multi-turn sessions the model frequently wraps the 2nd+ response in a Markdown code fence (` ```json ... ``` `). The bare `JSON.parse` then throws, the code falls into its `catch`, sets `error: true`, and the prompt/preset are lost — exactly the "1st prompt works, 2nd fails" symptom in the issue.

**Fix.** Extract a small, pure helper `parseImageAssistantContent(raw)` that:

1. trims whitespace,
2. strips a surrounding Markdown code fence (` ```json ` / bare ` ``` `),
3. as a last resort, extracts the outermost `{ ... }` when prose surrounds the JSON,
4. then `JSON.parse`s and validates the result is a plain object.

On genuinely unparseable output it returns the **same** `{ prompt: null, …, error: true }` shape the call site produced before, so truly-bad responses still degrade gracefully (the existing retry UI is unchanged). The component call site now delegates to this helper.

I fixed this on the **parse side** rather than hardening the system prompt because it is deterministic: regardless of whether the model emits a fence, the frontend recovers. A prompt-side change ("never use code fences") only lowers the failure rate — it can't eliminate it, since the model is probabilistic. The two are complementary; this PR is the robust half. Happy to adjust if maintainers prefer a prompt-side tweak as well.

No backend / CDK / API surface is touched; the change is a single call-site swap plus an additive, backward-compatible helper.

## Checklist

- [ ] Modified relevant documentation — *n/a (internal bug fix, no user-facing docs)*
- [x] Verified operation in local environment — `npm -w packages/web run test` (278 passing, incl. the new cases), `npm run custom-lint:build && npm run web:lint` clean, `npm run web:build` green (Node 22)
- [ ] Executed `npm run cdk:test` … — *n/a (no CDK changes)*

### Tests

Added `packages/web/tests/components/GenerateImageAssistant/parseImageAssistantContent.test.ts` covering: plain JSON, ` ```json `-fenced, bare ` ``` `-fenced, leading/trailing whitespace, prose-wrapped, invalid → `error: true`, and non-object JSON (primitive/array) → `error: true`. A fenced payload and its unfenced equivalent now parse to the identical object.

## Related Issues

- Fixes #1392
