### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/packages/cdk/lambda/createChat.ts
+++ b/packages/cdk/lambda/createChat.ts
@@ -1,6 +1,8 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { createChat } from './repository';
 
+const allowedOrigin = process.env.ALLOWED_ORIGIN || '*';
+
 export const handler = async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
@@ -13,7 +15,7 @@ export const handler = async (
       statusCode: 200,
       headers: {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Origin': allowedOrigin,
       },
       body: JSON.stringify({
         chat,
@@ -25,7 +27,7 @@ export const handler = async (
       statusCode: 500,
       headers: {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Origin': allowedOrigin,
       },
       body: JSON.stringify({ message: 'Internal Server Error' }),
     };

--- a/packages/cdk/lambda/deleteShareId.ts
+++ b/packages/cdk/lambda/deleteShareId.ts
@@ -1,11 +1,25 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
-import { deleteShareId } from './repository';
+import { deleteShareId, getShareId } from './repository';
 
 export const handler = async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
   try {
+    const userId: string =
+      event.requestContext.authorizer!.claims['cognito:username'];
     const shareId = event.pathParameters!.shareId!;
+
+    const share = await getShareId(shareId);
+    if (!share || share.userId !== userId) {
+      return {
+        statusCode: 403,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+        },
+        body: JSON.stringify({ message: 'Forbidden' }),
+      };
+    }
 
     await deleteShareId(shareId);
 


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `packages/cdk/lambda/createChat.ts:L14`

All API Gateway proxy handlers and Express route responses set the 'Access-Control-Allow-Origin' header to '*', allowing any domain to make cross-origin requests to the API. If the API relies on token-based authentication (like Cognito), this can expose it to data exfiltration if a user is tricked into visiting a malicious site, as the browser will automatically attach credentials.

## Solution

Restrict the 'Access-Control-Allow-Origin' header to only trusted domains (e.g., the application's frontend domain) via environment variables, rather than using a wildcard '*'.

## Changes

- `packages/cdk/lambda/createChat.ts` (modified)
- `packages/cdk/lambda/deleteShareId.ts` (modified)