### PR TITLE
feat: edit message

### DIFF
--- a/packages/cdk/lambda/api/routes/chats.ts
+++ b/packages/cdk/lambda/api/routes/chats.ts
@@ -6,6 +6,7 @@ import { handler as deleteChatHandler } from '../../deleteChat';
 import { handler as updateTitleHandler } from '../../updateTitle';
 import { handler as listMessagesHandler } from '../../listMessages';
 import { handler as createMessagesHandler } from '../../createMessages';
+import { handler as deleteMessagesHandler } from '../../deleteMessages';
 import { handler as updateFeedbackHandler } from '../../updateFeedback';
 import { wrapHandler } from './helpers';
 
@@ -20,4 +21,5 @@ router.delete('/:chatId', wrapHandler(deleteChatHandler, chatId));
 router.put('/:chatId/title', wrapHandler(updateTitleHandler, chatId));
 router.get('/:chatId/messages', wrapHandler(listMessagesHandler, chatId));
 router.post('/:chatId/messages', wrapHandler(createMessagesHandler, chatId));
+router.delete('/:chatId/messages', wrapHandler(deleteMessagesHandler, chatId));
 router.post('/:chatId/feedbacks', wrapHandler(updateFeedbackHandler, chatId));

--- a/packages/cdk/lambda/deleteMessages.ts
+++ b/packages/cdk/lambda/deleteMessages.ts
@@ -1,0 +1,58 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { deleteMessagesFrom, findChatById } from './repository';
+
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    const userId: string =
+      event.requestContext.authorizer!.claims['cognito:username'];
+    const chatId = event.pathParameters!.chatId!;
+    const fromCreatedDate = event.queryStringParameters?.fromCreatedDate;
+
+    if (!fromCreatedDate) {
+      return {
+        statusCode: 400,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+        },
+        body: JSON.stringify({ message: 'fromCreatedDate is required' }),
+      };
+    }
+
+    const chat = await findChatById(userId, chatId);
+
+    if (chat === null) {
+      return {
+        statusCode: 403,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+        },
+        body: JSON.stringify({ message: 'Forbidden' }),
+      };
+    }
+
+    await deleteMessagesFrom(chatId, fromCreatedDate);
+
+    return {
+      statusCode: 204,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: '',
+    };
+  } catch (error) {
+    console.log(error);
+    return {
+      statusCode: 500,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify({ message: 'Internal Server Error' }),
+    };
+  }
+};

--- a/packages/cdk/lambda/repository.ts
+++ b/packages/cdk/lambda/repository.ts
@@ -493,6 +493,64 @@ export const deleteChat = async (
   }
 };
 
