### PR TITLE
feat(chat-history): サイドバーにユースケース別アイコンを表示し議事録を履歴に永続化

### DIFF
--- a/packages/cdk/lambda/predictTitle.ts
+++ b/packages/cdk/lambda/predictTitle.ts
@@ -17,6 +17,18 @@ export const handler = async (
 
     const req = JSON.parse(event.body) as PredictTitleRequest;
 
+    console.log(
+      'predictTitle request:',
+      JSON.stringify({
+        hasPrompt: !!req.prompt,
+        chatId: req.chat?.chatId,
+        chatPK: req.chat?.id,
+        createdDate: req.chat?.createdDate,
+        usecase: req.chat?.usecase,
+        id: req.id,
+      })
+    );
+
     // Validation
     if (!req.prompt || !req.chat?.id || !req.chat?.createdDate || !req.id) {
       throw new Error('Invalid request format');
@@ -41,7 +53,12 @@ export const handler = async (
         '$2'
       ) ?? '';
 
-    await setChatTitle(req.chat.id, req.chat.createdDate, title);
+    await setChatTitle(
+      req.chat.id,
+      req.chat.createdDate,
+      title,
+      req.chat.usecase
+    );
 
     return {
       statusCode: 200,

--- a/packages/cdk/lambda/repository.ts
+++ b/packages/cdk/lambda/repository.ts
@@ -384,8 +384,17 @@ export const batchCreateMessages = async (
 export const setChatTitle = async (
   id: string,
   createdDate: string,
-  title: string
+  title: string,
+  usecase?: string
 ) => {
+  const updateExprParts = ['title = :title'];
+  const exprValues: Record<string, string> = { ':title': title };
+
+  if (usecase) {
+    updateExprParts.push('usecase = :usecase');
+    exprValues[':usecase'] = usecase;
+  }
+
   const res = await dynamoDbDocument.send(
     new UpdateCommand({
       TableName: TABLE_NAME,
@@ -393,10 +402,8 @@ export const setChatTitle = async (
         id: id,
         createdDate: createdDate,
       },
-      UpdateExpression: 'set title = :title',
-      ExpressionAttributeValues: {
-        ':title': title,
-      },
+      UpdateExpression: `set ${updateExprParts.join(', ')}`,
+      ExpressionAttributeValues: exprValues,
       ReturnValues: 'ALL_NEW',
     })
   );

--- a/packages/cdk/lambda/updateTitle.ts
+++ b/packages/cdk/lambda/updateTitle.ts
@@ -27,7 +27,8 @@ export const handler = async (
     const updatedChat = await setChatTitle(
       chatItem?.id,
       chatItem?.createdDate,
-      req.title
+      req.title,
+      req.usecase
     );
 
     return {

--- a/packages/types/src/protocol.d.ts
+++ b/packages/types/src/protocol.d.ts
@@ -87,6 +87,7 @@ export type UpdateFeedbackResponse = {
 
 export type UpdateTitleRequest = {
   title: string;
+  usecase?: string;
 };
 
 export type UpdateTitleResponse = {

--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -157,7 +157,7 @@ chat:
   drop_files: Drop files here
   hint_cmd_enter: ⌘ + Enter to Submit
   hint_ctrl_enter: Ctrl + Enter to Submit
-  history: Conversation History
+  history: History
   initialize: Initialize
   open_link: Open Link
   prompt_examples: Prompt Examples

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -146,7 +146,7 @@ chat:
   drop_files: ファイルをドロップしてください
   hint_cmd_enter: ⌘ + Enter で送信
   hint_ctrl_enter: Ctrl + Enter で送信
-  history: 会話履歴
+  history: 履歴
   initialize: 初期化
   open_link: リンクを開く
   prompt_examples: プロンプト例

--- a/packages/web/public/locales/translation/ko.yaml
+++ b/packages/web/public/locales/translation/ko.yaml
@@ -27,7 +27,7 @@ chat:
   drop_files: 파일을 여기에 드롭
   hint_cmd_enter: ⌘ + Enter로 전송
   hint_ctrl_enter: Ctrl + Enter로 전송
-  history: 대화 기록
+  history: 기록
   initialize: 초기화
   model_parameters: 모델 매개변수
   open_link: 링크 열기

--- a/packages/web/public/locales/translation/th.yaml
+++ b/packages/web/public/locales/translation/th.yaml
@@ -17,7 +17,7 @@ chat:
   drop_files: วางไฟล์ที่นี่
   hint_cmd_enter: ⌘ + Enter เพื่อส่ง
   hint_ctrl_enter: Ctrl + Enter เพื่อส่ง
-  history: ประวัติการสนทนา
+  history: ประวัติ
   initialize: เริ่มต้นใหม่
   open_link: เปิดลิงก์
   prompt_examples: ตัวอย่าง prompt

--- a/packages/web/public/locales/translation/vi.yaml
+++ b/packages/web/public/locales/translation/vi.yaml
@@ -17,7 +17,7 @@ chat:
   drop_files: Vui lòng thả file
   hint_cmd_enter: ⌘ + Enter để gửi
   hint_ctrl_enter: Ctrl + Enter để gửi
-  history: Lịch sử cuộc trò chuyện
+  history: Lịch sử
   initialize: Khởi tạo
   open_link: Mở liên kết
   prompt_examples: Ví dụ prompt

--- a/packages/web/src/components/ChatListItem.tsx
+++ b/packages/web/src/components/ChatListItem.tsx
@@ -8,10 +8,11 @@ import React, {
 } from 'react';
 import { BaseProps } from '../@types/common';
 import { Link } from 'react-router-dom';
-import { PiChat, PiCheck, PiPencilLine, PiTrash, PiX } from 'react-icons/pi';
+import { PiCheck, PiPencilLine, PiTrash, PiX } from 'react-icons/pi';
 import ButtonIcon from './ButtonIcon';
 import { Chat } from 'generative-ai-use-cases';
 import { decomposeId } from '../utils/ChatUtils';
+import { getUseCaseIcon } from '../utils/UseCaseIconMap';
 import DialogConfirmDeleteChat from './DialogConfirmDeleteChat';
 
 type Props = BaseProps & {
@@ -114,9 +115,7 @@ const ChatListItem: React.FC<Props> = (props) => {
         to={`/chat/${chatId}`}>
         <div
           className={`flex h-8 max-h-5 w-full justify-start overflow-hidden`}>
-          <div className="mr-2 ">
-            <PiChat />
-          </div>
+          <div className="mr-2 ">{getUseCaseIcon(props.chat.usecase)}</div>
           <div className="relative flex-1 text-ellipsis break-all">
             {editing ? (
               <input

--- a/packages/web/src/components/agentBuilder/AgentChatUnified.tsx
+++ b/packages/web/src/components/agentBuilder/AgentChatUnified.tsx
@@ -20,6 +20,11 @@ import ButtonIcon from '../ButtonIcon';
 import Select from '../Select';
 
 // Define file limits for the chat interface
+// File size limits for AgentCore (AgentCore Runtime route: Frontend → AgentCore Runtime → Bedrock Converse API)
+// - AgentCore Runtime payload limit: 100MB (not a bottleneck)
+// - Anthropic Claude max request size: 32MB for the entire HTTP request body
+// - Nova PDF/DOCX direct upload limit: 25MB combined (model-side error if exceeded)
+// - Setting to 32MB as the upper bound based on Claude's documented limit
 const fileLimit: FileLimit = {
   accept: {
     doc: [
@@ -39,7 +44,7 @@ const fileLimit: FileLimit = {
     video: [],
   },
   maxFileCount: 5,
-  maxFileSizeMB: 10,
+  maxFileSizeMB: 32,
   maxImageFileCount: 5,
   maxImageFileSizeMB: 5,
   maxVideoFileCount: 0,

--- a/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
+++ b/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
@@ -44,8 +44,10 @@ const ragEnabled: boolean = import.meta.env.VITE_APP_RAG_ENABLED === 'true';
 const ragKnowledgeBaseEnabled: boolean =
   import.meta.env.VITE_APP_RAG_KNOWLEDGE_BASE_ENABLED === 'true';
 
-// Match pages/ChatPage.tsx
-// If a difference occurs, update it
+// File size limits for UseCaseBuilder (Lambda route: API Gateway → Lambda → Bedrock Converse API)
+// - Lambda synchronous payload limit: 6MB
+// - File data is base64-encoded in the request, so max original file size ≈ 6MB / 1.33 ≈ 4.5MB
+// - Match pages/ChatPage.tsx. If a difference occurs, update it
 const fileLimit: FileLimit = {
   accept: AcceptedDotExtensions,
   maxFileCount: 5,

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -220,22 +220,34 @@ const useChatState = create<{
   };
 
   const setPredictedTitle = async (id: string) => {
-    const currentTitle = get().chats[id].chat?.title;
-    if (currentTitle && currentTitle.length > 0) return;
+    try {
+      const currentTitle = get().chats[id].chat?.title;
+      if (currentTitle && currentTitle.length > 0) return;
 
-    // If the title is an empty string, predict the title and set it
-    const modelId = getModelId(id);
-    const model = findModelByModelId(modelId)!;
-    const prompter = getPrompter(modelId);
-    const title = await predictTitle({
-      model,
-      chat: get().chats[id].chat!,
-      prompt: prompter.setTitlePrompt({
-        messages: omitUnusedMessageProperties(get().chats[id].messages),
-      }),
-      id: '/title',
-    });
-    setTitle(id, title);
+      // If the title is an empty string, predict the title and set it
+      const modelId = getModelId(id);
+      const model = findModelByModelId(modelId)!;
+      const prompter = getPrompter(modelId);
+
+      // Derive usecase from the id (pathname) so it gets persisted with the title
+      const chat = { ...get().chats[id].chat! };
+      if (!chat.usecase) {
+        const match = id.match(/([^/]+)/);
+        chat.usecase = match ? '/' + match[1] : id;
+      }
+
+      const title = await predictTitle({
+        model,
+        chat,
+        prompt: prompter.setTitlePrompt({
+          messages: omitUnusedMessageProperties(get().chats[id].messages),
+        }),
+        id: '/title',
+      });
+      setTitle(id, title);
+    } catch (e) {
+      console.error('setPredictedTitle failed:', e);
+    }
   };
 
   const createChatIfNotExist = async (id: string): Promise<string> => {

--- a/packages/web/src/hooks/useChatApi.ts
+++ b/packages/web/src/hooks/useChatApi.ts
@@ -93,9 +93,10 @@ const useChatApi = () => {
         chatId ? `chats/${chatId}/messages` : null
       );
     },
-    updateTitle: async (chatId: string, title: string) => {
+    updateTitle: async (chatId: string, title: string, usecase?: string) => {
       const req: UpdateTitleRequest = {
         title,
+        usecase,
       };
       const res = await http.put<UpdateTitleResponse>(
         `chats/${chatId}/title`,

--- a/packages/web/src/hooks/useMeetingMinutes.ts
+++ b/packages/web/src/hooks/useMeetingMinutes.ts
@@ -1,8 +1,15 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
+import { v4 as uuid } from 'uuid';
 import useChatApi from './useChatApi';
-import { MODELS } from './useModel';
+import useChatList from './useChatList';
+import { MODELS, findModelByModelId } from './useModel';
 import { getPrompter, MeetingMinutesParams, DiagramOption } from '../prompts';
-import { UnrecordedMessage, Model } from 'generative-ai-use-cases';
+import {
+  UnrecordedMessage,
+  Model,
+  ToBeRecordedMessage,
+} from 'generative-ai-use-cases';
+import { decomposeId } from '../utils/ChatUtils';
 
 export const useMeetingMinutes = (
   minutesStyle: MeetingMinutesParams['style'],
@@ -13,11 +20,22 @@ export const useMeetingMinutes = (
   setLastGeneratedTime: (time: Date | null) => void,
   diagramOptions?: DiagramOption[]
 ) => {
-  const { predictStream } = useChatApi();
+  const {
+    predictStream,
+    createChat,
+    createMessages,
+    updateTitle,
+    predictTitle,
+  } = useChatApi();
+  const { mutate: mutateChatList } = useChatList();
   const { modelIds: availableModels, textModels } = MODELS;
 
   // Only keep local state for temporary values
   const [loading, setLoading] = useState(false);
+
+  // Session-level chat ID: reused across generations within the same session
+  const sessionChatIdRef = useRef<string | null>(null);
+  const sessionChatRawIdRef = useRef<string | null>(null); // Full chat ID for API calls
 
   const generateMinutes = useCallback(
     async (
@@ -110,6 +128,73 @@ export const useMeetingMinutes = (
         setLastProcessedTranscript(transcript);
         setLastGeneratedTime(new Date());
         onGenerate?.('success', { minutes: fullResponse });
+
+        // Save to DynamoDB as a chat record (best-effort, non-blocking)
+        // Reuse the same chat within this session so all generations are grouped together.
+        try {
+          const isFirstSave = !sessionChatRawIdRef.current;
+          let rawChatId = sessionChatRawIdRef.current;
+          let chatId = sessionChatIdRef.current;
+          let chatObject: Parameters<typeof predictTitle>[0]['chat'] | null =
+            null;
+
+          if (!rawChatId || !chatId) {
+            // First generation in this session: create a new chat
+            const chatResponse = await createChat();
+            rawChatId = chatResponse.chat.chatId;
+            chatId = decomposeId(rawChatId);
+            chatObject = chatResponse.chat;
+            sessionChatRawIdRef.current = rawChatId;
+            sessionChatIdRef.current = chatId;
+          }
+
+          const toBeRecordedMessages: ToBeRecordedMessage[] = [
+            {
+              role: 'user',
+              content: transcript,
+              messageId: uuid(),
+              usecase: '/meeting-minutes',
+            },
+            {
+              role: 'assistant',
+              content: fullResponse,
+              messageId: uuid(),
+              usecase: '/meeting-minutes',
+              llmType: modelId,
+            },
+          ];
+
+          await createMessages(rawChatId, {
+            messages: toBeRecordedMessages,
+          });
+
+          // Generate title on the first save only
+          if (isFirstSave && chatId && chatObject) {
+            const titleModel = findModelByModelId(modelId);
+            if (titleModel) {
+              const prompter = getPrompter(modelId);
+              const titlePrompt = prompter.setTitlePrompt({
+                messages: [
+                  { role: 'user', content: transcript },
+                  { role: 'assistant', content: fullResponse },
+                ],
+              });
+              const generatedTitle = await predictTitle({
+                model: titleModel,
+                chat: chatObject,
+                prompt: titlePrompt,
+                id: '/title',
+              });
+              await updateTitle(chatId, generatedTitle, '/meeting-minutes');
+            }
+          }
+
+          // Refresh the chat list so new/updated entry appears in sidebar
+          mutateChatList();
+        } catch (saveError) {
+          // Don't fail the generation if save fails
+          console.warn('Failed to save meeting minutes to history:', saveError);
+        }
       } catch (error) {
         onGenerate?.('error', {
           message: error instanceof Error ? error.message : 'Unknown error',
@@ -123,6 +208,11 @@ export const useMeetingMinutes = (
       customPrompt,
       diagramOptions,
       predictStream,
+      createChat,
+      createMessages,
+      updateTitle,
+      predictTitle,
+      mutateChatList,
       textModels,
       autoGenerateSessionTimestamp,
       setGeneratedMinutes,
@@ -135,6 +225,9 @@ export const useMeetingMinutes = (
     setGeneratedMinutes('');
     setLastProcessedTranscript('');
     setLastGeneratedTime(null);
+    // Reset session so next generation starts a new chat history
+    sessionChatIdRef.current = null;
+    sessionChatRawIdRef.current = null;
   }, [setGeneratedMinutes, setLastProcessedTranscript, setLastGeneratedTime]);
 
   return {

--- a/packages/web/src/pages/AgentChatPage.tsx
+++ b/packages/web/src/pages/AgentChatPage.tsx
@@ -17,6 +17,9 @@ import useFiles from '../hooks/useFiles';
 import { FileLimit } from 'generative-ai-use-cases';
 import { useTranslation } from 'react-i18next';
 
+// File size limits for Agent Chat (Lambda route: API Gateway → Lambda → Bedrock Agent)
+// - Lambda synchronous payload limit: 6MB
+// - File data is base64-encoded in the request, so max original file size ≈ 6MB / 1.33 ≈ 4.5MB
 const fileLimit: FileLimit = {
   accept: {
     doc: [
@@ -36,7 +39,7 @@ const fileLimit: FileLimit = {
     video: [],
   },
   maxFileCount: 5,
-  maxFileSizeMB: 10,
+  maxFileSizeMB: 4.5,
   maxImageFileCount: 0,
   maxImageFileSizeMB: 0,
   maxVideoFileCount: 0,

--- a/packages/web/src/pages/AgentCorePage.tsx
+++ b/packages/web/src/pages/AgentCorePage.tsx
@@ -17,6 +17,11 @@ import { PiArrowLeft } from 'react-icons/pi';
 import ButtonIcon from '../components/ButtonIcon';
 
 // Define file limits for the chat interface
+// File size limits for AgentCore (AgentCore Runtime route: Frontend → AgentCore Runtime → Bedrock Converse API)
+// - AgentCore Runtime payload limit: 100MB (not a bottleneck)
+// - Anthropic Claude max request size: 32MB for the entire HTTP request body
+// - Nova PDF/DOCX direct upload limit: 25MB combined (model-side error if exceeded)
+// - Setting to 32MB as the upper bound based on Claude's documented limit
 const fileLimit: FileLimit = {
   accept: {
     doc: [
@@ -36,7 +41,7 @@ const fileLimit: FileLimit = {
     video: [],
   },
   maxFileCount: 5,
-  maxFileSizeMB: 10,
+  maxFileSizeMB: 32,
   maxImageFileCount: 5,
   maxImageFileSizeMB: 5,
   maxVideoFileCount: 0,

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -33,6 +33,10 @@ import ModelParameters from '../components/ModelParameters';
 import { AcceptedDotExtensions } from '../utils/MediaUtils';
 import { useTranslation } from 'react-i18next';
 
+// File size limits for Chat (Lambda route: API Gateway → Lambda → Bedrock Converse API)
+// - Lambda synchronous payload limit: 6MB
+// - File data is base64-encoded in the request, so max original file size ≈ 6MB / 1.33 ≈ 4.5MB
+// - Bedrock Converse API document limit: 4.5MB per document (except Claude 4+ PDF and Nova PDF/DOCX)
 const fileLimit: FileLimit = {
   accept: AcceptedDotExtensions,
   maxFileCount: 5,

--- a/packages/web/src/utils/UseCaseIconMap.tsx
+++ b/packages/web/src/utils/UseCaseIconMap.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import {
+  PiChat,
+  PiChatsCircle,
+  PiChatCircleText,
+  PiRobot,
+  PiGraph,
+  PiFlowArrow,
+  PiMicrophoneBold,
+  PiPencil,
+  PiNote,
+  PiNotebook,
+  PiPenNib,
+  PiTranslate,
+  PiGlobe,
+  PiImages,
+  PiVideoLight,
+  PiVideoCamera,
+  PiTreeStructure,
+  PiMagnifyingGlass,
+} from 'react-icons/pi';
+
+/**
+ * Maps usecase path (stored in Chat.usecase) to the corresponding icon.
+ * The usecase value is extracted from the page route, e.g. "/chat", "/meeting-minutes".
+ */
+const useCaseIconMap: Record<string, React.ReactNode> = {
+  '/chat': <PiChatsCircle />,
+  '/rag': <PiChatCircleText />,
+  '/rag-knowledge-base': <PiChatCircleText />,
+  '/agent': <PiRobot />,
+  '/mcp': <PiGraph />,
+  '/agent-core': <PiRobot />,
+  '/agent-builder': <PiRobot />,
+  '/research': <PiMagnifyingGlass />,
+  '/flow-chat': <PiFlowArrow />,
+  '/voice-chat': <PiMicrophoneBold />,
+  '/generate': <PiPencil />,
+  '/summarize': <PiNote />,
+  '/meeting-minutes': <PiNotebook />,
+  '/writer': <PiPenNib />,
+  '/translate': <PiTranslate />,
+  '/web-content': <PiGlobe />,
+  '/image': <PiImages />,
+  '/video': <PiVideoLight />,
+  '/video-analyzer': <PiVideoCamera />,
+  '/diagram': <PiTreeStructure />,
+};
+
+/**
+ * Get the icon for a given usecase string.
+ * Falls back to PiChat if no matching usecase is found.
+ */
+export const getUseCaseIcon = (usecase?: string): React.ReactNode => {
+  if (!usecase) return <PiChat />;
+  return useCaseIconMap[usecase] ?? <PiChat />;
+};


### PR DESCRIPTION
## Description of Changes

Chat 履歴サイドバーの視認性向上、議事録の履歴永続化、各ルートのファイルサイズ制限調整を行います。

### 1. Chat 履歴サイドバーのユースケース別アイコン表示

- `UseCaseIconMap` を新規追加し、`/chat`, `/rag`, `/meeting-minutes` などユースケースごとに `react-icons/pi` から専用アイコンを割り当て
- `ChatListItem` の汎用 `PiChat` を、ユースケースに応じたアイコンに置き換え
- 既存の履歴にもアイコンが反映されるよう、`setPredictedTitle` でルートからユースケースを導出し、`setChatTitle` / `updateTitle` で DynamoDB に永続化(次回のタイトル予測時に backfill)
- アイコンで種別が視覚的に伝わるため、サイドバーラベルを "Conversation History" → "History" に短縮 (en / ja / ko / th / vi)
<img width="1512" height="677" alt="Screenshot 2026-07-13 at 11 28 47" src="https://github.com/user-attachments/assets/9be82e2a-ea8b-43e8-8f30-45fb854dbafd" />

### 2. 議事録の DynamoDB 永続化

- 議事録生成結果を chat record として DynamoDB に保存し、サイドバーに `/meeting-minutes` アイコン付きで表示
- 同一セッション中は同じ `chatId` を使い回し、初回保存時に `predictTitle` + `updateTitle` でタイトル生成
- ユーザーが state を clear した際は session ref をリセット
- 保存失敗は catch してログのみ残し、議事録生成本体には影響しないよう隔離

### 3. ファイルサイズ制限をインフラ実制約に合わせて調整

- 対象: `AgentChatUnified`, `UseCaseBuilderView`, `AgentChatPage`, `AgentCorePage`, `ChatPage`
- 各ルートで実際に許容されるサイズ上限にフロントエンド側の制限を合わせる

### Impact / Compatibility

- 破壊的変更なし
- 既存の Chat 履歴は、次回のタイトル予測時にユースケース情報が backfill される
- 議事録は本 PR 以降の生成分から履歴に残る(既存分には遡及しない)

## Checklist

- [ ] Modified relevant documentation (該当Docなし)
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

なし

