### PR TITLE
fix(web): prevent minutes style falling back to transcription

### DIFF
--- a/packages/web/src/prompts/claude.ts
+++ b/packages/web/src/prompts/claude.ts
@@ -12,6 +12,7 @@ import {
   WebContentParams,
   DiagramParams,
   MeetingMinutesParams,
+  isSavedPromptStyle,
 } from './index';
 
 import {
@@ -600,10 +601,21 @@ Output only the selected chart type from the <Choice> list, with an exact match,
       );
   },
   meetingMinutesPrompt(params: MeetingMinutesParams): string {
-    if (params.style === 'custom' && params.customPrompt) {
-      return params.customPrompt;
+    // 'custom' and 'savedPrompt:*' styles use the user-provided prompt.
+    // When the prompt body is missing (e.g. still loading), fall back to
+    // the 'transcription' prompt explicitly rather than implicitly.
+    if (params.style === 'custom' || isSavedPromptStyle(params.style)) {
+      return (
+        params.customPrompt ||
+        this.meetingMinutesPrompt({ style: 'transcription' })
+      );
     }
 
+    // Exhaustive switch over built-in styles: every style selectable in
+    // the UI MUST have its own case here. A missing case is a compile
+    // error (see the `never` check in `default`), which prevents styles
+    // from silently falling back to the 'transcription' prompt
+    // (see https://github.com/aws-samples/generative-ai-use-cases/issues/1349).
     switch (params.style) {
       case 'summary':
         return `As a professional meeting facilitator, create a concise summary of the meeting focusing on:
@@ -695,8 +707,18 @@ ${MERMAID_SPECIAL_CHARS_WARNING}
 \`\`\``;
 
       case 'transcription':
-      default:
         return `As a professional translator, please correct filler words and misrecognition in received transcribed text. Please add paragraph breaks if you detect obvious topic changes, and if you find important statements related to the topic, please format them in bold style. For speakers, you must transcribe in received text language.`;
+
+      default: {
+        // Compile-time exhaustiveness check: adding a new style to
+        // MeetingMinutesParams['style'] without a case above is a type
+        // error. At runtime (should never happen), fall back explicitly.
+        const unhandledStyle: never = params.style;
+        console.error(
+          `Unhandled meeting minutes style: ${unhandledStyle}. Falling back to 'transcription'.`
+        );
+        return this.meetingMinutesPrompt({ style: 'transcription' });
+      }
     }
   },
 };

--- a/packages/web/src/prompts/index.ts
+++ b/packages/web/src/prompts/index.ts
@@ -86,6 +86,13 @@ export type MeetingMinutesParams = {
   diagramOptions?: DiagramOption[];
 };
 
