### PR TITLE
fix(cdk): transcode Shift_JIS and EUC-JP text documents to UTF-8

### DIFF
--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -32,6 +32,7 @@ import {
 } from './promptCache';
 import { getFormatFromMimeType, getMimeTypeFromFileName } from './media';
 import { convertToSafeFilename } from './fileNameUtils';
+import { convertTextDocumentToUtf8 } from './textEncoding';
 
 // Default Models
 
@@ -474,7 +475,10 @@ const createConverseCommandInput = (
               format,
               name: convertToSafeFilename(extra.name),
               source: {
-                bytes: Buffer.from(extra.source.data, 'base64'),
+                bytes: convertTextDocumentToUtf8(
+                  Buffer.from(extra.source.data, 'base64'),
+                  format
+                ),
               },
             },
           } as ContentBlock.DocumentMember);

--- a/packages/cdk/lambda/utils/textEncoding.ts
+++ b/packages/cdk/lambda/utils/textEncoding.ts
@@ -1,0 +1,60 @@
+/**
+ * Text-based document formats whose bytes Bedrock interprets as text.
+ * Binary formats (pdf, doc, docx, xls, xlsx) must never be re-encoded.
+ */
+const TEXT_DOCUMENT_FORMATS = new Set(['txt', 'csv', 'md', 'html']);
+
+/**
+ * Legacy Japanese encodings to try, in order, when the bytes are not valid UTF-8.
+ * Shift_JIS is first because it is by far the most common on Japanese systems.
+ */
+const FALLBACK_ENCODINGS = ['shift_jis', 'euc-jp'];
+
+const isValidUtf8 = (bytes: Uint8Array): boolean => {
+  try {
+    new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Convert a text document to UTF-8 when it is encoded in a legacy Japanese charset.
+ *
+ * Bedrock inspects the bytes of a document rather than trusting the declared format.
+ * Shift_JIS content is detected as `application/octet-stream` and the request fails with
+ * `ValidationException: Unsupported MIME type`. Re-encoding to UTF-8 makes the same
+ * content acceptable, so users do not have to convert the file themselves.
+ *
+ * Bytes are returned unchanged when the format is binary, when they are already valid
+ * UTF-8, or when no candidate encoding decodes them cleanly.
+ *
+ * @param bytes Raw file content
+ * @param format Bedrock document format (e.g. 'csv', 'pdf')
+ * @returns UTF-8 encoded bytes, or the original bytes when no conversion applies
+ */
+export const convertTextDocumentToUtf8 = (
+  bytes: Uint8Array,
+  format: string
+): Uint8Array => {
+  if (!TEXT_DOCUMENT_FORMATS.has(format)) {
+    return bytes;
+  }
+
+  if (isValidUtf8(bytes)) {
+    return bytes;
+  }
+
+  for (const encoding of FALLBACK_ENCODINGS) {
+    try {
+      const decoded = new TextDecoder(encoding, { fatal: true }).decode(bytes);
+      return new TextEncoder().encode(decoded);
+    } catch {
+      // Not this encoding; try the next candidate
+    }
+  }
+
+  // Unknown encoding. Leave the bytes alone so Bedrock reports the problem.
+  return bytes;
+};

--- a/packages/cdk/test/lambda/utils/textEncoding.test.ts
+++ b/packages/cdk/test/lambda/utils/textEncoding.test.ts
@@ -1,0 +1,54 @@
+/* eslint-disable i18nhelper/no-jp-string */
+import { convertTextDocumentToUtf8 } from '../../../lambda/utils/textEncoding';
+
+// The same two-line CSV in each encoding; EXPECTED below is the decoded text
+const SHIFT_JIS = Uint8Array.from([
+  0x96, 0xbc, 0x91, 0x4f, 0x2c, 0x95, 0x94, 0x8f, 0x90, 0x0a, 0x8e, 0x52, 0x93,
+  0x63, 0x91, 0xbe, 0x98, 0x59, 0x2c, 0x89, 0x63, 0x8b, 0xc6, 0x95, 0x94, 0x0a,
+]);
+const EUC_JP = Uint8Array.from([
+  0xcc, 0xbe, 0xc1, 0xb0, 0x2c, 0xc9, 0xf4, 0xbd, 0xf0, 0x0a, 0xbb, 0xb3, 0xc5,
+  0xc4, 0xc2, 0xc0, 0xcf, 0xba, 0x2c, 0xb1, 0xc4, 0xb6, 0xc8, 0xc9, 0xf4, 0x0a,
+]);
+const EXPECTED = '名前,部署\n山田太郎,営業部\n';
+
+const asText = (bytes: Uint8Array) => new TextDecoder('utf-8').decode(bytes);
+
+describe('convertTextDocumentToUtf8', () => {
+  it('converts Shift_JIS to UTF-8 for a text format', () => {
+    const result = convertTextDocumentToUtf8(SHIFT_JIS, 'csv');
+    expect(asText(result)).toBe(EXPECTED);
+  });
+
+  it('converts EUC-JP to UTF-8 for a text format', () => {
+    const result = convertTextDocumentToUtf8(EUC_JP, 'txt');
+    expect(asText(result)).toBe(EXPECTED);
+  });
+
+  it('leaves valid UTF-8 untouched', () => {
+    const utf8 = new TextEncoder().encode(EXPECTED);
+    const result = convertTextDocumentToUtf8(utf8, 'csv');
+    expect(result).toBe(utf8);
+  });
+
+  it('leaves ASCII untouched', () => {
+    const ascii = new TextEncoder().encode('name,department\n');
+    const result = convertTextDocumentToUtf8(ascii, 'md');
+    expect(result).toBe(ascii);
+  });
+
+  // Binary formats must never be re-encoded, even though their bytes are not valid UTF-8
+  it.each(['pdf', 'doc', 'docx', 'xls', 'xlsx'])(
+    'leaves %s untouched',
+    (format) => {
+      const result = convertTextDocumentToUtf8(SHIFT_JIS, format);
+      expect(result).toBe(SHIFT_JIS);
+    }
+  );
+
+  it('leaves bytes untouched when no candidate encoding decodes them', () => {
+    const undecodable = Uint8Array.from([0xff, 0xfe, 0x00, 0x81, 0xff]);
+    const result = convertTextDocumentToUtf8(undecodable, 'txt');
+    expect(result).toBe(undecodable);
+  });
+});


### PR DESCRIPTION
## Description of Changes

Attaching a Shift_JIS encoded text file fails with:

```
ValidationException: Unsupported MIME type: application/octet-stream.
Retry your request with a supported file type: xlsx, txt, pdf, csv, md, doc, html, xls, docx
```

I measured where this comes from by calling `bedrock-runtime:Converse` directly in
`ap-northeast-1` (`jp.anthropic.claude-haiku-4-5-20251001-v1:0`), sending the same CSV in
different encodings and changing nothing else:

| Bytes sent | `format` | Result |
|---|---|---|
| UTF-8 | `csv` | accepted, model reads the content correctly |
| **Shift_JIS** | `csv` | **ValidationException: Unsupported MIME type: application/octet-stream** |
| **Shift_JIS** | `txt` | same |
| **Shift_JIS re-encoded to UTF-8** | `csv` | **accepted, model reads the content correctly** |

So the rejection comes from Bedrock, and **the declared `format` is ignored — Bedrock
sniffs the bytes**. This confirms what @kazuhitogo found in #1399 and what @toshikwa noted
in #1181.

The last row is the part I would like to raise: **the same content goes through once it is
re-encoded**, so this can be fixed rather than only reported.

In #1399 the plan was to surface a clearer "UTF-8 only" message. That is a real improvement
over the current error, but #1181 asks for CSV files to be accepted *regardless of
encoding*, and Shift_JIS is still what several Japanese SaaS products emit when you export
a file. Converting on the server removes the manual step entirely.

**If you would rather keep the error-message approach, I am happy to close this and send
that instead** — I wrote this partly to show that transcoding is viable and cheap.

### What this PR does

Adds `convertTextDocumentToUtf8` and applies it where the Converse document content block
is built:

- only `txt`, `csv`, `md` and `html` are considered; **binary formats (`pdf`, `doc`,
  `docx`, `xls`, `xlsx`) are never re-encoded**
- bytes that are already valid UTF-8 are returned untouched (this also covers ASCII)
- otherwise `shift_jis` then `euc-jp` are tried with a strict decoder, and the decoded text
  is re-encoded as UTF-8
- bytes that no candidate decodes cleanly are left alone, so Bedrock still reports the
  problem rather than us silently sending mojibake

**No new dependency.** Node's built-in `TextDecoder` supports `shift_jis` and `euc-jp`.

**Compatibility:** UTF-8 and ASCII content is byte-for-byte unchanged, and binary formats
are untouched. The only behavior change is that files which previously failed the API call
now succeed.

**Out of scope:** the Bedrock Agents path in `bedrockAgentApi.ts` uses `byteContent` with a
different validation path, and UTF-16 is not attempted because a strict UTF-16 decode
accepts almost any byte sequence and would misfire.

### Verified end to end

Passing the real output of `convertTextDocumentToUtf8` to Converse:

```
rejected  Shift_JIS as-is                     → ValidationException: Unsupported MIME type
accepted  convertTextDocumentToUtf8(bytes)    → "山田太郎"
```

## Checklist

- [x] Modified relevant documentation — n/a (internal utility; the function carries a
      comment explaining the Bedrock behavior)
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` — 49 tests / 15 snapshots passed, **no snapshot differences**

Also run:

- `npm -w packages/cdk test -- textEncoding` — 10 passed
- `npm run web:test` — 278 passed
- `npm -w packages/cdk run lint` (`--max-warnings 0`) and `prettier --check` clean

## Related Issues

- #1399
- #1181
