### PR TITLE
fix(web): use latest settings for first-recording translation

### DIFF
--- a/packages/web/src/components/MeetingMinutes/MeetingMinutesRealtimeTranslation.tsx
+++ b/packages/web/src/components/MeetingMinutes/MeetingMinutesRealtimeTranslation.tsx
@@ -86,6 +86,14 @@ const MeetingMinutesRealtimeTranslation: React.FC<
   const isAtBottomRef = useRef<boolean>(true);
   const generateSystemContextRef = useRef<(() => Promise<void>) | null>(null);
   const realtimeSegmentsRef = useRef<RealtimeSegment[]>([]);
+  const translateSentenceRef = useRef<
+    | ((
+        segment: RealtimeSegment,
+        sentenceIndex: number,
+        translationSegment: TranslationSegment
+      ) => Promise<void>)
+    | null
+  >(null);
 
   // Microphone and screen audio hooks
   const {
@@ -230,7 +238,9 @@ const MeetingMinutesRealtimeTranslation: React.FC<
           );
         }
 
-        const recentSegmentsText = getRecentSegmentsContext(realtimeSegments);
+        const recentSegmentsText = getRecentSegmentsContext(
+          realtimeSegmentsRef.current
+        );
         if (recentSegmentsText) {
           contexts.push(`Recent conversation context: ${recentSegmentsText}`);
         }
@@ -287,10 +297,12 @@ const MeetingMinutesRealtimeTranslation: React.FC<
         console.error('Failed to translate sentence:', error);
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+
     [
       selectedTranslationModel,
+      primaryLanguage,
       secondaryLanguage,
+      translationType,
       userDefinedContext,
       systemGeneratedContext,
       translate,
@@ -300,6 +312,11 @@ const MeetingMinutesRealtimeTranslation: React.FC<
       // Note: getLanguageNameFromCode and getRecentSegmentsContext are external functions and stable
     ]
   );
+
+  // Keep ref updated with the latest translateSentence so that the
+  // interval-based translation always uses current settings
+  // (avoids stale closures; same pattern as generateSystemContextRef)
+  translateSentenceRef.current = translateSentence;
 
   // Hook for generating system context
   const { predict } = useChatApi();
@@ -626,20 +643,30 @@ const MeetingMinutesRealtimeTranslation: React.FC<
         for (const translationSentence of sentencesToTranslate) {
           const sentenceIndex =
             segment.translationSegments.indexOf(translationSentence);
-          // Translate individual sentence (duplicate prevention is now handled inside translateSentence)
-          await translateSentence(segment, sentenceIndex, translationSentence);
+          // Translate individual sentence via ref to always use the latest
+          // settings (target language, contexts). Calling translateSentence
+          // directly here would capture a stale closure because this effect
+          // intentionally omits function dependencies.
+          // (duplicate prevention is handled inside translateSentence)
+          if (translateSentenceRef.current) {
+            await translateSentenceRef.current(
+              segment,
+              sentenceIndex,
+              translationSentence
+            );
+          }
         }
       }
     }, translationInterval);
 
     return () => clearInterval(intervalId);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     realtimeTranslationEnabled,
     selectedTranslationModel,
     translationInterval,
     // Note: We intentionally omit function dependencies to prevent infinite loop recreation of this useEffect.
-    // The interval function accesses current values through closure, which is acceptable for this use case.
+    // The interval callback reads the latest values via refs
+    // (realtimeSegmentsRef / translateSentenceRef) to avoid stale closures.
   ]);
 
   // Recording states