+// Type guard for the 'savedPrompt:<id>' style variants
+export const isSavedPromptStyle = (
+  style: MeetingMinutesParams['style']
+): style is `savedPrompt:${string}` => {
+  return style.startsWith('savedPrompt:');
+};
+
 export type PromptListItem = {
   title: string;
   systemContext: string;

--- a/packages/web/tests/hooks/useMeetingMinutes.test.ts
+++ b/packages/web/tests/hooks/useMeetingMinutes.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { claudePrompter } from '../../src/prompts/claude';
+import { MeetingMinutesParams } from '../../src/prompts';
+
+// Capture the messages passed to predictStream so we can inspect
+// which system prompt was actually sent to the model.
+const predictStreamMock = vi.fn();
+
+vi.mock('../../src/hooks/useChatApi', () => ({
+  default: () => ({
+    predictStream: (...args: unknown[]) => {
+      predictStreamMock(...args);
+      // Return an async iterable like the real implementation
+      return (async function* () {
+        yield JSON.stringify({ text: 'generated minutes' });
+      })();
+    },
+    createChat: vi.fn().mockResolvedValue({ chat: { chatId: 'chat#test' } }),
+    createMessages: vi.fn().mockResolvedValue({}),
+    updateTitle: vi.fn().mockResolvedValue({}),
+    predictTitle: vi.fn().mockResolvedValue('title'),
+  }),
+}));
+
+vi.mock('../../src/hooks/useChatList', () => ({
+  default: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock('../../src/hooks/useModel', () => ({
+  MODELS: {
+    modelIds: ['claude-test-model'],
+    textModels: [{ modelId: 'claude-test-model', type: 'bedrock' }],
+  },
+  findModelByModelId: vi.fn().mockReturnValue({
+    modelId: 'claude-test-model',
+    type: 'bedrock',
+  }),
+}));
+
+// Import after mocks are declared
+import useMeetingMinutes from '../../src/hooks/useMeetingMinutes';
+
+// The system prompt used for the 'transcription' style (the fallback
+// reported in issue #1349 as being wrongly used for summary/detail)
+const transcriptionPrompt = claudePrompter.meetingMinutesPrompt({
+  style: 'transcription',
+});
+
+/**
+ * Render the hook with a given style and run one generation,
+ * returning the system prompt that was sent to predictStream.
+ */
+const generateAndGetSystemPrompt = async (
+  style: MeetingMinutesParams['style'],
+  customPrompt = ''
+): Promise<string> => {
+  predictStreamMock.mockClear();
+
+  const { result } = renderHook(() =>
+    useMeetingMinutes(
+      style,
+      customPrompt,
+      null,
+      () => {},
+      () => {},
+      () => {}
+    )
+  );
+
+  await act(async () => {
+    await result.current.generateMinutes(
+      'This is a test transcript.',
+      'claude-test-model'
+    );
+  });
+
+  expect(predictStreamMock).toHaveBeenCalledTimes(1);
+  const callArg = predictStreamMock.mock.calls[0][0] as {
+    messages: { role: string; content: string }[];
+  };
+  const systemMessage = callArg.messages.find((m) => m.role === 'system');
+  expect(systemMessage).toBeDefined();
+  return systemMessage!.content;
+};
+
+describe('useMeetingMinutes style -> system prompt mapping (issue #1349)', () => {
+  beforeEach(() => {
+    predictStreamMock.mockClear();
+  });
+
+  it('uses the summary system prompt when style is "summary" (Summary)', async () => {
+    const systemPrompt = await generateAndGetSystemPrompt('summary');
+    // Must NOT fall back to the transcription prompt
+    expect(systemPrompt).not.toBe(transcriptionPrompt);
+    expect(systemPrompt).toContain('professional meeting facilitator');
+  });
+
+  it('uses the detail system prompt when style is "detail" (Detail)', async () => {
+    const systemPrompt = await generateAndGetSystemPrompt('detail');
+    expect(systemPrompt).not.toBe(transcriptionPrompt);
+    expect(systemPrompt).toContain('professional secretary');
+  });
+
+  it('uses the faq system prompt when style is "faq" (FAQ)', async () => {
+    const systemPrompt = await generateAndGetSystemPrompt('faq');
+    expect(systemPrompt).not.toBe(transcriptionPrompt);
+    expect(systemPrompt).toContain('question-and-answer');
+  });
+
+  it('uses the transcription system prompt when style is "transcription" (Transcription)', async () => {
+    const systemPrompt = await generateAndGetSystemPrompt('transcription');
+    expect(systemPrompt).toBe(transcriptionPrompt);
+  });
+
+  it('uses the user-provided prompt when style is "custom"', async () => {
+    const systemPrompt = await generateAndGetSystemPrompt(
+      'custom',
+      'my custom prompt body'
+    );
+    expect(systemPrompt).toBe('my custom prompt body');
+  });
+
+  it('uses the saved prompt body when style is "savedPrompt:<id>"', async () => {
+    const systemPrompt = await generateAndGetSystemPrompt(
+      'savedPrompt:abc123',
+      'my saved prompt body'
+    );
+    expect(systemPrompt).toBe('my saved prompt body');
+  });
+});
+
+describe('claudePrompter.meetingMinutesPrompt style mapping (issue #1349)', () => {
+  it.each([
+    ['summary', 'professional meeting facilitator'],
+    ['detail', 'professional secretary'],
+    ['faq', 'question-and-answer'],
+    ['newspaper', 'professional journalist'],
+    ['diagram', 'visual documentation specialist'],
+    ['whiteboard', 'whiteboard facilitator'],
+  ] as const)(
+    'returns a dedicated prompt (not the transcription fallback) for style "%s"',
+    (style, expectedFragment) => {
+      const prompt = claudePrompter.meetingMinutesPrompt({ style });
+      expect(prompt).not.toBe(transcriptionPrompt);
+      expect(prompt).toContain(expectedFragment);
+    }
+  );
+
+  it('returns the custom prompt body for style "custom"', () => {
+    expect(
+      claudePrompter.meetingMinutesPrompt({
+        style: 'custom',
+        customPrompt: 'my prompt',
+      })
+    ).toBe('my prompt');
+  });
+
+  it('returns the saved prompt body for style "savedPrompt:<id>"', () => {
+    expect(
+      claudePrompter.meetingMinutesPrompt({
+        style: 'savedPrompt:xyz',
+        customPrompt: 'saved body',
+      })
+    ).toBe('saved body');
+  });
+
+  it.each([['custom'], ['savedPrompt:xyz']] as const)(
+    'falls back to the transcription prompt when style is "%s" but the prompt body is empty',
+    (style) => {
+      expect(
+        claudePrompter.meetingMinutesPrompt({ style, customPrompt: '' })
+      ).toBe(transcriptionPrompt);
+    }
+  );
+});


### PR DESCRIPTION
## Description of Changes

議事録ユースケースで、スタイル「要約」(summary) /「詳細」(detail) を選択しても 'transcription' プロンプトに暗黙フォールバックし、文字起こしがそのまま出力される問題（#1349 のスタイル部分）への対応です。

**背景**: 報告時点 (v5.0系) の `meetingMinutesPrompt` の switch には `summary` / `detail` の case がなく `default`（transcription）に落ちていました。報告症状そのものは PR #1373 が case を追加したことで偶発的に解消済みですが、「case のないスタイルが黙って transcription にフォールバックする」構造は残存していました。

**変更内容**:
- `meetingMinutesPrompt` の switch を網羅化し、`default` 節に `never` 型によるコンパイル時網羅性チェックを追加。今後 `MeetingMinutesParams['style']` にスタイルを追加して case を書き忘れると型エラーになります
- `custom` / `savedPrompt:*` スタイルでプロンプト本文が空の場合の transcription フォールバックを明示化（型ガード `isSavedPromptStyle` を追加）
- 回帰テスト16件を追加（Issue 当時のコードで red、修正後 green を確認済み）

既存ユーザーへの影響: なし（挙動変更は「網羅漏れ時に型エラーになる」開発時のみ。ランタイム挙動は現行と同一）

## Checklist

- [ ] Modified relevant documentation (N/A: コードのみの変更)
- [x] Verified operation in local environment (`npm run web:build` / `npm run lint` / `npm run web:test` 294/294 passed)
- [ ] Executed `npm run cdk:test` (N/A: web パッケージのみの変更で CDK に変更なし)

## Related Issues

Fixes #1349 （症状は #1373 で解消済み・本PRは構造的な再発防止と回帰テスト整備。404 部分は別PR fix/minutes-edit-404 で対応）
