### PR TITLE
fix(agent-builder): システムプロンプトの AI 生成で組み込みツールも提案する

### DIFF
--- a/packages/web/src/components/agentBuilder/AgentForm.tsx
+++ b/packages/web/src/components/agentBuilder/AgentForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
@@ -46,6 +46,19 @@ const AgentForm: React.FC<AgentFormProps> = ({
   const { t } = useTranslation();
   const { modelIds: availableModels, modelDisplayName } = MODELS;
 
+  // Built-in tools offered to the AI so that it can suggest them.
+  // Add an entry here when a new built-in tool is introduced.
+  const availableBuiltInTools = useMemo(
+    () => [
+      {
+        id: 'codeExecution',
+        name: t('agent_builder.code_execution'),
+        description: t('agent_builder.code_execution_description'),
+      },
+    ],
+    [t]
+  );
+
   // Form state
   const [formData, setFormData] = useState<AgentFormData>({
     name: '',
@@ -69,6 +82,7 @@ const AgentForm: React.FC<AgentFormProps> = ({
   const {
     generatedPrompt,
     suggestedMCPServers,
+    suggestedBuiltInTools,
     isGenerating,
     generate: generatePrompt,
     cancel: cancelGeneration,
@@ -77,6 +91,7 @@ const AgentForm: React.FC<AgentFormProps> = ({
     agentName: formData.name,
     agentDescription: formData.description,
     availableMCPServers,
+    availableBuiltInTools,
   });
 
   // Update systemPrompt when generation produces new content
@@ -92,6 +107,16 @@ const AgentForm: React.FC<AgentFormProps> = ({
       setFormData((prev) => ({ ...prev, mcpServers: suggestedMCPServers }));
     }
   }, [suggestedMCPServers]);
+
+  // Update built-in tools when AI suggests them
+  useEffect(() => {
+    if (suggestedBuiltInTools.length > 0) {
+      setFormData((prev) => ({
+        ...prev,
+        codeExecutionEnabled: suggestedBuiltInTools.includes('codeExecution'),
+      }));
+    }
+  }, [suggestedBuiltInTools]);
 
   // Update formData.modelId when availableModels becomes available
   useEffect(() => {

--- a/packages/web/src/hooks/usePromptGeneration.ts
+++ b/packages/web/src/hooks/usePromptGeneration.ts
@@ -12,6 +12,9 @@ import useChatApi from './useChatApi';
 import { parseStreamChunk, extractTextFromChunks } from '../utils/streamParser';
 import {
   buildAgentSystemPromptGeneratorPrompt,
+  BuiltInToolForPrompt,
+  BUILT_IN_TOOLS_START_MARKER,
+  BUILT_IN_TOOLS_END_MARKER,
   MCP_SERVERS_START_MARKER,
   MCP_SERVERS_END_MARKER,
   SYSTEM_PROMPT_START_MARKER,
@@ -23,11 +26,13 @@ export interface UsePromptGenerationParams {
   agentName: string;
   agentDescription: string;
   availableMCPServers: AvailableMCPServer[];
+  availableBuiltInTools?: BuiltInToolForPrompt[];
 }
 
 export interface UsePromptGenerationReturn {
   generatedPrompt: string;
   suggestedMCPServers: string[];
+  suggestedBuiltInTools: string[];
   isGenerating: boolean;
   error: Error | null;
   generate: () => Promise<string>;
@@ -41,24 +46,35 @@ export interface UsePromptGenerationReturn {
  * @param rawOutput - The accumulated raw output from the LLM
  * @returns Array of MCP server names, or null if markers not yet complete
  */
-const parseMCPServers = (rawOutput: string): string[] | null => {
-  const startIndex = rawOutput.indexOf(MCP_SERVERS_START_MARKER);
-  const endIndex = rawOutput.indexOf(MCP_SERVERS_END_MARKER);
+const parseMarkedLines = (
+  rawOutput: string,
+  startMarker: string,
+  endMarker: string
+): string[] | null => {
+  const startIndex = rawOutput.indexOf(startMarker);
+  const endIndex = rawOutput.indexOf(endMarker);
 
   if (startIndex === -1 || endIndex === -1 || endIndex <= startIndex) {
     return null;
   }
 
-  const content = rawOutput.slice(
-    startIndex + MCP_SERVERS_START_MARKER.length,
-    endIndex
-  );
+  const content = rawOutput.slice(startIndex + startMarker.length, endIndex);
 
   return content
     .split('\n')
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
 };
+
+const parseMCPServers = (rawOutput: string): string[] | null =>
+  parseMarkedLines(rawOutput, MCP_SERVERS_START_MARKER, MCP_SERVERS_END_MARKER);
+
+const parseBuiltInTools = (rawOutput: string): string[] | null =>
+  parseMarkedLines(
+    rawOutput,
+    BUILT_IN_TOOLS_START_MARKER,
+    BUILT_IN_TOOLS_END_MARKER
+  );
 
 /**
  * Extracts the system prompt content from raw output, handling streaming.
@@ -95,15 +111,25 @@ const extractSystemPrompt = (rawOutput: string): string => {
 export const usePromptGeneration = (
   params: UsePromptGenerationParams
 ): UsePromptGenerationReturn => {
-  const { modelId, agentName, agentDescription, availableMCPServers } = params;
+  const {
+    modelId,
+    agentName,
+    agentDescription,
+    availableMCPServers,
+    availableBuiltInTools,
+  } = params;
   const { predictStream } = useChatApi();
 
   const [generatedPrompt, setGeneratedPrompt] = useState('');
   const [suggestedMCPServers, setSuggestedMCPServers] = useState<string[]>([]);
+  const [suggestedBuiltInTools, setSuggestedBuiltInTools] = useState<string[]>(
+    []
+  );
   const [isGenerating, setIsGenerating] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
   const mcpServersParsedRef = useRef(false);
+  const builtInToolsParsedRef = useRef(false);
 
   /**
    * Generates a system prompt using the LLM.
@@ -117,6 +143,8 @@ export const usePromptGeneration = (
     setGeneratedPrompt('');
     setSuggestedMCPServers([]);
     mcpServersParsedRef.current = false;
+    builtInToolsParsedRef.current = false;
+    setSuggestedBuiltInTools([]);
     abortControllerRef.current = new AbortController();
 
     let rawOutput = '';
@@ -128,6 +156,10 @@ export const usePromptGeneration = (
         description: agentDescription,
         availableMCPServers:
           availableMCPServers.length > 0 ? availableMCPServers : undefined,
+        availableBuiltInTools:
+          availableBuiltInTools && availableBuiltInTools.length > 0
+            ? availableBuiltInTools
+            : undefined,
       });
 
       // Stream the response
@@ -155,6 +187,15 @@ export const usePromptGeneration = (
 
         if (text) {
           rawOutput += text;
+
+          // Try to parse built-in tools once we have the complete section
+          if (!builtInToolsParsedRef.current) {
+            const builtInTools = parseBuiltInTools(rawOutput);
+            if (builtInTools !== null) {
+              setSuggestedBuiltInTools(builtInTools);
+              builtInToolsParsedRef.current = true;
+            }
+          }
 
           // Try to parse MCP servers once we have the complete section
           if (!mcpServersParsedRef.current) {
@@ -189,6 +230,7 @@ export const usePromptGeneration = (
     agentName,
     agentDescription,
     availableMCPServers,
+    availableBuiltInTools,
     predictStream,
   ]);
 
@@ -208,14 +250,17 @@ export const usePromptGeneration = (
   const reset = useCallback(() => {
     setGeneratedPrompt('');
     setSuggestedMCPServers([]);
+    setSuggestedBuiltInTools([]);
     setError(null);
     setIsGenerating(false);
     mcpServersParsedRef.current = false;
+    builtInToolsParsedRef.current = false;
   }, []);
 
   return {
     generatedPrompt,
     suggestedMCPServers,
+    suggestedBuiltInTools,
     isGenerating,
     error,
     generate,

--- a/packages/web/src/prompts/agentSystemPromptGenerator.ts
+++ b/packages/web/src/prompts/agentSystemPromptGenerator.ts
@@ -11,15 +11,24 @@ export interface MCPServerForPrompt {
   category: string;
 }
 
+export interface BuiltInToolForPrompt {
+  id: string;
+  name: string;
+  description: string;
+}
+
 export interface AgentPromptParams {
   name: string;
   description: string;
   availableMCPServers?: MCPServerForPrompt[];
+  availableBuiltInTools?: BuiltInToolForPrompt[];
 }
 
 // Markers for parsing AI output
 export const MCP_SERVERS_START_MARKER = '<SELECTED_MCP_SERVERS>';
 export const MCP_SERVERS_END_MARKER = '</SELECTED_MCP_SERVERS>';
+export const BUILT_IN_TOOLS_START_MARKER = '<SELECTED_BUILT_IN_TOOLS>';
+export const BUILT_IN_TOOLS_END_MARKER = '</SELECTED_BUILT_IN_TOOLS>';
 export const SYSTEM_PROMPT_START_MARKER = '<SYSTEM_PROMPT>';
 export const SYSTEM_PROMPT_END_MARKER = '</SYSTEM_PROMPT>';
 
@@ -33,7 +42,11 @@ export const SYSTEM_PROMPT_END_MARKER = '</SYSTEM_PROMPT>';
 export const buildAgentSystemPromptGeneratorPrompt = (
   params: AgentPromptParams
 ): string => {
-  const { name, description, availableMCPServers } = params;
+  const { name, description, availableMCPServers, availableBuiltInTools } =
+    params;
+
+  const hasBuiltInTools =
+    !!availableBuiltInTools && availableBuiltInTools.length > 0;
 
   const mcpServersSection =
     availableMCPServers && availableMCPServers.length > 0
@@ -43,6 +56,24 @@ Select the most appropriate servers for this agent based on its purpose.
 ${availableMCPServers.map((s) => `- ${s.name} [${s.category}]: ${s.description}`).join('\n')}
 `
       : '';
+
+  const builtInToolsSection = hasBuiltInTools
+    ? `
+## Available Built-in Tools
+These tools are provided by the platform. Select the ones that this agent needs.
+${availableBuiltInTools.map((t) => `- ${t.id} (${t.name}): ${t.description}`).join('\n')}
+`
+    : '';
+
+  const builtInToolsOutputInstructions = hasBuiltInTools
+    ? `Output the selected built-in tool ids (one per line) between ${BUILT_IN_TOOLS_START_MARKER} and ${BUILT_IN_TOOLS_END_MARKER} tags.
+`
+    : '';
+
+  const builtInToolsRequirements = hasBuiltInTools
+    ? `
+- Select ONLY the built-in tools that are required by the agent's purpose (can be zero or more). Prefer a built-in tool over an MCP server when both can achieve the same thing.`
+    : '';
 
   const mcpOutputInstructions =
     availableMCPServers && availableMCPServers.length > 0
@@ -63,28 +94,36 @@ Based on the following information, generate an optimal system prompt for this a
 ## Agent Information
 - Name: ${name}
 - Description: ${description}
-${mcpServersSection}
+${mcpServersSection}${builtInToolsSection}
 ## Requirements
 1. Clearly define the role and purpose of the agent
-2. Describe the personality and behavior the agent should have${mcpRequirements}
+2. Describe the personality and behavior the agent should have${mcpRequirements}${builtInToolsRequirements}
 5. Include guidelines for interaction with users
 6. List any constraints or important notes
 7. Write the system prompt in the same language as the Name and Description provided above
 
 ## Output Format
-${mcpOutputInstructions}
+${builtInToolsOutputInstructions}${mcpOutputInstructions}
 
 Example output format:
 ${
-  availableMCPServers && availableMCPServers.length > 0
-    ? `${MCP_SERVERS_START_MARKER}
+  hasBuiltInTools
+    ? `${BUILT_IN_TOOLS_START_MARKER}
+built-in-tool-id-1
+${BUILT_IN_TOOLS_END_MARKER}
+
+`
+    : ''
+}${
+    availableMCPServers && availableMCPServers.length > 0
+      ? `${MCP_SERVERS_START_MARKER}
 server-name-1
 server-name-2
 ${MCP_SERVERS_END_MARKER}
 
 `
-    : ''
-}${SYSTEM_PROMPT_START_MARKER}
+      : ''
+  }${SYSTEM_PROMPT_START_MARKER}
 Your system prompt content here...
 ${SYSTEM_PROMPT_END_MARKER}
 

--- a/packages/web/tests/components/agentBuilder/agentSystemPromptGenerator.test.ts
+++ b/packages/web/tests/components/agentBuilder/agentSystemPromptGenerator.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildAgentSystemPromptGeneratorPrompt,
+  BUILT_IN_TOOLS_START_MARKER,
+  BUILT_IN_TOOLS_END_MARKER,
+  MCP_SERVERS_START_MARKER,
+} from '../../../src/prompts/agentSystemPromptGenerator';
+
+const builtInTools = [
+  {
+    id: 'codeExecution',
+    name: 'Code execution',
+    description: 'Runs code and scripts.',
+  },
+];
+
+const mcpServers = [
+  {
+    name: 'tavily-search',
+    description: 'Web search powered by Tavily',
+    category: 'Search',
+  },
+];
+
+describe('buildAgentSystemPromptGeneratorPrompt built-in tools', () => {
+  it('lists the available built-in tools', () => {
+    const prompt = buildAgentSystemPromptGeneratorPrompt({
+      name: 'agent',
+      description: 'description',
+      availableBuiltInTools: builtInTools,
+    });
+
+    expect(prompt).toContain('Available Built-in Tools');
+    expect(prompt).toContain('codeExecution');
+    expect(prompt).toContain('Runs code and scripts.');
+  });
+
+  it('asks for the selection between the built-in tool markers', () => {
+    const prompt = buildAgentSystemPromptGeneratorPrompt({
+      name: 'agent',
+      description: 'description',
+      availableBuiltInTools: builtInTools,
+    });
+
+    expect(prompt).toContain(BUILT_IN_TOOLS_START_MARKER);
+    expect(prompt).toContain(BUILT_IN_TOOLS_END_MARKER);
+  });
+
+  it('omits the section when no built-in tool is available', () => {
+    const prompt = buildAgentSystemPromptGeneratorPrompt({
+      name: 'agent',
+      description: 'description',
+      availableMCPServers: mcpServers,
+    });
+
+    expect(prompt).not.toContain('Available Built-in Tools');
+    expect(prompt).not.toContain(BUILT_IN_TOOLS_START_MARKER);
+    // MCP server selection keeps working on its own
+    expect(prompt).toContain(MCP_SERVERS_START_MARKER);
+  });
+
+  it('supports built-in tools and MCP servers at the same time', () => {
+    const prompt = buildAgentSystemPromptGeneratorPrompt({
+      name: 'agent',
+      description: 'description',
+      availableMCPServers: mcpServers,
+      availableBuiltInTools: builtInTools,
+    });
+
+    expect(prompt).toContain('Available Built-in Tools');
+    expect(prompt).toContain('Available MCP Servers');
+    expect(prompt).toContain(BUILT_IN_TOOLS_START_MARKER);
+    expect(prompt).toContain(MCP_SERVERS_START_MARKER);
+    // The built-in tool selection is requested before the MCP servers
+    expect(prompt.indexOf(BUILT_IN_TOOLS_START_MARKER)).toBeLessThan(
+      prompt.lastIndexOf(MCP_SERVERS_START_MARKER)
+    );
+  });
+
+  it('prefers a built-in tool over an MCP server when both fit', () => {
+    const prompt = buildAgentSystemPromptGeneratorPrompt({
+      name: 'agent',
+      description: 'description',
+      availableMCPServers: mcpServers,
+      availableBuiltInTools: builtInTools,
+    });
+
+    expect(prompt).toContain('Prefer a built-in tool over an MCP server');
+  });
+});


### PR DESCRIPTION
Closes #1675

### 概要

エージェントビルダーの「AI により生成する」で、ツール設定の組み込みツールも提案対象に含めるようにします。

これまで提案の対象は MCP サーバーのみだったため、組み込みツールを使う意図を説明に書いても、AI は MCP サーバーの中から代替を選んでしまい、ツール設定のチェックボックスは変化しませんでした。

### 再現していた挙動

| 入力 | 結果 |
| --- | --- |
| 名前: `google検索エージェント`<br>説明: `ブラウザツールでGoogleの検索を代行してくれるエージェント` | MCP サーバーの `tavily-search` が選択される。ツール設定は変化しない |

### 原因

`agentSystemPromptGenerator.ts` の `AgentPromptParams` が受け取るのは名前・説明・利用可能な MCP サーバーのみで、組み込みツールの情報が含まれていませんでした。生成されるプロンプトにも MCP サーバーの一覧しか記載されないため、AI は組み込みツールの存在を認識できません。

### 変更内容

既存の MCP サーバー提案と同じマーカー方式を踏襲しました。

| ファイル | 内容 |
| --- | --- |
| `packages/web/src/prompts/agentSystemPromptGenerator.ts` | `availableBuiltInTools` の受け取り、一覧の記載、`<SELECTED_BUILT_IN_TOOLS>` マーカーの追加 |
| `packages/web/src/hooks/usePromptGeneration.ts` | マーカーの解析、`suggestedBuiltInTools` の返却 |
| `packages/web/src/components/agentBuilder/AgentForm.tsx` | 利用可能な組み込みツールの一覧提供、提案結果のチェックボックスへの反映 |

出力フォーマットは既存の構造を保ったまま、組み込みツールの選択を先に出力させています。

```
<SELECTED_BUILT_IN_TOOLS>
codeExecution
</SELECTED_BUILT_IN_TOOLS>

<SELECTED_MCP_SERVERS>
server-name-1
</SELECTED_MCP_SERVERS>

<SYSTEM_PROMPT>
...
</SYSTEM_PROMPT>
```

組み込みツールが利用可能でない場合は、該当セクションとマーカーの指示を出力しません。既存の MCP サーバーのみの動作は変わりません。

### 設計上の判断

**一覧は呼び出し側から渡す**

利用可能な組み込みツールの一覧は `AgentForm` から渡す形にしました。組み込みツールが追加された際は、この一覧に 1 件足すだけで対応できます。

```ts
const availableBuiltInTools = useMemo(
  () => [
    {
      id: 'codeExecution',
      name: t('agent_builder.code_execution'),
      description: t('agent_builder.code_execution_description'),
    },
  ],
  [t]
);
```

この形にしたことで、**デプロイ設定で無効になっているツールを一覧に含めない**という制御が呼び出し側で行えます。組織のポリシーで無効にしているツールが AI に提案されることを防げます。

**MCP サーバーより組み込みツールを優先するよう指示**

同じことが両方で実現できる場合は組み込みツールを選ぶよう、プロンプトに指示を入れています。追加の設定や API キーを必要としないためです。

### 動作確認

- `packages/web/tests/components/agentBuilder/agentSystemPromptGenerator.test.ts` を追加 (5 件)
  - 組み込みツールの一覧が記載されること
  - マーカーによる選択指示が含まれること
  - 組み込みツールがない場合はセクションを出力せず、MCP サーバーの選択は従来どおり動作すること
  - 組み込みツールと MCP サーバーを同時に扱えること
  - 組み込みツールを優先する指示が含まれること
- `npm run lint` 通過
- `npm run cdk:test` 40 tests / 15 snapshots 通過
- web 283 tests 通過

### 関連

本機能は #1358 で追加されたものです。追加時点ではツール設定の組み込みツールが少なかったため、MCP サーバーのみを対象とする設計で十分だったと理解しています。

以下の提案がマージされた場合、`availableBuiltInTools` に項目を追加することで同様に提案対象へ含められます。

- #1670 / #1673 Web Search ツールの追加
- #1674 Browser ツールの追加
