### PR TITLE
fix(cdk): follow LastEvaluatedKey when looking up a chat or system context by id

### DIFF
--- a/packages/cdk/lambda/repository.ts
+++ b/packages/cdk/lambda/repository.ts
@@ -19,6 +19,8 @@ import {
   DynamoDBDocumentClient,
   PutCommand,
   QueryCommand,
+  QueryCommandInput,
+  QueryCommandOutput,
   TransactWriteCommand,
   UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
@@ -50,33 +52,53 @@ export const createChat = async (_userId: string): Promise<Chat> => {
   return item;
 };
 
+/**
+ * Run a Query that relies on a FilterExpression and return the first matching item.
+ *
+ * DynamoDB reads up to 1 MB per Query page and applies FilterExpression *after* that
+ * read, so a matching item can sit on a later page even though the key condition is
+ * narrow. Without following LastEvaluatedKey the item is reported as not found.
+ */
+const queryFirstMatch = async <T>(
+  input: Omit<QueryCommandInput, 'ExclusiveStartKey'>
+): Promise<T | null> => {
+  let exclusiveStartKey: QueryCommandInput['ExclusiveStartKey'] = undefined;
+
+  do {
+    const res: QueryCommandOutput = await dynamoDbDocument.send(
+      new QueryCommand({ ...input, ExclusiveStartKey: exclusiveStartKey })
+    );
+
+    if (res.Items && res.Items.length > 0) {
+      return res.Items[0] as T;
+    }
+
+    exclusiveStartKey = res.LastEvaluatedKey;
+  } while (exclusiveStartKey);
+
+  return null;
+};
+
 export const findChatById = async (
   _userId: string,
   _chatId: string
 ): Promise<Chat | null> => {
   const userId = `user#${_userId}`;
   const chatId = `chat#${_chatId}`;
-  const res = await dynamoDbDocument.send(
-    new QueryCommand({
-      TableName: TABLE_NAME,
-      KeyConditionExpression: '#id = :id',
-      FilterExpression: '#chatId = :chatId',
-      ExpressionAttributeNames: {
-        '#id': 'id',
-        '#chatId': 'chatId',
-      },
-      ExpressionAttributeValues: {
-        ':id': userId,
-        ':chatId': chatId,
-      },
-    })
-  );
 
-  if (!res.Items || res.Items.length === 0) {
-    return null;
-  } else {
-    return res.Items[0] as Chat;
-  }
+  return await queryFirstMatch<Chat>({
+    TableName: TABLE_NAME,
+    KeyConditionExpression: '#id = :id',
+    FilterExpression: '#chatId = :chatId',
+    ExpressionAttributeNames: {
+      '#id': 'id',
+      '#chatId': 'chatId',
+    },
+    ExpressionAttributeValues: {
+      ':id': userId,
+      ':chatId': chatId,
+    },
+  });
 };
 
 export const findSystemContextById = async (
@@ -85,27 +107,20 @@ export const findSystemContextById = async (
 ): Promise<SystemContext | null> => {
   const userId = `systemContext#${_userId}`;
   const systemContextId = `systemContext#${_systemContextId}`;
-  const res = await dynamoDbDocument.send(
-    new QueryCommand({
-      TableName: TABLE_NAME,
-      KeyConditionExpression: '#id = :id',
-      FilterExpression: '#systemContextId = :systemContextId',
-      ExpressionAttributeNames: {
-        '#id': 'id',
-        '#systemContextId': 'systemContextId',
-      },
-      ExpressionAttributeValues: {
-        ':id': userId,
-        ':systemContextId': systemContextId,
-      },
-    })
-  );
 
-  if (!res.Items || res.Items.length === 0) {
-    return null;
-  } else {
-    return res.Items[0] as SystemContext;
-  }
+  return await queryFirstMatch<SystemContext>({
+    TableName: TABLE_NAME,
+    KeyConditionExpression: '#id = :id',
+    FilterExpression: '#systemContextId = :systemContextId',
+    ExpressionAttributeNames: {
+      '#id': 'id',
+      '#systemContextId': 'systemContextId',
+    },
+    ExpressionAttributeValues: {
+      ':id': userId,
+      ':systemContextId': systemContextId,
+    },
+  });
 };
 
 export const listChats = async (

--- a/packages/cdk/test/lambda/repository.test.ts
+++ b/packages/cdk/test/lambda/repository.test.ts
@@ -1,0 +1,95 @@
+const mockSend = jest.fn();
+
+jest.mock('@aws-sdk/lib-dynamodb', () => {
+  const actual = jest.requireActual('@aws-sdk/lib-dynamodb');
+  return {
+    ...actual,
+    DynamoDBDocumentClient: {
+      ...actual.DynamoDBDocumentClient,
+      from: () => ({ send: mockSend }),
+    },
+  };
+});
+
+process.env.TABLE_NAME = 'test-table';
+process.env.STATS_TABLE_NAME = 'test-stats-table';
+
+import { findChatById, findSystemContextById } from '../../lambda/repository';
+
+beforeEach(() => {
+  mockSend.mockReset();
+});
+
+describe('findChatById', () => {
+  // DynamoDB applies FilterExpression after reading a 1 MB page, so a matching item
+  // can sit on a later page. The query must follow LastEvaluatedKey.
+  it('finds an item that is only on a later page', async () => {
+    mockSend
+      .mockResolvedValueOnce({ Items: [], LastEvaluatedKey: { id: 'page-2' } })
+      .mockResolvedValueOnce({ Items: [], LastEvaluatedKey: { id: 'page-3' } })
+      .mockResolvedValueOnce({
+        Items: [{ chatId: 'chat#abc', title: 'found' }],
+      });
+
+    const result = await findChatById('user-1', 'abc');
+
+    expect(result).toEqual({ chatId: 'chat#abc', title: 'found' });
+    expect(mockSend).toHaveBeenCalledTimes(3);
+  });
+
+  it('passes LastEvaluatedKey as ExclusiveStartKey on the next page', async () => {
+    mockSend
+      .mockResolvedValueOnce({ Items: [], LastEvaluatedKey: { id: 'page-2' } })
+      .mockResolvedValueOnce({ Items: [{ chatId: 'chat#abc' }] });
+
+    await findChatById('user-1', 'abc');
+
+    expect(mockSend.mock.calls[0][0].input.ExclusiveStartKey).toBeUndefined();
+    expect(mockSend.mock.calls[1][0].input.ExclusiveStartKey).toEqual({
+      id: 'page-2',
+    });
+  });
+
+  it('returns null when every page is exhausted without a match', async () => {
+    mockSend
+      .mockResolvedValueOnce({ Items: [], LastEvaluatedKey: { id: 'page-2' } })
+      .mockResolvedValueOnce({ Items: [] });
+
+    const result = await findChatById('user-1', 'missing');
+
+    expect(result).toBeNull();
+    expect(mockSend).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not issue a second query when the first page already matches', async () => {
+    mockSend.mockResolvedValueOnce({ Items: [{ chatId: 'chat#abc' }] });
+
+    const result = await findChatById('user-1', 'abc');
+
+    expect(result).toEqual({ chatId: 'chat#abc' });
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('findSystemContextById', () => {
+  it('finds an item that is only on a later page', async () => {
+    mockSend
+      .mockResolvedValueOnce({ Items: [], LastEvaluatedKey: { id: 'page-2' } })
+      .mockResolvedValueOnce({
+        Items: [{ systemContextId: 'systemContext#sc-1' }],
+      });
+
+    const result = await findSystemContextById('user-1', 'sc-1');
+
+    expect(result).toEqual({ systemContextId: 'systemContext#sc-1' });
+    expect(mockSend).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns null when every page is exhausted without a match', async () => {
+    mockSend.mockResolvedValueOnce({ Items: [] });
+
+    const result = await findSystemContextById('user-1', 'missing');
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Description of Changes

`findChatById` issued a single `Query` with a `FilterExpression` and ignored `LastEvaluatedKey`:

```ts
const res = await dynamoDbDocument.send(new QueryCommand({
  KeyConditionExpression: '#id = :id',
  FilterExpression: '#chatId = :chatId',
}));
if (!res.Items || res.Items.length === 0) return null;
```

DynamoDB reads up to 1 MB per page **and applies `FilterExpression` after that read**. For a user whose `user#<id>` partition exceeds 1 MB, the target chat can sit on a later page, so the function returns `null` even though the chat exists. This is what #1663 reports: heavy users stop being able to save new messages.

This PR extracts a small `queryFirstMatch` helper that follows `LastEvaluatedKey` until a match is found or the pages are exhausted, and uses it for `findChatById`.

**`findSystemContextById` had the identical pattern** (single `Query` + `FilterExpression`, no pagination), so it is fixed the same way. It is not covered by an existing issue; I found it while checking for other occurrences. A survey of `repository.ts` shows these were the only two — `listChats` already paginates, and the remaining queries do not use `FilterExpression`.

**Compatibility:** no signature or return-type change. The only difference is that a lookup which previously returned `null` for a large partition now returns the item. For partitions under 1 MB the behavior and the number of API calls are unchanged.

## Checklist

- [x] Modified relevant documentation — n/a (internal data-access layer; the helper carries a comment explaining the DynamoDB behavior)
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` — 45 tests / 15 snapshots passed, **no snapshot differences**

New unit tests in `packages/cdk/test/lambda/repository.test.ts` cover:

- a match that only appears on a later page
- `LastEvaluatedKey` being passed as `ExclusiveStartKey` on the following request
- returning `null` once the pages are exhausted
- not issuing a second query when the first page already matches

**These tests fail against the previous implementation** (4 of the 6 fail; the 2 that pass are the controls — a first-page match and a single-page miss), so they characterize the bug rather than the fix.

Also run:

- `npm run web:test` — 278 passed
- `tsc --noEmit` — no errors
- `eslint` and `prettier --check` clean on all changed files

## Related Issues

- #1663