+/**
+ * Delete the messages in a chat whose createdDate is greater than or equal to
+ * fromCreatedDate.
+ *
+ * Used when a user edits a message in the middle of a conversation: the
+ * messages after the edited one are discarded, so they must be removed from the
+ * table as well. Otherwise they would be restored on reload and mixed with the
+ * regenerated messages.
+ *
+ * Note: this does not roll back the token usage recorded in the stats table,
+ * because the tokens were actually consumed.
+ */
+export const deleteMessagesFrom = async (
+  _chatId: string,
+  fromCreatedDate: string
+): Promise<void> => {
+  const chatId = `chat#${_chatId}`;
+  const res = await dynamoDbDocument.send(
+    new QueryCommand({
+      TableName: TABLE_NAME,
+      KeyConditionExpression: '#id = :id AND #createdDate >= :fromCreatedDate',
+      ExpressionAttributeNames: {
+        '#id': 'id',
+        '#createdDate': 'createdDate',
+      },
+      ExpressionAttributeValues: {
+        ':id': chatId,
+        ':fromCreatedDate': fromCreatedDate,
+      },
+      // Only the key attributes are needed to delete the items
+      ProjectionExpression: '#id, #createdDate',
+    })
+  );
+  const keys = (res.Items ?? []) as { id: string; createdDate: string }[];
+
+  // Split into chunks of 25 (DynamoDB BatchWrite limit)
+  const chunkSize = 25;
+  for (let i = 0; i < keys.length; i += chunkSize) {
+    const chunk = keys.slice(i, i + chunkSize);
+    await dynamoDbDocument.send(
+      new BatchWriteCommand({
+        RequestItems: {
+          [TABLE_NAME]: chunk.map((key) => {
+            return {
+              DeleteRequest: {
+                Key: {
+                  id: key.id,
+                  createdDate: key.createdDate,
+                },
+              },
+            };
+          }),
+        },
+      })
+    );
+  }
+};
+
 export const updateSystemContextTitle = async (
   _userId: string,
   _systemContextId: string,

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -689,6 +689,9 @@ export class Api extends Construct {
     const messages = chat.addResource('messages');
     messages.addMethod('GET');
     messages.addMethod('POST');
+    // Explicitly defined because the addProxy() catch-all does not apply to
+    // methods of a Resource that is already declared above.
+    messages.addMethod('DELETE');
     chat.addResource('feedbacks').addMethod('POST');
 
     const systemcontexts = api.root.addResource('systemcontexts');
@@ -777,7 +780,7 @@ export class Api extends Construct {
 
     // Force a new API Gateway deployment.
     // Bump this version when route configuration changes.
-    const API_DEPLOYMENT_VERSION = 'v2';
+    const API_DEPLOYMENT_VERSION = 'v3';
     const deployment = new Deployment(this, 'ApiDeployment', { api });
     deployment.addToLogicalId(API_DEPLOYMENT_VERSION);
 

--- a/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
+++ b/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
@@ -5680,7 +5680,7 @@ exports[`GenerativeAiUseCases matches the snapshot (closed network mode) 6`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Delete",
     },
-    "APIApiDeployment3A5021237a3dd9dd1d0a04e8bff19caaa142feb6": {
+    "APIApiDeployment3A502123d250ee865e87535bbd9ca2feaef95e15": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "APIApiApi4XXDCF913C8",
@@ -5700,6 +5700,7 @@ exports[`GenerativeAiUseCases matches the snapshot (closed network mode) 6`] = `
         "APIApichatschatIdfeedbacksPOST3E9ACBEC",
         "APIApichatschatIdfeedbacksF371F57A",
         "APIApichatschatIdGET152C9123",
+        "APIApichatschatIdmessagesDELETE5EC16981",
         "APIApichatschatIdmessagesGET94AB097F",
         "APIApichatschatIdmessagesOPTIONS20207E07",
         "APIApichatschatIdmessagesPOST4197DA8F",
@@ -5847,7 +5848,7 @@ exports[`GenerativeAiUseCases matches the snapshot (closed network mode) 6`] = `
       "Type": "AWS::ApiGateway::Deployment",
       "UpdateReplacePolicy": "Delete",
     },
-    "APIApiDeployment5C507F9Aca4e0dc5f0cd630edc0afa70cb44493d": {
+    "APIApiDeployment5C507F9A5caad0d70705540ac60b679a7ecf6503": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "APIApiproxyANYB1864AFB",
@@ -5861,6 +5862,7 @@ exports[`GenerativeAiUseCases matches the snapshot (closed network mode) 6`] = `
         "APIApichatschatIdfeedbacksOPTIONS7AB34AA5",
         "APIApichatschatIdfeedbacksPOST3E9ACBEC",
         "APIApichatschatIdGET152C9123",
+        "APIApichatschatIdmessagesDELETE5EC16981",
         "APIApichatschatIdmessagesGET94AB097F",
         "APIApichatschatIdmessagesOPTIONS20207E07",
         "APIApichatschatIdmessagesPOST4197DA8F",
@@ -5969,7 +5971,7 @@ exports[`GenerativeAiUseCases matches the snapshot (closed network mode) 6`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "APIApiDeployment3A5021237a3dd9dd1d0a04e8bff19caaa142feb6",
+          "Ref": "APIApiDeployment3A502123d250ee865e87535bbd9ca2feaef95e15",
         },
         "RestApiId": {
           "Ref": "APIApiFFA96F67",
@@ -7527,6 +7529,47 @@ exports[`GenerativeAiUseCases matches the snapshot (closed network mode) 6`] = `
         },
       },
       "Type": "AWS::ApiGateway::Resource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "APIApichatschatIdmessagesDELETE5EC16981": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "AuthorizationType": "COGNITO_USER_POOLS",
+        "AuthorizerId": {
+          "Ref": "APIAuthorizer9DCC037B",
+        },
+        "HttpMethod": "DELETE",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:us-east-1:lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "APIApiHandler18BC61F9",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "APIApichatschatIdmessagesAF527CE8",
+        },
+        "RestApiId": {
+          "Ref": "APIApiFFA96F67",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
       "UpdateReplacePolicy": "Delete",
     },
     "APIApichatschatIdmessagesGET94AB097F": {
@@ -19556,7 +19599,7 @@ exports[`GenerativeAiUseCases matches the snapshot 6`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Delete",
     },
-    "APIApiDeployment3A502123b4d122413b06aa1dcc09b7c3e41b73c2": {
+    "APIApiDeployment3A5021236a0c386960c6207673305bff58f4b1ce": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "APIApiApi4XXDCF913C8",
@@ -19576,6 +19619,7 @@ exports[`GenerativeAiUseCases matches the snapshot 6`] = `
         "APIApichatschatIdfeedbacksPOST3E9ACBEC",
         "APIApichatschatIdfeedbacksF371F57A",
         "APIApichatschatIdGET152C9123",
+        "APIApichatschatIdmessagesDELETE5EC16981",
         "APIApichatschatIdmessagesGET94AB097F",
         "APIApichatschatIdmessagesOPTIONS20207E07",
         "APIApichatschatIdmessagesPOST4197DA8F",
@@ -19723,7 +19767,7 @@ exports[`GenerativeAiUseCases matches the snapshot 6`] = `
       "Type": "AWS::ApiGateway::Deployment",
       "UpdateReplacePolicy": "Delete",
     },
-    "APIApiDeployment5C507F9A0550cc981adbb009856909b90e72a075": {
+    "APIApiDeployment5C507F9A3cccac9ba81ab6f6038a7ef69b8bb32b": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "APIApiproxyANYB1864AFB",
@@ -19737,6 +19781,7 @@ exports[`GenerativeAiUseCases matches the snapshot 6`] = `
         "APIApichatschatIdfeedbacksOPTIONS7AB34AA5",
         "APIApichatschatIdfeedbacksPOST3E9ACBEC",
         "APIApichatschatIdGET152C9123",
+        "APIApichatschatIdmessagesDELETE5EC16981",
         "APIApichatschatIdmessagesGET94AB097F",
         "APIApichatschatIdmessagesOPTIONS20207E07",
         "APIApichatschatIdmessagesPOST4197DA8F",
@@ -19845,7 +19890,7 @@ exports[`GenerativeAiUseCases matches the snapshot 6`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "APIApiDeployment3A502123b4d122413b06aa1dcc09b7c3e41b73c2",
+          "Ref": "APIApiDeployment3A5021236a0c386960c6207673305bff58f4b1ce",
         },
         "RestApiId": {
           "Ref": "APIApiFFA96F67",
@@ -21337,6 +21382,47 @@ exports[`GenerativeAiUseCases matches the snapshot 6`] = `
         },
       },
       "Type": "AWS::ApiGateway::Resource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "APIApichatschatIdmessagesDELETE5EC16981": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "AuthorizationType": "COGNITO_USER_POOLS",
+        "AuthorizerId": {
+          "Ref": "APIAuthorizer9DCC037B",
+        },
+        "HttpMethod": "DELETE",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:us-east-1:lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "APIApiHandler18BC61F9",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "APIApichatschatIdmessagesAF527CE8",
+        },
+        "RestApiId": {
+          "Ref": "APIApiFFA96F67",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
       "UpdateReplacePolicy": "Delete",
     },
     "APIApichatschatIdmessagesGET94AB097F": {

--- a/packages/cdk/test/lambda/deleteMessages.test.ts
+++ b/packages/cdk/test/lambda/deleteMessages.test.ts
@@ -1,0 +1,101 @@
+import { APIGatewayProxyEvent } from 'aws-lambda';
+import { handler } from '../../lambda/deleteMessages';
+import { deleteMessagesFrom, findChatById } from '../../lambda/repository';
+import { Chat } from 'generative-ai-use-cases';
+
+// Mock the repository
+jest.mock('../../lambda/repository');
+const mockedDeleteMessagesFrom = deleteMessagesFrom as jest.MockedFunction<
+  typeof deleteMessagesFrom
+>;
+const mockedFindChatById = findChatById as jest.MockedFunction<
+  typeof findChatById
+>;
+
+// Helper function to create APIGatewayProxyEvent
+function createAPIGatewayProxyEvent(
+  chatId?: string,
+  userId?: string,
+  queryStringParameters?: Record<string, string>
+): APIGatewayProxyEvent {
+  return {
+    pathParameters: chatId ? { chatId } : {},
+    queryStringParameters: queryStringParameters ?? null,
+    requestContext: {
+      authorizer: userId
+        ? {
+            claims: {
+              'cognito:username': userId,
+            },
+          }
+        : undefined,
+    },
+  } as unknown as APIGatewayProxyEvent;
+}
+
+const chat: Chat = {
+  id: 'user#testUser',
+  createdDate: '1234567890',
+  chatId: 'chat#chat123',
+  usecase: 'test',
+  title: 'test',
+  updatedDate: '1234567890',
+};
+
+describe('deleteMessages Lambda handler', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('deletes the messages from the given createdDate', async () => {
+    mockedFindChatById.mockResolvedValue(chat);
+    mockedDeleteMessagesFrom.mockResolvedValue(undefined);
+
+    const res = await handler(
+      createAPIGatewayProxyEvent('chat123', 'testUser', {
+        fromCreatedDate: '1234567891#0',
+      })
+    );
+
+    expect(res.statusCode).toBe(204);
+    expect(mockedDeleteMessagesFrom).toHaveBeenCalledWith(
+      'chat123',
+      '1234567891#0'
+    );
+  });
+
+  test('returns 400 when fromCreatedDate is not given', async () => {
+    const res = await handler(
+      createAPIGatewayProxyEvent('chat123', 'testUser')
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(mockedDeleteMessagesFrom).not.toHaveBeenCalled();
+  });
+
+  test('returns 403 when the chat belongs to another user', async () => {
+    mockedFindChatById.mockResolvedValue(null);
+
+    const res = await handler(
+      createAPIGatewayProxyEvent('chat123', 'anotherUser', {
+        fromCreatedDate: '1234567891#0',
+      })
+    );
+
+    expect(res.statusCode).toBe(403);
+    expect(mockedDeleteMessagesFrom).not.toHaveBeenCalled();
+  });
+
+  test('returns 500 when the repository throws an error', async () => {
+    mockedFindChatById.mockResolvedValue(chat);
+    mockedDeleteMessagesFrom.mockRejectedValue(new Error('DynamoDB error'));
+
+    const res = await handler(
+      createAPIGatewayProxyEvent('chat123', 'testUser', {
+        fromCreatedDate: '1234567891#0',
+      })
+    );
+
+    expect(res.statusCode).toBe(500);
+  });
+});

--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -155,6 +155,10 @@ chat:
   delete_link: Delete Link
   delete_link_message: You can stop sharing the conversation history by deleting the link.
   drop_files: Drop files here
+  edit_message_confirmation: Edit Message
+  edit_message_warning: >-
+    Editing this message will delete all the messages after it. Do you want to
+    continue?
   hint_cmd_enter: ⌘ + Enter to Submit
   hint_ctrl_enter: Ctrl + Enter to Submit
   history: History
@@ -469,6 +473,8 @@ drawer:
   tools: Tools
   use_cases: Use Cases
 error:
+  editFailed: Failed to edit the message. Please try again.
+  editTargetNotFound: The message to edit was not found. Please reload the page.
   streamingError:
     ACCESS_DENIED: The selected model is not enabled. Please enable the model in the Amazon Bedrock console.
     PAYLOAD_TOO_LARGE: The attached file is too large. Please reduce the file size or number of attachments and try again.

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -144,6 +144,8 @@ chat:
   delete_link: リンクの削除
   delete_link_message: リンクを削除することで、会話履歴の公開を停止できます。
   drop_files: ファイルをドロップしてください
+  edit_message_confirmation: メッセージの編集
+  edit_message_warning: このメッセージを編集すると、これ以降のメッセージは削除されます。続行しますか？
   hint_cmd_enter: ⌘ + Enter で送信
   hint_ctrl_enter: Ctrl + Enter で送信
   history: 履歴
@@ -407,6 +409,8 @@ drawer:
   tools: ツール
   use_cases: ユースケース
 error:
+  editFailed: メッセージの編集に失敗しました。再度お試しください。
+  editTargetNotFound: 編集対象のメッセージが見つかりませんでした。画面を再読み込みしてください。
   streamingError:
     ACCESS_DENIED: 選択されたモデルが有効化されていません。Amazon Bedrock コンソールでモデルを有効化してください。
     PAYLOAD_TOO_LARGE: 添付ファイルのサイズが大きすぎます。ファイルサイズまたは添付数を減らして再度お試しください。

--- a/packages/web/public/locales/translation/ko.yaml
+++ b/packages/web/public/locales/translation/ko.yaml
@@ -25,6 +25,8 @@ chat:
   delete_link: 링크 삭제
   delete_link_message: 링크를 삭제하여 대화 기록 공유를 중단할 수 있습니다.
   drop_files: 파일을 여기에 드롭
+  edit_message_confirmation: 메시지 편집
+  edit_message_warning: 이 메시지를 편집하면 이후의 모든 메시지가 삭제됩니다. 계속하시겠습니까?
   hint_cmd_enter: ⌘ + Enter로 전송
   hint_ctrl_enter: Ctrl + Enter로 전송
   history: 기록
@@ -312,6 +314,8 @@ drawer:
   tools: 도구
   use_cases: 사용 사례
 error:
+  editFailed: 메시지 편집에 실패했습니다. 다시 시도해 주세요.
+  editTargetNotFound: 편집할 메시지를 찾을 수 없습니다. 페이지를 다시 로드해 주세요.
   streamingError:
     ACCESS_DENIED: 선택한 모델이 활성화되어 있지 않습니다. Amazon Bedrock 콘솔에서 모델을 활성화해 주세요.
     PAYLOAD_TOO_LARGE: 첨부 파일의 크기가 너무 큽니다. 파일 크기 또는 첨부 파일 수를 줄이고 다시 시도해 주세요.

--- a/packages/web/public/locales/translation/th.yaml
+++ b/packages/web/public/locales/translation/th.yaml
@@ -15,6 +15,8 @@ chat:
   delete_link: ลบลิงก์
   delete_link_message: คุณสามารถหยุดการแชร์ประวัติการสนทนาโดยการลบลิงก์
   drop_files: วางไฟล์ที่นี่
+  edit_message_confirmation: แก้ไขข้อความ
+  edit_message_warning: การแก้ไขข้อความนี้จะลบข้อความทั้งหมดที่อยู่หลังจากนี้ ต้องการดำเนินการต่อหรือไม่
   hint_cmd_enter: ⌘ + Enter เพื่อส่ง
   hint_ctrl_enter: Ctrl + Enter เพื่อส่ง
   history: ประวัติ
@@ -318,6 +320,8 @@ drawer:
   tools: เครื่องมือ
   use_cases: Use cases
 error:
+  editFailed: แก้ไขข้อความไม่สำเร็จ กรุณาลองอีกครั้ง
+  editTargetNotFound: ไม่พบข้อความที่ต้องการแก้ไข กรุณาโหลดหน้าใหม่
   streamingError:
     ACCESS_DENIED: โมเดลที่เลือกยังไม่ได้เปิดใช้งาน กรุณาเปิดใช้งานโมเดลในคอนโซล Amazon Bedrock
     PAYLOAD_TOO_LARGE: ไฟล์แนบมีขนาดใหญ่เกินไป กรุณาลดขนาดไฟล์หรือจำนวนไฟล์แนบแล้วลองใหม่อีกครั้ง

--- a/packages/web/public/locales/translation/vi.yaml
+++ b/packages/web/public/locales/translation/vi.yaml
@@ -15,6 +15,10 @@ chat:
   delete_link: Xóa liên kết
   delete_link_message: Bằng cách xóa liên kết, bạn có thể ngừng công khai lịch sử cuộc trò chuyện.
   drop_files: Vui lòng thả file
+  edit_message_confirmation: Chỉnh sửa tin nhắn
+  edit_message_warning: >-
+    Việc chỉnh sửa tin nhắn này sẽ xóa tất cả tin nhắn phía sau. Bạn có muốn
+    tiếp tục?
   hint_cmd_enter: ⌘ + Enter để gửi
   hint_ctrl_enter: Ctrl + Enter để gửi
   history: Lịch sử
@@ -317,6 +321,8 @@ drawer:
   tools: Công cụ
   use_cases: Use case
 error:
+  editFailed: Không thể chỉnh sửa tin nhắn. Vui lòng thử lại.
+  editTargetNotFound: Không tìm thấy tin nhắn cần chỉnh sửa. Vui lòng tải lại trang.
   streamingError:
     ACCESS_DENIED: Mô hình được chọn chưa được kích hoạt. Vui lòng kích hoạt mô hình trong bảng điều khiển Amazon Bedrock.
     PAYLOAD_TOO_LARGE: Tệp đính kèm quá lớn. Vui lòng giảm kích thước tệp hoặc số lượng tệp đính kèm và thử lại.

--- a/packages/web/public/locales/translation/zh.yaml
+++ b/packages/web/public/locales/translation/zh.yaml
@@ -15,6 +15,8 @@ chat:
   delete_link: 删除链接
   delete_link_message: 通过删除链接，您可以停止公开对话历史。
   drop_files: 请拖放文件
+  edit_message_confirmation: 编辑消息
+  edit_message_warning: 编辑此消息将删除其后的所有消息。是否继续？
   history: 对话历史
   initialize: 初始化
   open_link: 打开链接
@@ -242,6 +244,8 @@ drawer:
   tools: 工具
   use_cases: 用例
 error:
+  editFailed: 消息编辑失败。请重试。
+  editTargetNotFound: 未找到要编辑的消息。请重新加载页面。
   streamingError:
     ACCESS_DENIED: 所选模型尚未启用。请在 Amazon Bedrock 控制台中启用该模型。
     PAYLOAD_TOO_LARGE: 附件文件过大。请减小文件大小或附件数量后重试。

--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
 import Markdown from './Markdown';
 import ButtonCopy from './ButtonCopy';
@@ -26,6 +26,7 @@ import useChat from '../hooks/useChat';
 import useTyping from '../hooks/useTyping';
 import FileCard from './FileCard';
 import FeedbackForm from './FeedbackForm';
+import DialogConfirmEditMessage from './DialogConfirmEditMessage';
 import Textarea from './Textarea';
 import useFiles from '../hooks/useFiles';
 import { useTranslation } from 'react-i18next';
@@ -40,8 +41,11 @@ type Props = BaseProps & {
   setShowSystemContextModal?: (value: boolean) => void;
   allowRetry?: boolean;
   editable?: boolean;
+  // Whether there are messages after this one. If true, committing an edit
+  // discards them, so a confirmation is shown.
+  hasFollowingMessages?: boolean;
   retryGeneration?: () => void;
-  onCommitEdit?: (modifiedPrompt: string) => void;
+  onCommitEdit?: (modifiedPrompt: string, messageId?: string) => void;
 };
 
 const ChatMessage: React.FC<Props> = (props) => {
@@ -57,6 +61,7 @@ const ChatMessage: React.FC<Props> = (props) => {
   const [showThankYouMessage, setShowThankYouMessage] = useState(false);
   const [editing, setEditing] = useState(false);
   const [editingPrompt, setEditingPrompt] = useState('');
+  const [showEditConfirmation, setShowEditConfirmation] = useState(false);
   const [isOpenTrace, setIsOpenTrace] = useState(false);
   const { getFileDownloadSignedUrl } = useFiles(pathname);
 
@@ -94,6 +99,18 @@ const ChatMessage: React.FC<Props> = (props) => {
   const disabled = useMemo(() => {
     return isSendingFeedback || !props.chatContent?.id;
   }, [isSendingFeedback, props]);
+
+  // The message can only be edited after it is recorded, because the messageId
+  // is required to identify which message to edit.
+  const editable = useMemo(() => {
+    return !!props.editable && !!chatContent?.messageId;
+  }, [props.editable, chatContent]);
+
+  const commitEdit = useCallback(() => {
+    setShowEditConfirmation(false);
+    setEditing(false);
+    props.onCommitEdit?.(editingPrompt, chatContent?.messageId);
+  }, [props, editingPrompt, chatContent]);
 
   const onSendFeedback = async (feedbackData: UpdateFeedbackRequest) => {
     if (!disabled) {
@@ -307,7 +324,7 @@ const ChatMessage: React.FC<Props> = (props) => {
               <PiFloppyDisk />
             </ButtonIcon>
           )}
-          {chatContent?.role === 'user' && props.editable && (
+          {chatContent?.role === 'user' && editable && (
             <>
               {editing ? (
                 <>
@@ -319,9 +336,10 @@ const ChatMessage: React.FC<Props> = (props) => {
                   </ButtonIcon>
                   <ButtonIcon
                     onClick={() => {
-                      if (props.onCommitEdit) {
-                        setEditing(false);
-                        props.onCommitEdit(editingPrompt);
+                      if (props.hasFollowingMessages) {
+                        setShowEditConfirmation(true);
+                      } else {
+                        commitEdit();
                       }
                     }}>
                     <PiCheck className="text-green-500" />
@@ -390,6 +408,14 @@ const ChatMessage: React.FC<Props> = (props) => {
           )}
         </div>
       </div>
+
+      {editable && (
+        <DialogConfirmEditMessage
+          isOpen={showEditConfirmation}
+          onConfirm={commitEdit}
+          onClose={() => setShowEditConfirmation(false)}
+        />
+      )}
     </div>
   );
 };

--- a/packages/web/src/components/DialogConfirmEditMessage.tsx
+++ b/packages/web/src/components/DialogConfirmEditMessage.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { BaseProps } from '../@types/common';
+import Button from './Button';
+import ModalDialog from './ModalDialog';
+import { useTranslation } from 'react-i18next';
+
+type Props = BaseProps & {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+};
+
+const DialogConfirmEditMessage: React.FC<Props> = (props) => {
+  const { t } = useTranslation();
+
+  return (
+    <ModalDialog {...props} title={t('chat.edit_message_confirmation')}>
+      <div>{t('chat.edit_message_warning')}</div>
+
+      <div className="mt-4 flex justify-end gap-2">
+        <Button outlined onClick={props.onClose} className="p-2">
+          {t('common.cancel')}
+        </Button>
+        <Button onClick={props.onConfirm} className="bg-red-500 p-2 text-white">
+          {t('common.edit')}
+        </Button>
+      </div>
+    </ModalDialog>
+  );
+};
+
+export default DialogConfirmEditMessage;

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -77,6 +77,7 @@ const useChatState = create<{
   ) => Promise<boolean | undefined>;
   edit: (
     id: string,
+    targetMessageId: string | undefined,
     content: string,
     mutateListChat: SWRInfiniteKeyedMutator<ListChatsResponse[]>,
     ignoreHistory: boolean,
@@ -141,6 +142,7 @@ const useChatState = create<{
   const {
     createChat,
     createMessages,
+    deleteMessagesFrom,
     updateFeedback,
     predictStream,
     predictTitle,
@@ -768,24 +770,27 @@ const useChatState = create<{
       const toBeRecordedMessages = addMessageIdsToUnrecordedMessages(id);
 
       // In the case of editting, update the last user's message
+      // (the message itself is already recorded, so it is not included in
+      // toBeRecordedMessages and has to be added explicitly)
       if (generationMode === 'edit') {
         const lastUserMessage: ShownMessage =
           get().chats[id].messages[get().chats[id].messages.length - 2];
-        const updatedUserMessage: ToBeRecordedMessage = {
-          createdDate: lastUserMessage.createdDate!,
-          messageId: lastUserMessage.messageId!,
-          usecase: lastUserMessage.usecase!,
-          ...lastUserMessage,
-        };
-        toBeRecordedMessages.push(updatedUserMessage);
+        if (lastUserMessage.messageId && lastUserMessage.createdDate) {
+          const updatedUserMessage: ToBeRecordedMessage = {
+            createdDate: lastUserMessage.createdDate,
+            messageId: lastUserMessage.messageId,
+            usecase: lastUserMessage.usecase!,
+            ...lastUserMessage,
+          };
+          toBeRecordedMessages.push(updatedUserMessage);
+        }
       }
 
-      // In the case of continuing to output, retrying, or editing, update the last assistant's message
-      if (
-        generationMode === 'continue' ||
-        generationMode === 'retry' ||
-        generationMode == 'edit'
-      ) {
+      // In the case of continuing to output or retrying, update the last
+      // assistant's message.
+      // (In the case of editing, the assistant's message is newly created and
+      // already included in toBeRecordedMessages)
+      if (generationMode === 'continue' || generationMode === 'retry') {
         const lastAssistantMessage: ShownMessage =
           get().chats[id].messages[get().chats[id].messages.length - 1];
         const updatedAssistantMessage: ToBeRecordedMessage = {
@@ -823,6 +828,8 @@ const useChatState = create<{
       }
       // edit/continue: Don't modify messages
       // - The conversation is already saved in DDB, so it can be restored by reloading
+      //   (in the case of editing, the conversation is restored as truncated at
+      //   the edited message, with its original content)
       // - The user can also retry
 
       // Detect Lambda payload too large error
@@ -992,6 +999,7 @@ const useChatState = create<{
 
     edit: async (
       id: string,
+      targetMessageId: string | undefined,
       content: string,
       mutateListChat: SWRInfiniteKeyedMutator<ListChatsResponse[]>,
       ignoreHistory: boolean,
@@ -1009,27 +1017,80 @@ const useChatState = create<{
         | AdditionalModelRequestFields
         | undefined = undefined
     ) => {
+      const messages = get().chats[id].messages;
+
+      // Find the index of the user message to edit.
+      // If targetMessageId is not given (backward compatibility), fall back to
+      // the last user message in the conversation.
+      const findLastUserMessageIndex = () => {
+        for (let i = messages.length - 1; i >= 0; i--) {
+          if (messages[i].role === 'user') {
+            return i;
+          }
+        }
+        return -1;
+      };
+      const targetIndex = targetMessageId
+        ? messages.findIndex((m) => m.messageId === targetMessageId)
+        : findLastUserMessageIndex();
+
+      if (targetIndex < 0) {
+        console.error(`The message to edit is not found: ${targetMessageId}`);
+        toast.error(i18next.t('error.editTargetNotFound'));
+        return;
+      }
+
+      // Delete the messages after the target from the table before truncating
+      // the local state. Without this, the discarded messages are restored on
+      // reload and mixed with the regenerated ones.
+      // The target message itself is kept: it is updated by createMessages
+      // after the regeneration, so the conversation stays consistent even if
+      // the regeneration fails.
+      const chatId = get().chats[id].chat?.chatId;
+      const firstDiscardedCreatedDate = messages
+        .slice(targetIndex + 1)
+        .find((m) => m.createdDate)?.createdDate;
+
+      if (chatId && firstDiscardedCreatedDate) {
+        // Prevent the conversation from being modified while the request is in
+        // flight (targetIndex would no longer point to the target message)
+        setLoading(id, true);
+
+        try {
+          await deleteMessagesFrom(chatId, firstDiscardedCreatedDate);
+        } catch (e) {
+          console.error(e);
+          setLoading(id, false);
+          toast.error(i18next.t('error.editFailed'));
+          return;
+        }
+      }
+
       set((state) => {
         const newChats = produce(state.chats, (draft) => {
-          const lastAssistantMessage = draft[id].messages.pop()!;
-          const lastUserMessage = draft[id].messages.pop()!;
+          const messages = draft[id].messages;
+          const targetUserMessage = messages[targetIndex];
 
-          // Clear the assistant message
+          // Edit the user message
+          const edittedUserMessage: UnrecordedMessage = {
+            ...targetUserMessage,
+            content,
+          };
+
+          // Remove the target message and everything after it (the rest of the
+          // conversation branch), then push the edited user message followed by
+          // a fresh, empty assistant message to be regenerated.
+          messages.splice(targetIndex);
+
           const clearedAssistantMessage: UnrecordedMessage = {
-            ...lastAssistantMessage,
+            role: 'assistant',
             content: '',
             trace: '',
             extraData: [],
           };
 
-          // Edit the user message
-          const edittedUserMessage: UnrecordedMessage = {
-            ...lastUserMessage,
-            content,
-          };
-
-          draft[id].messages.push(edittedUserMessage);
-          draft[id].messages.push(clearedAssistantMessage);
+          messages.push(edittedUserMessage);
+          messages.push(clearedAssistantMessage);
         });
 
         return {
@@ -1209,6 +1270,7 @@ const useChat = (id: string, chatId?: string) => {
       );
     },
     editChat: (
+      targetMessageId: string | undefined,
       content: string,
       ignoreHistory: boolean = false,
       preProcessInput:
@@ -1227,6 +1289,7 @@ const useChat = (id: string, chatId?: string) => {
     ) => {
       edit(
         id,
+        targetMessageId,
         content,
         mutateChatList,
         ignoreHistory,

--- a/packages/web/src/hooks/useChatApi.ts
+++ b/packages/web/src/hooks/useChatApi.ts
@@ -49,6 +49,17 @@ const useChatApi = () => {
     deleteChat: async (chatId: string) => {
       return http.delete<void>(`chats/${chatId}`);
     },
+    // Delete the messages whose createdDate is greater than or equal to
+    // fromCreatedDate. Used when a message in the middle of the conversation is
+    // edited and the following messages are discarded.
+    deleteMessagesFrom: async (_chatId: string, fromCreatedDate: string) => {
+      const chatId = decomposeId(_chatId);
+      return http.delete<void>(
+        `chats/${chatId}/messages?fromCreatedDate=${encodeURIComponent(
+          fromCreatedDate
+        )}`
+      );
+    },
     deleteAllChats: async (): Promise<void> => {
       let exclusiveStartKey: string | undefined = undefined;
       let hasMore = true;

--- a/packages/web/src/pages/AgentChatPage.tsx
+++ b/packages/web/src/pages/AgentChatPage.tsx
@@ -184,10 +184,15 @@ const AgentChatPage: React.FC = () => {
     setSessionId(uuidv4());
   }, [forceToStop, setSessionId]);
 
+  // Only the last user message can be edited.
+  // The conversation history is kept in the server-side agent session and only
+  // the last message is sent on each request, so truncating the conversation in
+  // the middle cannot be reflected on the agent side.
   const onEdit = useCallback(
-    (modifiedPrompt: string) => {
+    (modifiedPrompt: string, messageId?: string) => {
       setFollowing(true);
       editChat(
+        messageId,
         modifiedPrompt,
         false,
         undefined,

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -336,9 +336,10 @@ const ChatPage: React.FC = () => {
   }, [forceToStop]);
 
   const onEdit = useCallback(
-    (modifiedPrompt: string) => {
+    (modifiedPrompt: string, messageId?: string) => {
       setFollowing(true);
       editChat(
+        messageId,
         modifiedPrompt,
         false,
         undefined,
@@ -620,11 +621,10 @@ const ChatPage: React.FC = () => {
                   setSaveSystemContext={setSaveSystemContext}
                   setShowSystemContextModal={setShowSystemContextModal}
                   allowRetry={idx === showingMessages.length - 1}
-                  editable={idx === showingMessages.length - 2 && !loading}
+                  editable={chat.role === 'user' && !loading}
+                  hasFollowingMessages={idx < showingMessages.length - 2}
                   onCommitEdit={
-                    idx === showingMessages.length - 2 && !loading
-                      ? onEdit
-                      : undefined
+                    chat.role === 'user' && !loading ? onEdit : undefined
                   }
                   retryGeneration={onRetry}
                 />

--- a/packages/web/src/pages/RagKnowledgeBasePage.tsx
+++ b/packages/web/src/pages/RagKnowledgeBasePage.tsx
@@ -293,10 +293,15 @@ const RagKnowledgeBasePage: React.FC = () => {
     setSessionId(undefined);
   }, [clear, setContent, setFilters, setSessionId]);
 
+  // Only the last user message can be edited.
+  // RetrieveAndGenerate keeps the conversation history in the server-side
+  // session and only the last message is sent on each request, so truncating the
+  // conversation in the middle cannot be reflected on the Knowledge Base side.
   const onEdit = useCallback(
-    (modifiedPrompt: string) => {
+    (modifiedPrompt: string, messageId?: string) => {
       const extraData: ExtraData[] = getExtraDataFromFilters();
       editChat(
+        messageId,
         modifiedPrompt,
         false,
         undefined,

--- a/packages/web/tests/components/ChatMessage.test.tsx
+++ b/packages/web/tests/components/ChatMessage.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ShownMessage } from 'generative-ai-use-cases';
+import ChatMessage from '../../src/components/ChatMessage';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useLocation: () => ({ pathname: '/chat' }),
+}));
+
+vi.mock('../../src/hooks/useChat', () => ({
+  default: () => ({
+    sendFeedback: vi.fn(),
+  }),
+  __esModule: true,
+}));
+
+vi.mock('../../src/hooks/useFiles', () => ({
+  default: () => ({
+    getFileDownloadSignedUrl: vi.fn(),
+  }),
+  __esModule: true,
+}));
+
+vi.mock('../../src/hooks/useTyping', () => ({
+  default: () => ({
+    setTypingTextInput: vi.fn(),
+    typingTextOutput: 'Hello',
+  }),
+  __esModule: true,
+}));
+
+const userMessage = (messageId?: string): ShownMessage =>
+  ({
+    id: 'chat#chat123',
+    role: 'user',
+    content: 'Hello',
+    messageId,
+  }) as ShownMessage;
+
+// The edit button is the only button rendered for a user message
+const editButtons = () => screen.queryAllByRole('button');
+
+describe('ChatMessage edit button', () => {
+  it('is shown for any recorded user message, not only the latest one', () => {
+    render(
+      <ChatMessage
+        chatContent={userMessage('msg123')}
+        editable={true}
+        // A message in the middle of the conversation
+        hasFollowingMessages={true}
+        onCommitEdit={vi.fn()}
+      />
+    );
+
+    expect(editButtons()).toHaveLength(1);
+  });
+
+  it('is hidden when the message is not recorded yet (no messageId)', () => {
+    render(
+      <ChatMessage
+        chatContent={userMessage(undefined)}
+        editable={true}
+        onCommitEdit={vi.fn()}
+      />
+    );
+
+    expect(editButtons()).toHaveLength(0);
+  });
+
+  it('is hidden when editable is false', () => {
+    render(
+      <ChatMessage
+        chatContent={userMessage('msg123')}
+        editable={false}
+        onCommitEdit={vi.fn()}
+      />
+    );
+
+    expect(editButtons()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Description of Changes

Extends the message edit feature (#1120) so that a message in the middle of a conversation can be edited, and fixes the data consistency issues that blocked it.

### Problem

The edit feature only allowed editing the last user message. Extending it to earlier messages surfaced two issues in the existing implementation:

1. **Discarded messages were left in DynamoDB.** Truncation was applied to the client
 state only, and there was no API to delete messages. On reload, the discarded
 messages came back and were mixed with the regenerated response (the edited user
 message keeps its original `createdDate` while the new response gets a newer one,
 so the restored order was broken).
2. **The assistant message was recorded twice.** The regenerated assistant message was
 pushed to `toBeRecordedMessages` by `addMessageIdsToUnrecordedMessages()` and then
 again by the `generationMode === 'edit'` branch, producing two DynamoDB items with
 the same `messageId` and different `createdDate`.

### Changes

**Backend**

- Add `DELETE /chats/{chatId}/messages?fromCreatedDate=...`
- `deleteMessagesFrom()` in `repository.ts` queries the keys with `createdDate >= :fromCreatedDate` and deletes them with chunked `BatchWriteItem` (same pattern as the existing `deleteChat()`)
- The handler returns 400 without `fromCreatedDate` and 403 when the chat belongs to another user (`findChatById()`)
- Token usage already recorded in the stats table is intentionally not rolled back, because the tokens were actually consumed
- `messages.addMethod('DELETE')` is declared explicitly in `api.ts` because the `addProxy()` catch-all does not apply to methods of an already declared Resource. `API_DEPLOYMENT_VERSION` is bumped to `v3` accordingly.

**Frontend**

- `useChat.edit()` now takes the target `messageId`, truncates the conversation at that message, and deletes the discarded messages from the table before updating the local state. The deletion range starts at the message *after* the target, so if the regeneration fails the stored conversation is still consistent (truncated at the edited message, with its original content).
- Validation moved out of the `produce()` recipe: if the target is not found, an error toast is shown and the regeneration is not started (previously it silently fell through and regenerated on top of the existing response).
- `loading` is set while the delete request is in flight so the conversation cannot be modified underneath the operation.
- The assistant message is no longer recorded twice (the `edit` case is removed from the assistant update branch).
- Messages without a `messageId` (not recorded yet) are not editable, to avoid editing the wrong message through the fallback path.
- A confirmation dialog is shown only when there are messages after the edited one, so
editing the last message stays a single click as before.

### Scope

| Use case | Editable messages |
| --- | --- |
| Chat | any user message |
| RAG Chat (Knowledge Base) | last user message only (unchanged) |
| Agent Chat | last user message only (unchanged) |

RAG Chat (KB) and Agent Chat send only the last message plus a `sessionId` (`RetrieveAndGenerateStream` / `InvokeAgent`), so the conversation history lives in the server-side session. Truncating the conversation on the client cannot be reflected there, which means the model would keep answering based on messages the user has just deleted. `RetrieveAndGenerate` has no equivalent of `sessionState.conversationHistory`, so a truncated history cannot be seeded either, and resetting the session would drop the whole context. Middle-of-conversation editing is therefore enabled only on the plain Chat page, where the full message list is sent on every request. Editing the last message behaves as before on all three pages.

### Impact on existing users

- Editing a message in the middle of a conversation deletes all the messages after it. This is irreversible, so a confirmation dialog was added. Branching (keeping the previous conversation as an alternative path) is out of scope for this PR.
- On edit, the regenerated assistant message is now stored as a new item (new `messageId`) instead of being updated in place. Feedback on that message was already reset by `batchCreateMessages()` before this change, so the visible behavior is the same.
- New i18n keys: `chat.edit_message_confirmation`, `chat.edit_message_warning`, `error.editFailed`, `error.editTargetNotFound` (added for all 6 languages).

## Checklist

- [ ] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

### Tests

- `packages/cdk/test/lambda/deleteMessages.test.ts`: 204 / 400 / 403 / 500
- `packages/web/tests/components/ChatMessage.test.tsx`: the edit button is shown for any
recorded user message, and hidden when the message has no `messageId` or is not editable
- `npm run lint`, `npm run web:test` (281 passed), `npx jest test/lambda` (34 passed)

## Related Issues

- #4
- Follows up #1120