### PR TITLE
agentcore runtime closed network

### DIFF
--- a/docs/en/CLOSED_NETWORK.md
+++ b/docs/en/CLOSED_NETWORK.md
@@ -29,9 +29,23 @@ Options related to closed network mode have the `closedNetwork` prefix. The foll
 - Deployment must be performed in an environment with internet connectivity. Also, internet connectivity is required when accessing the operation verification environment from the management console.
 - Deployment requires the same environment as normal mode deployment. Specifically, AWS IAM user configuration, Node.js, and Docker are needed.
 - The region where GenU is deployed and the model region must be the same. Currently, it's not possible to deploy GenU in ap-northeast-1 and use models from us-east-1.
+- When enabling AgentCore (`agentBuilderEnabled` / `createGenericAgentCoreRuntime`), `agentCoreRegion` must also be the same region. In closed network mode, the AgentCore Runtime shares the closed VPC, so it cannot be deployed to a different region (if not specified, it automatically defaults to the same value as `region`). Research Agent (`researchAgentEnabled`) cannot be used in closed network mode because the AgentCore Runtime currently uses a fixed PUBLIC network configuration.
 - Since various resources are created, when importing an existing VPC, it's recommended to use as clean an environment as possible.
 - SAML integration is not available.
 - Voice Chat use case is currently not available.
+
+## AgentCore in Closed Network Mode
+
+When `closedNetworkMode: true` and either `agentBuilderEnabled` or `createGenericAgentCoreRuntime` is enabled, the AgentCore Runtime is automatically deployed with a PRIVATE network configuration (`isAgentCoreNetworkPrivate=true`), sharing the closed VPC and subnets from the ClosedNetworkStack. You do not need to separately specify `agentCoreVpcId` / `agentCoreSubnetIds`.
+
+The following VPC Endpoints are automatically created in the closed VPC, so all communication from the AgentCore Runtime and browser InvokeAgentRuntime calls are completed within the VPC:
+
+- `bedrock-agentcore` (Runtime data plane / control plane)
+- `bedrock-agentcore-gateway` (AgentCore Gateway invocation)
+- `bedrock-runtime` (Foundation Model invocation)
+- `ecr` / `ecr-docker` (Runtime image pull)
+- `logs` (CloudWatch Logs)
+- `s3` (Gateway Endpoint for FileBucket and data source access)
 
 ## Example of Valid Configuration File
 
@@ -142,17 +156,19 @@ Here we make two assumptions:
 
 The endpoints that require name resolution from clients are as follows. Parts enclosed in `<>` need to be replaced with actual values.
 