--- a/packages/web/tests/components/MeetingMinutes/MeetingMinutesRealtimeTranslation.test.tsx
+++ b/packages/web/tests/components/MeetingMinutes/MeetingMinutesRealtimeTranslation.test.tsx
@@ -1,0 +1,275 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  cleanup,
+} from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import MeetingMinutesRealtimeTranslation from '../../../src/components/MeetingMinutes/MeetingMinutesRealtimeTranslation';
+
+// Raw transcript segment shape returned by useMicrophone
+interface RawSegment {
+  resultId: string;
+  startTime: number;
+  endTime: number;
+  isPartial: boolean;
+  transcripts: { speakerLabel?: string; transcript: string }[];
+  languageCode?: string;
+}
+
+// Hoisted mutable mock state (vi.mock factories are hoisted above imports)
+const { translateMock, micState } = vi.hoisted(() => {
+  return {
+    translateMock: vi.fn(async (): Promise<string | null> => 'translated-text'),
+    micState: {
+      recording: false,
+      rawTranscripts: [] as {
+        resultId: string;
+        startTime: number;
+        endTime: number;
+        isPartial: boolean;
+        transcripts: { speakerLabel?: string; transcript: string }[];
+        languageCode?: string;
+      }[],
+    },
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../../src/hooks/useMicrophone', () => ({
+  default: () => ({
+    startTranscription: vi.fn(),
+    stopTranscription: vi.fn(),
+    recording: micState.recording,
+    clearTranscripts: vi.fn(),
+    rawTranscripts: micState.rawTranscripts,
+  }),
+}));
+
+vi.mock('../../../src/hooks/useScreenAudio', () => ({
+  default: () => ({
+    prepareScreenCapture: vi.fn(),
+    startTranscriptionWithStream: vi.fn(),
+    stopTranscription: vi.fn(),
+    recording: false,
+    clearTranscripts: vi.fn(),
+    isSupported: false,
+    error: null,
+    rawTranscripts: [],
+  }),
+}));
+
+vi.mock('../../../src/hooks/useRealtimeTranslation', () => ({
+  default: () => ({
+    availableModels: ['model-a'],
+    translate: translateMock,
+    translationInterval: 100,
+    setTranslationInterval: vi.fn(),
+    hasTextChanged: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../src/hooks/useChatApi', () => ({
+  default: () => ({
+    predict: vi.fn(async () => ''),
+  }),
+}));
+
+vi.mock('../../../src/hooks/useModel', () => ({
+  MODELS: {
+    modelIds: ['model-a'],
+    lightModelIds: [],
+    modelDisplayName: (id: string) => id,
+  },
+  findModelByModelId: () => undefined,
+}));
+
+vi.mock('../../../src/components/Select', () => ({
+  default: ({
+    value,
+    onChange,
+    options,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+    options: { value: string; label: string }[];
+  }) => (
+    <select value={value} onChange={(e) => onChange(e.target.value)}>
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+vi.mock('../../../src/components/Textarea', () => ({
+  default: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+  }) => <textarea value={value} onChange={(e) => onChange(e.target.value)} />,
+}));
+
+vi.mock(
+  '../../../src/components/MeetingMinutes/MeetingMinutesSettingsPanel',
+  () => ({
+    default: ({ children }: { children?: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+  })
+);
+
+vi.mock(
+  '../../../src/components/MeetingMinutes/MeetingMinutesControlButtons',
+  () => ({
+    default: ({
+      onStartRecording,
+      onStopRecording,
+    }: {
+      onStartRecording: () => void;
+      onStopRecording: () => void;
+    }) => (
+      <div>
+        <button data-testid="start-recording" onClick={onStartRecording} />
+        <button data-testid="stop-recording" onClick={onStopRecording} />
+      </div>
+    ),
+  })
+);
+
+vi.mock(
+  '../../../src/components/MeetingMinutes/MeetingMinutesTranscriptSegment',
+  () => ({
+    default: () => null,
+  })
+);
+
+// Combobox render order in the component:
+// [0] = primary (transcription) language, [1] = secondary (translation) language,
+// [2] = translation type, [3] = translation model
+const PRIMARY_LANGUAGE_SELECT = 0;
+const SECONDARY_LANGUAGE_SELECT = 1;
+
+const feedMicSegment = (segment: RawSegment) => {
+  micState.rawTranscripts = [...micState.rawTranscripts, segment];
+};
+
+describe('MeetingMinutesRealtimeTranslation - translation target language', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    translateMock.mockClear();
+    micState.recording = false;
+    micState.rawTranscripts = [];
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('uses the user-selected target language and recent context on the FIRST recording (Issue #1331)', async () => {
+    const { rerender } = render(<MeetingMinutesRealtimeTranslation />);
+
+    // User configures: transcription = Japanese, translation = English
+    const selects = screen.getAllByRole('combobox');
+    fireEvent.change(selects[PRIMARY_LANGUAGE_SELECT], {
+      target: { value: 'ja-JP' },
+    });
+    fireEvent.change(selects[SECONDARY_LANGUAGE_SELECT], {
+      target: { value: 'en-US' },
+    });
+
+    // First recording starts
+    fireEvent.click(screen.getByTestId('start-recording'));
+
+    // A finalized transcript segment arrives from the microphone
+    feedMicSegment({
+      resultId: 'r1',
+      startTime: 0,
+      endTime: 2,
+      isPartial: false,
+      transcripts: [{ transcript: 'first recording sentence?' }],
+      languageCode: 'ja-JP',
+    });
+    rerender(<MeetingMinutesRealtimeTranslation />);
+
+    // Let the interval-based translation fire
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+
+    expect(translateMock).toHaveBeenCalled();
+    const [text, , targetLanguage, context] = translateMock.mock.calls[0];
+    expect(text).toBe('first recording sentence?');
+    // Bug: stale closure captured the initial default ('ja-JP' -> 'Japanese')
+    expect(targetLanguage).toBe('English');
+    // Bug: stale empty segments meant no recent-context (<consider>) was sent
+    expect(context).toContain('first recording sentence');
+  });
+
+  it('keeps following the latest language setting on subsequent recordings', async () => {
+    const { rerender } = render(<MeetingMinutesRealtimeTranslation />);
+
+    const selects = screen.getAllByRole('combobox');
+    fireEvent.change(selects[PRIMARY_LANGUAGE_SELECT], {
+      target: { value: 'ja-JP' },
+    });
+    fireEvent.change(selects[SECONDARY_LANGUAGE_SELECT], {
+      target: { value: 'en-US' },
+    });
+
+    // First recording
+    fireEvent.click(screen.getByTestId('start-recording'));
+    feedMicSegment({
+      resultId: 'r1',
+      startTime: 0,
+      endTime: 2,
+      isPartial: false,
+      transcripts: [{ transcript: 'first recording sentence?' }],
+      languageCode: 'ja-JP',
+    });
+    rerender(<MeetingMinutesRealtimeTranslation />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+
+    expect(translateMock).toHaveBeenCalled();
+    expect(translateMock.mock.calls[0][2]).toBe('English');
+
+    // Stop, change the translation language, then record again
+    fireEvent.click(screen.getByTestId('stop-recording'));
+    fireEvent.change(selects[SECONDARY_LANGUAGE_SELECT], {
+      target: { value: 'zh-CN' },
+    });
+    fireEvent.click(screen.getByTestId('start-recording'));
+
+    feedMicSegment({
+      resultId: 'r2',
+      startTime: 10,
+      endTime: 12,
+      isPartial: false,
+      transcripts: [{ transcript: 'second recording sentence?' }],
+      languageCode: 'ja-JP',
+    });
+    rerender(<MeetingMinutesRealtimeTranslation />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+
+    const secondRecordingCall = translateMock.mock.calls.find(
+      (call) => call[0] === 'second recording sentence?'
+    );
+    expect(secondRecordingCall).toBeDefined();
+    // The second recording must use the latest setting (Chinese)
+    expect(secondRecordingCall?.[2]).toBe('Chinese');
+  });
+});


### PR DESCRIPTION
## Description of Changes

議事録生成の初回録音時に、画面で設定した翻訳先言語が送信プロンプトの `<language>` タグに反映されず、翻訳が動作しない問題（#1331）への対応です。

**根本原因**: `MeetingMinutesRealtimeTranslation.tsx` のインターバル翻訳 useEffect における stale closure です。このエフェクトは無限ループ防止のため関数依存を意図的に省略しており、`setInterval` のコールバックがマウント直後（デフォルト翻訳モデル自動設定時点）の `translateSentence` を捕捉します。その時点の state 初期値（`secondaryLanguage='ja-JP'`、空のコンテキスト、空の `realtimeSegments`）が固定されるため、初回録音では設定変更が反映されませんでした。録音停止→設定変更→再録音で直る（deps に含まれる設定変更でエフェクトが再実行される）という Issue の再現条件とも一致します。

**変更内容**:
- `translateSentenceRef` を導入し、インターバルコールバックから常に最新の `translateSentence` を参照するよう変更（既存の `generateSystemContextRef` と同一パターン）
- `getRecentSegmentsContext` も ref 経由の最新値を参照するよう修正（初回に `<consider>` タグが付かない問題も同一原因のため合わせて解消）
- `translateSentence` の useCallback deps に欠落していた `primaryLanguage` / `translationType` を追加（双方向翻訳時の同種 stale の予防）
- コンポーネントテストを追加（修正前 red、修正後 green を確認済み）

既存ユーザーへの影響: なし（2回目以降の録音の挙動は不変。回帰テストで確認済み）

## Checklist

- [ ] Modified relevant documentation (N/A: コードのみの変更)
- [x] Verified operation in local environment (`npm run web:build` / `npm run lint` / `npm run web:test` passed)
- [ ] Executed `npm run cdk:test` (N/A: web パッケージのみの変更で CDK に変更なし)

## Related Issues

Fixes #1331