-| Service Name                | Role                        | Endpoint                                                     | How to Check Endpoint                                                                         |
-| --------------------------- | --------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
-| Application Load Balancer   | Web static file server      | Custom domain or internal-\<aaa>.\<region>.elb.amazonaws.com | Check with ClosedNetworkWebUrl output of ClosedNetworkStack                                   |
-| API Gateway                 | Main API                    | \<xxx>.execute-api.\<region>.amazonaws.com                   | Check with ApiEndpoint output of **GenerativeAiUseCasesStack**                                |
-| API Gateway                 | Cognito User Pool proxy     | \<yyy>.execute-api.\<region>.amazonaws.com                   | Check with CognitoPrivateProxyCognitoUserPoolProxyApiEndpoint... output of ClosedNetworkStack |
-| API Gateway                 | Cognito Identity Pool proxy | \<zzz>.execute-api.\<region>.amazonaws.com                   | Check with CognitoPrivateProxyCognitoIdPoolProxyApiEndpoint... output of ClosedNetworkStack   |
-| Amazon S3                   | Signed URLs                 | s3.\<region>.amazonaws.com                                   | Endpoint is fixed                                                                             |
-| AWS Lambda                  | Streaming output            | lambda.\<region>.amazonaws.com                               | Endpoint is fixed                                                                             |
-| Amazon Transcribe           | Speech-to-text              | transcribe.\<region>.amazonaws.com                           | Endpoint is fixed                                                                             |
-| Amazon Transcribe Streaming | Real-time speech-to-text    | transcribestreaming.\<region>.amazonaws.com                  | Endpoint is fixed                                                                             |
-| Amazon Polly                | Text-to-speech              | polly.\<region>.amazonaws.com                                | Endpoint is fixed                                                                             |
+| Service Name                | Role                         | Endpoint                                                     | How to Check Endpoint                                                                         |
+| --------------------------- | ---------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| Application Load Balancer   | Web static file server       | Custom domain or internal-\<aaa>.\<region>.elb.amazonaws.com | Check with ClosedNetworkWebUrl output of ClosedNetworkStack                                   |
+| API Gateway                 | Main API                     | \<xxx>.execute-api.\<region>.amazonaws.com                   | Check with ApiEndpoint output of **GenerativeAiUseCasesStack**                                |
+| API Gateway                 | Cognito User Pool proxy      | \<yyy>.execute-api.\<region>.amazonaws.com                   | Check with CognitoPrivateProxyCognitoUserPoolProxyApiEndpoint... output of ClosedNetworkStack |
+| API Gateway                 | Cognito Identity Pool proxy  | \<zzz>.execute-api.\<region>.amazonaws.com                   | Check with CognitoPrivateProxyCognitoIdPoolProxyApiEndpoint... output of ClosedNetworkStack   |
+| Amazon S3                   | Signed URLs                  | s3.\<region>.amazonaws.com                                   | Endpoint is fixed                                                                             |
+| AWS Lambda                  | Streaming output             | lambda.\<region>.amazonaws.com                               | Endpoint is fixed                                                                             |
+| Amazon Transcribe           | Speech-to-text               | transcribe.\<region>.amazonaws.com                           | Endpoint is fixed                                                                             |
+| Amazon Transcribe Streaming | Real-time speech-to-text     | transcribestreaming.\<region>.amazonaws.com                  | Endpoint is fixed                                                                             |
+| Amazon Polly                | Text-to-speech               | polly.\<region>.amazonaws.com                                | Endpoint is fixed                                                                             |
+| Bedrock AgentCore Runtime   | AgentCore Runtime execution  | bedrock-agentcore.\<region>.amazonaws.com                    | Endpoint is fixed                                                                             |
+| Bedrock AgentCore Gateway   | AgentCore Gateway invocation | bedrock-agentcore-gateway.\<region>.amazonaws.com            | Endpoint is fixed                                                                             |
 
 Please modify your DNS server configuration to specify the IP address of the Resolver Endpoint as the resolver (forwarder) for all endpoints in the table above.
 The IP address of the Resolver Endpoint can be confirmed by opening [Route53](https://console.aws.amazon.com/route53resolver), selecting Inbound endpoints, and clicking on the created endpoint.
@@ -166,17 +182,19 @@ When configuring the local machine's /etc/hosts, you need the IP addresses of ea
 However, since these IP addresses may change and you can only specify a single IP address without redundancy, please use this only for operation verification.
 The following summarizes the endpoints that need configuration and how to check their IP addresses.
 
-| Service Name                | Role                        | Endpoint                                                     | How to Check IP Address |
-| --------------------------- | --------------------------- | ------------------------------------------------------------ | ----------------------- |
-| Application Load Balancer   | Web static file server      | Custom domain or internal-\<aaa>.\<region>.elb.amazonaws.com | Method 1                |
-| API Gateway                 | Main API                    | \<xxx>.execute-api.\<region>.amazonaws.com                   | Method 2                |
-| API Gateway                 | Cognito User Pool proxy     | \<yyy>.execute-api.\<region>.amazonaws.com                   | Method 2                |
-| API Gateway                 | Cognito Identity Pool proxy | \<zzz>.execute-api.\<region>.amazonaws.com                   | Method 2                |
-| Amazon S3                   | Signed URLs                 | \<S3 bucket name>.s3.\<region>.amazonaws.com                 | Method 2                |
-| AWS Lambda                  | Streaming output            | lambda.\<region>.amazonaws.com                               | Method 2                |
-| Amazon Transcribe           | Speech-to-text              | transcribe.\<region>.amazonaws.com                           | Method 2                |
-| Amazon Transcribe Streaming | Real-time speech-to-text    | transcribestreaming.\<region>.amazonaws.com                  | Method 2                |
-| Amazon Polly                | Text-to-speech              | polly.\<region>.amazonaws.com                                | Method 2                |
+| Service Name                | Role                         | Endpoint                                                     | How to Check IP Address |
+| --------------------------- | ---------------------------- | ------------------------------------------------------------ | ----------------------- |
+| Application Load Balancer   | Web static file server       | Custom domain or internal-\<aaa>.\<region>.elb.amazonaws.com | Method 1                |
+| API Gateway                 | Main API                     | \<xxx>.execute-api.\<region>.amazonaws.com                   | Method 2                |
+| API Gateway                 | Cognito User Pool proxy      | \<yyy>.execute-api.\<region>.amazonaws.com                   | Method 2                |
+| API Gateway                 | Cognito Identity Pool proxy  | \<zzz>.execute-api.\<region>.amazonaws.com                   | Method 2                |
+| Amazon S3                   | Signed URLs                  | \<S3 bucket name>.s3.\<region>.amazonaws.com                 | Method 2                |
+| AWS Lambda                  | Streaming output             | lambda.\<region>.amazonaws.com                               | Method 2                |
+| Amazon Transcribe           | Speech-to-text               | transcribe.\<region>.amazonaws.com                           | Method 2                |
+| Amazon Transcribe Streaming | Real-time speech-to-text     | transcribestreaming.\<region>.amazonaws.com                  | Method 2                |
+| Amazon Polly                | Text-to-speech               | polly.\<region>.amazonaws.com                                | Method 2                |
+| Bedrock AgentCore Runtime   | AgentCore Runtime execution  | bedrock-agentcore.\<region>.amazonaws.com                    | Method 2                |
+| Bedrock AgentCore Gateway   | AgentCore Gateway invocation | bedrock-agentcore-gateway.\<region>.amazonaws.com            | Method 2                |
 
 - Method 1: Open Network Interfaces in [EC2](https://console.aws.amazon.com/ec2/home) and search for "elb". The target ENI is the one with Security group names starting with ClosedNetworkStack.... Click the Network interface ID to see the Private IPv4 address. Since there are multiple, select one of them.
 - Method 2: Open Endpoints in [VPC](https://console.aws.amazon.com/vpcconsole/home) and look for the corresponding service name. The service name is the reverse of the endpoint. (However, for API Gateway, the ID is omitted.) Click the VPC endpoint ID to see the deployed Subnets and IP addresses at the bottom of the page. Since there are multiple, select one of them.

--- a/docs/ja/CLOSED_NETWORK.md
+++ b/docs/ja/CLOSED_NETWORK.md
@@ -30,9 +30,23 @@
 - デプロイはインターネットに疎通可能な環境で行う必要があります。また、動作検証環境にはマネージメントコンソールからアクセスするため、その場合もインターネット疎通が必要になります。
 - デプロイには、通常モードのデプロイと同様の環境が必要です。具体的には、AWS IAM ユーザーの設定、Node.js、Docker が必要です。
 - GenU がデプロイされるリージョンとモデルのリージョンは同一である必要があります。GenU を ap-northeast-1 にデプロイし、us-east-1 のモデルを利用するといったことは現状できません。
+- AgentCore (`agentBuilderEnabled` / `createGenericAgentCoreRuntime`) を有効化する場合、`agentCoreRegion` も同一リージョンである必要があります。閉域モードでは閉域 VPC を AgentCore Runtime が共有するため、別リージョンへのデプロイはできません (指定がない場合は自動的に `region` と同一になります)。Research Agent (`researchAgentEnabled`) は AgentCore Runtime が現状 PUBLIC ネットワーク固定のため、閉域モードでは利用できません。
 - 様々なリソースを作成するため、既存の VPC をインポートする場合は可能な限り clean な環境を利用することを推奨します。
 - SAML 連携は利用できません。
 - Voice Chat のユースケースは現状利用できません。
+
+## 閉域モードでの AgentCore
+
+`closedNetworkMode: true` かつ `agentBuilderEnabled` または `createGenericAgentCoreRuntime` を有効化した場合、AgentCore Runtime は自動的に PRIVATE ネットワーク構成 (`isAgentCoreNetworkPrivate=true`) でデプロイされ、閉域 VPC とサブネットを ClosedNetworkStack から共有します。`agentCoreVpcId` / `agentCoreSubnetIds` を別途指定する必要はありません。
+
+VPC Endpoint は閉域 VPC に下記が自動作成されるため、AgentCore Runtime からの通信および ブラウザからの InvokeAgentRuntime はすべて VPC 内で完結します。
+
+- `bedrock-agentcore` (Runtime データプレーン / コントロールプレーン)
+- `bedrock-agentcore-gateway` (AgentCore Gateway 呼び出し)
+- `bedrock-runtime` (Foundation Model 呼び出し)
+- `ecr` / `ecr-docker` (Runtime イメージの Pull)
+- `logs` (CloudWatch Logs)
+- `s3` (Gateway Endpoint。FileBucket やデータソースへのアクセス)
 
 ## 有効な設定ファイルの例
 
@@ -143,18 +157,19 @@ Certificate body には ssl.crt の中身、Certificate private key には ssl.k
 
 クライアントから名前解決が必要なエンドポイントは以下の通りです。`<>` で囲まれた箇所は実際の値に置き換えが必要です。
 
-| サービス名                  | 役割                       | エンドポイント                                              | エンドポイントの確認方法                                  |
-| --------------------------- | -------------------------- | ----------------------------------------------------------- | --------------------------------------------------------- |
-| Application Load Balancer   | Web 静的ファイルのサーバー | 独自ドメイン or internal-\<aaa>.\<region>.elb.amazonaws.com | ClosedNetworkStack の出力の ClosedNetworkWebUrl で確認    |
-| API Gateway                 | メインの API               | \<xxx>.execute-api.\<region>.amazonaws.com                  | **GenerativeAiUseCasesStack** の出力の ApiEndpoint で確認 |
-| Cognito User Pool           | 認証                       | cognito-idp.\<region>.amazonaws.com                         | エンドポイントは固定                                      |
-| Cognito Identity Pool       | 一時認証情報の取得         | cognito-identity.\<region>.amazonaws.com                    | エンドポイントは固定                                      |
-| Amazon S3                   | 署名付き URL               | s3.\<region>.amazonaws.com                                  | エンドポイントは固定                                      |
-| AWS Lambda                  | ストリーミング出力         | lambda.\<region>.amazonaws.com                              | エンドポイントは固定                                      |
-| Amazon Transcribe           | 文字起こし                 | transcribe.\<region>.amazonaws.com                          | エンドポイントは固定                                      |
-| Amazon Transcribe Streaming | リアルタイム文字起こし     | transcribestreaming.\<region>.amazonaws.com                 | エンドポイントは固定                                      |
-| Amazon Polly                | 文字の読み上げ             | polly.\<region>.amazonaws.com                               | エンドポイントは固定                                      |
-| Bedrock AgentCore Runtime   | AgentCore Runtime の実行   | bedrock-agentcore.\<region>.amazonaws.com                   | エンドポイントは固定                                      |
+| サービス名                  | 役割                         | エンドポイント                                              | エンドポイントの確認方法                                  |
+| --------------------------- | ---------------------------- | ----------------------------------------------------------- | --------------------------------------------------------- |
+| Application Load Balancer   | Web 静的ファイルのサーバー   | 独自ドメイン or internal-\<aaa>.\<region>.elb.amazonaws.com | ClosedNetworkStack の出力の ClosedNetworkWebUrl で確認    |
+| API Gateway                 | メインの API                 | \<xxx>.execute-api.\<region>.amazonaws.com                  | **GenerativeAiUseCasesStack** の出力の ApiEndpoint で確認 |
+| Cognito User Pool           | 認証                         | cognito-idp.\<region>.amazonaws.com                         | エンドポイントは固定                                      |
+| Cognito Identity Pool       | 一時認証情報の取得           | cognito-identity.\<region>.amazonaws.com                    | エンドポイントは固定                                      |
+| Amazon S3                   | 署名付き URL                 | s3.\<region>.amazonaws.com                                  | エンドポイントは固定                                      |
+| AWS Lambda                  | ストリーミング出力           | lambda.\<region>.amazonaws.com                              | エンドポイントは固定                                      |
+| Amazon Transcribe           | 文字起こし                   | transcribe.\<region>.amazonaws.com                          | エンドポイントは固定                                      |
+| Amazon Transcribe Streaming | リアルタイム文字起こし       | transcribestreaming.\<region>.amazonaws.com                 | エンドポイントは固定                                      |
+| Amazon Polly                | 文字の読み上げ               | polly.\<region>.amazonaws.com                               | エンドポイントは固定                                      |
+| Bedrock AgentCore Runtime   | AgentCore Runtime の実行     | bedrock-agentcore.\<region>.amazonaws.com                   | エンドポイントは固定                                      |
+| Bedrock AgentCore Gateway   | AgentCore Gateway の呼び出し | bedrock-agentcore-gateway.\<region>.amazonaws.com           | エンドポイントは固定                                      |
 
 上の表のすべてのエンドポイントのリゾルバー (フォワーダー) として Resolver Endpoint の IP アドレスを指定するように DNS サーバーの設定を変更してください。
 Resolver Endpoint の IP アドレスは、[Route53](https://console.aws.amazon.com/route53resolver) を開き、Inbound endpoints を選択して、作成したエンドポイントをクリックすることで確認できます。

--- a/packages/cdk/lambda-python/generic-agent-core-runtime/Dockerfile
+++ b/packages/cdk/lambda-python/generic-agent-core-runtime/Dockerfile
@@ -17,6 +17,13 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 # Pre-install mcp-remote for faster startup
 RUN npm install -g mcp-remote
 
+# Pre-install mcp-proxy-for-aws so it works without runtime PyPI access
+# (required for closed network mode where the runtime VPC has no internet egress).
+# UV_TOOL_BIN_DIR=/usr/local/bin places the binary on PATH so mcp.json can call
+# `mcp-proxy-for-aws` directly without going through `uvx` (which would re-fetch
+# from PyPI at every invocation due to UV_NO_CACHE=1).
+RUN UV_TOOL_BIN_DIR=/usr/local/bin UV_TOOL_DIR=/usr/local/uv-tools uv tool install mcp-proxy-for-aws
+
 # Copy dependency files
 COPY pyproject.toml .python-version uv.lock ./
 # Install Python dependencies

--- a/packages/cdk/lib/agent-core-stack.ts
+++ b/packages/cdk/lib/agent-core-stack.ts
@@ -1,5 +1,6 @@
 import { Stack, StackProps, CfnOutput } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
+import { IVpc, ISubnet } from 'aws-cdk-lib/aws-ec2';
 import { GenericAgentCore } from './construct/generic-agent-core';
 import { ProcessedStackInput } from './stack-input';
 import { BucketInfo } from 'generative-ai-use-cases';
@@ -7,6 +8,10 @@ import { REMOTE_OUTPUT_KEYS } from './remote-output-keys';
 
 export interface AgentCoreStackProps extends StackProps {
   readonly params: ProcessedStackInput;
+  // Pre-resolved VPC + subnets from ClosedNetworkStack (closed network mode).
+  // When provided, AgentCore Runtime is deployed inside this VPC and reuses its endpoints.
+  readonly vpc?: IVpc;
+  readonly subnets?: ISubnet[];
 }
 
 export class AgentCoreStack extends Stack {
@@ -26,6 +31,8 @@ export class AgentCoreStack extends Stack {
         isAgentCoreNetworkPrivate: params.isAgentCoreNetworkPrivate,
         agentCoreVpcId: params.agentCoreVpcId,
         agentCoreSubnetIds: params.agentCoreSubnetIds,
+        vpc: props.vpc,
+        subnets: props.subnets,
         gatewayArns: params.agentCoreGatewayArns ?? undefined,
       });
 

--- a/packages/cdk/lib/closed-network-stack.ts
+++ b/packages/cdk/lib/closed-network-stack.ts
@@ -13,6 +13,7 @@ export interface ClosedNetworkStackProps extends StackProps {
 
 export class ClosedNetworkStack extends Stack {
   public readonly vpc: ec2.IVpc;
+  public readonly closedVpc: ClosedVpc;
   public readonly apiGatewayVpcEndpoint: ec2.InterfaceVpcEndpoint;
   public readonly webBucket: s3.Bucket;
 
@@ -105,6 +106,7 @@ export class ClosedNetworkStack extends Stack {
     }
 
     this.vpc = closedVpc.vpc;
+    this.closedVpc = closedVpc;
     this.webBucket = closedWeb.bucket;
     this.apiGatewayVpcEndpoint = closedVpc.apiGatewayVpcEndpoint;
   }

--- a/packages/cdk/lib/construct/closedNetwork/closed-vpc.ts
+++ b/packages/cdk/lib/construct/closedNetwork/closed-vpc.ts
@@ -10,6 +10,8 @@ const VPC_ENDPOINTS: Record<string, ec2.InterfaceVpcEndpointAwsService> = {
   TranscribeStreaming: ec2.InterfaceVpcEndpointAwsService.TRANSCRIBE_STREAMING,
   Polly: ec2.InterfaceVpcEndpointAwsService.POLLY,
   AgentCore: ec2.InterfaceVpcEndpointAwsService.BEDROCK_AGENTCORE,
+  AgentCoreGateway:
+    ec2.InterfaceVpcEndpointAwsService.BEDROCK_AGENTCORE_GATEWAY,
   // Cognito VPC Endpoints (Private Link)
   CognitoIdp: ec2.InterfaceVpcEndpointAwsService.COGNITO_IDP,
   CognitoIdentity: new ec2.InterfaceVpcEndpointAwsService('cognito-identity'),
@@ -24,6 +26,9 @@ const VPC_ENDPOINTS: Record<string, ec2.InterfaceVpcEndpointAwsService> = {
   CloudWatchLogs: ec2.InterfaceVpcEndpointAwsService.CLOUDWATCH_LOGS,
   Kendra: ec2.InterfaceVpcEndpointAwsService.KENDRA,
   Sts: ec2.InterfaceVpcEndpointAwsService.STS,
+  // Required by AgentCore Gateway to read API key secrets at invocation time,
+  // and by the API Key Credential Provider creation flow to read user secrets.
+  SecretsManager: ec2.InterfaceVpcEndpointAwsService.SECRETS_MANAGER,
 };
 
 export interface ClosedVpcProps {
@@ -35,6 +40,7 @@ export interface ClosedVpcProps {
 
 export class ClosedVpc extends Construct {
   public readonly vpc: ec2.IVpc;
+  public readonly subnets: ec2.ISubnet[];
   public readonly apiGatewayVpcEndpoint: ec2.InterfaceVpcEndpoint;
   public readonly hostedZone: PrivateHostedZone | undefined;
 
@@ -59,6 +65,13 @@ export class ClosedVpc extends Construct {
         ],
       });
     }
+
+    // Resolve the subnet set used by VPC endpoints; reused by other constructs (e.g. AgentCore Runtime)
+    this.subnets = props.subnetIds
+      ? props.subnetIds.map((subnetId, index) =>
+          ec2.Subnet.fromSubnetId(this, `ClosedSubnet${index}`, subnetId)
+        )
+      : vpc.isolatedSubnets;
 
     vpc.addGatewayEndpoint('S3GatewayEndpoint', {
       service: ec2.GatewayVpcEndpointAwsService.S3,

--- a/packages/cdk/lib/construct/generic-agent-core.ts
+++ b/packages/cdk/lib/construct/generic-agent-core.ts
@@ -40,6 +40,10 @@ export interface GenericAgentCoreProps {
   isAgentCoreNetworkPrivate?: boolean;
   agentCoreVpcId?: string | null;
   agentCoreSubnetIds?: string[] | null;
+  // Pre-resolved VPC / subnets (e.g. injected from ClosedNetworkStack via cross-stack reference).
+  // When provided, these are used directly instead of Vpc.fromLookup(agentCoreVpcId).
+  vpc?: IVpc;
+  subnets?: ISubnet[];
   gatewayArns?: string[];
 }
 
@@ -70,6 +74,8 @@ export class GenericAgentCore extends Construct {
       isAgentCoreNetworkPrivate = false,
       agentCoreVpcId = null,
       agentCoreSubnetIds = null,
+      vpc: providedVpc,
+      subnets: providedSubnets,
       gatewayArns,
     } = props;
 
@@ -88,11 +94,20 @@ export class GenericAgentCore extends Construct {
     let vpc: IVpc | undefined;
     let subnets: ISubnet[] | undefined;
 
-    if (isAgentCoreNetworkPrivate && agentCoreVpcId && agentCoreSubnetIds) {
-      vpc = Vpc.fromLookup(this, 'AgentCoreVpc', { vpcId: agentCoreVpcId });
-      subnets = agentCoreSubnetIds.map((subnetId, index) =>
-        Subnet.fromSubnetId(this, `AgentCoreSubnet${index}`, subnetId)
-      );
+    // Resolve VPC + subnets: prefer pre-resolved refs (e.g. from ClosedNetworkStack), then fall back to lookup-by-id
+    if (isAgentCoreNetworkPrivate) {
+      if (providedVpc && providedSubnets && providedSubnets.length > 0) {
+        vpc = providedVpc;
+        subnets = providedSubnets;
+      } else if (agentCoreVpcId && agentCoreSubnetIds) {
+        vpc = Vpc.fromLookup(this, 'AgentCoreVpc', { vpcId: agentCoreVpcId });
+        subnets = agentCoreSubnetIds.map((subnetId, index) =>
+          Subnet.fromSubnetId(this, `AgentCoreSubnet${index}`, subnetId)
+        );
+      }
+    }
+
+    if (vpc && subnets) {
       securityGroup = new SecurityGroup(this, 'AgentCoreSecurityGroup', {
         vpc,
         description: 'Security group for AgentCore Runtime',

--- a/packages/cdk/lib/create-stacks.ts
+++ b/packages/cdk/lib/create-stacks.ts
@@ -114,6 +114,8 @@ export const createStacks = (app: cdk.App, params: ProcessedStackInput) => {
             region: params.agentCoreRegion,
           },
           params: params,
+          vpc: closedNetworkStack?.closedVpc.vpc,
+          subnets: closedNetworkStack?.closedVpc.subnets,
         })
       : null;
 

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -249,6 +249,29 @@ export const stackInputSchema = baseStackInputSchema
         'Both VPC ID and Subnet IDs must be provided together for AgentCore network configuration',
       path: ['agentCoreVpcId'],
     }
+  )
+  .refine(
+    (data) => {
+      // In closed network mode, AgentCore must run in the same region as the closed VPC
+      const agentCoreEnabled =
+        data.agentBuilderEnabled ||
+        data.createGenericAgentCoreRuntime ||
+        data.researchAgentEnabled;
+      if (
+        data.closedNetworkMode &&
+        agentCoreEnabled &&
+        data.agentCoreRegion &&
+        data.agentCoreRegion !== data.region
+      ) {
+        return false;
+      }
+      return true;
+    },
+    {
+      message:
+        'agentCoreRegion must equal region when closedNetworkMode=true (the AgentCore Runtime shares the closed VPC, which exists in a single region)',
+      path: ['agentCoreRegion'],
+    }
   );
 
 // schema after conversion
@@ -297,4 +320,7 @@ export const processedStackInputSchema = baseStackInputSchema.extend({
 });
 
 export type StackInput = z.infer<typeof stackInputSchema>;
+// Input type: fields with .default() are optional — use this for partial
+// parameter objects in parameter.ts so defaults don't need to be repeated.
+export type StackInputIn = z.input<typeof stackInputSchema>;
 export type ProcessedStackInput = z.infer<typeof processedStackInputSchema>;

--- a/packages/cdk/parameter.ts
+++ b/packages/cdk/parameter.ts
@@ -76,14 +76,20 @@ export const getParams = (app: cdk.App): ProcessedStackInput => {
       params.endpointNames,
       params.modelRegion
     ),
-    // Process agentCoreRegion: null -> modelRegion
-    agentCoreRegion: params.agentCoreRegion || params.modelRegion,
-    // Compute isAgentCoreNetworkPrivate from VPC configuration
-    isAgentCoreNetworkPrivate: !!(
-      params.agentCoreVpcId &&
-      params.agentCoreSubnetIds &&
-      params.agentCoreSubnetIds.length > 0
-    ),
+    // Process agentCoreRegion: null -> modelRegion (forced to region in closed mode)
+    agentCoreRegion: params.closedNetworkMode
+      ? params.region
+      : params.agentCoreRegion || params.modelRegion,
+    // Compute isAgentCoreNetworkPrivate.
+    // In closed network mode, AgentCore Runtime is always private (uses the closed VPC).
+    // Otherwise, private mode is enabled when both agentCoreVpcId and agentCoreSubnetIds are provided.
+    isAgentCoreNetworkPrivate:
+      params.closedNetworkMode ||
+      !!(
+        params.agentCoreVpcId &&
+        params.agentCoreSubnetIds &&
+        params.agentCoreSubnetIds.length > 0
+      ),
     // Load branding configuration
     brandingConfig: loadBrandingConfig(),
   };

--- a/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
+++ b/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
@@ -1017,6 +1017,33 @@ exports[`GenerativeAiUseCases matches the snapshot (closed network mode) 1`] = `
       },
       "Type": "AWS::EC2::VPCEndpoint",
     },
+    "ClosedVpcVpcEndpointAgentCoreGateway2554684E": {
+      "Properties": {
+        "PrivateDnsEnabled": true,
+        "SecurityGroupIds": [
+          {
+            "Fn::GetAtt": [
+              "ClosedVpcSecurityGroup985DC3EC",
+              "GroupId",
+            ],
+          },
+        ],
+        "ServiceName": "com.amazonaws.us-east-1.bedrock-agentcore.gateway",
+        "SubnetIds": [
+          {
+            "Ref": "ClosedVpcisolatedSubnet1Subnet2EF6D3F3",
+          },
+          {
+            "Ref": "ClosedVpcisolatedSubnet2SubnetB169C8D3",
+          },
+        ],
+        "VpcEndpointType": "Interface",
+        "VpcId": {
+          "Ref": "ClosedVpcC15583C9",
+        },
+      },
+      "Type": "AWS::EC2::VPCEndpoint",
+    },
     "ClosedVpcVpcEndpointApiGateway6200AA11": {
       "Properties": {
         "PrivateDnsEnabled": true,
@@ -1353,6 +1380,33 @@ exports[`GenerativeAiUseCases matches the snapshot (closed network mode) 1`] = `
           },
         ],
         "ServiceName": "com.amazonaws.us-east-1.s3",
+        "SubnetIds": [
+          {
+            "Ref": "ClosedVpcisolatedSubnet1Subnet2EF6D3F3",
+          },
+          {
+            "Ref": "ClosedVpcisolatedSubnet2SubnetB169C8D3",
+          },
+        ],
+        "VpcEndpointType": "Interface",
+        "VpcId": {
+          "Ref": "ClosedVpcC15583C9",
+        },
+      },
+      "Type": "AWS::EC2::VPCEndpoint",
+    },
+    "ClosedVpcVpcEndpointSecretsManagerBC10A72C": {
+      "Properties": {
+        "PrivateDnsEnabled": true,
+        "SecurityGroupIds": [
+          {
+            "Fn::GetAtt": [
+              "ClosedVpcSecurityGroup985DC3EC",
+              "GroupId",
+            ],
+          },
+        ],
+        "ServiceName": "com.amazonaws.us-east-1.secretsmanager",
         "SubnetIds": [
           {
             "Ref": "ClosedVpcisolatedSubnet1Subnet2EF6D3F3",


### PR DESCRIPTION
### Summary

Enables AgentCore Runtime to operate in closed network mode by sharing the VPC and subnets from `ClosedNetworkStack`. When `closedNetworkMode: true`, AgentCore is
automatically deployed with `PRIVATE` network configuration — no need to manually specify `agentCoreVpcId` / `agentCoreSubnetIds`.

### Changes

**Infrastructure (CDK)**
- `closed-vpc.ts`: Add `AgentCoreGateway` and `SecretsManager` VPC Endpoints; expose `subnets` property for cross-stack sharing
- `closed-network-stack.ts`: Expose `closedVpc` construct for downstream stacks
- `agent-core-stack.ts`: Accept optional `vpc` / `subnets` props from ClosedNetworkStack
- `generic-agent-core.ts`: Prefer provided VPC/subnets over `Vpc.fromLookup()` when available (closed network path)
- `create-stacks.ts`: Wire `closedNetworkStack.closedVpc.{vpc,subnets}` → `AgentCoreStack`
- `stack-input.ts`: Add validation — `agentCoreRegion` must equal `region` in closed network mode; export `StackInputIn` type
- `parameter.ts`: Auto-set `isAgentCoreNetworkPrivate=true` and force `agentCoreRegion=region` when `closedNetworkMode=true`

**Runtime**
- `Dockerfile`: Pre-install `mcp-proxy-for-aws` so Gateway access works without runtime PyPI connectivity

**Documentation**
- `docs/ja/CLOSED_NETWORK.md` / `docs/en/CLOSED_NETWORK.md`:
- Document AgentCore constraints in closed network mode
- Add "AgentCore in Closed Network Mode" section (VPC Endpoints list)
- Add `bedrock-agentcore` / `bedrock-agentcore-gateway` rows to DNS resolution tables

**Tests**
- Snapshot updated to include new VPC Endpoints (`AgentCoreGateway`, `SecretsManager`)

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

#1509