### PR TITLE
fix(web): re-measure a textarea whose height was computed before layout

### DIFF
--- a/packages/web/src/components/Textarea.tsx
+++ b/packages/web/src/components/Textarea.tsx
@@ -31,22 +31,54 @@ const Textarea: React.FC<Props> = (props) => {
   const maxHeight = props.maxHeight || MAX_HEIGHT;
 
   useLayoutEffect(() => {
-    if (!ref.current || props.resizable) return;
-    // Reset the height to auto to calculate the scroll height
-    ref.current.style.height = 'auto';
-    ref.current.style.overflowY = 'hidden';
+    const element = ref.current;
+    if (!element || props.resizable) return;
 
-    // Ensure the layout is updated before calculating the scroll height
-    // due to the bug in Firefox:
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1795904
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1787062
-    void ref.current.scrollHeight;
+    let running = false;
 
-    // Set the height to match content, up to max height
-    const scrollHeight = ref.current.scrollHeight;
-    const isMax = maxHeight > 0 && scrollHeight > maxHeight;
-    ref.current.style.height = (isMax ? maxHeight : scrollHeight) + 'px';
-    ref.current.style.overflowY = isMax ? 'auto' : 'hidden';
+    const applyHeight = () => {
+      // Guard against the ResizeObserver observing the height we set ourselves
+      if (running) return;
+      running = true;
+
+      // Reset the height to auto to calculate the scroll height
+      element.style.height = 'auto';
+      element.style.overflowY = 'hidden';
+
+      // Ensure the layout is updated before calculating the scroll height
+      // due to the bug in Firefox:
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1795904
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1787062
+      void element.scrollHeight;
+
+      // scrollHeight covers the content and the padding but not the border, while the
+      // height assigned below is interpreted as the full border box
+      const style = window.getComputedStyle(element);
+      const borderHeight =
+        style.boxSizing === 'border-box'
+          ? parseFloat(style.borderTopWidth) +
+            parseFloat(style.borderBottomWidth)
+          : 0;
+
+      // Set the height to match content, up to max height
+      const contentHeight = element.scrollHeight + borderHeight;
+      const isMax = maxHeight > 0 && contentHeight > maxHeight;
+      element.style.height = (isMax ? maxHeight : contentHeight) + 'px';
+      element.style.overflowY = isMax ? 'auto' : 'hidden';
+
+      running = false;
+    };
+
+    applyHeight();
+
+    // The first measurement can run before the element has been laid out, for example
+    // while the dialog that contains it is still being mounted. scrollHeight is 0 then,
+    // and because this effect only depends on the value, a textarea whose value never
+    // changes afterwards would keep that height forever. Re-measure whenever the box
+    // actually changes so the height catches up.
+    const observer = new ResizeObserver(applyHeight);
+    observer.observe(element);
+    return () => observer.disconnect();
   }, [props.value, props.resizable, maxHeight]);
 
   return (


### PR DESCRIPTION
> **Updated.** My first version of this PR only corrected a 2px border-box miscalculation and I noted that I could not reproduce the reported symptom. I have since found the real cause and rewritten the fix. Details below.

## Description of Changes

The auto-size effect in `Textarea` runs on mount and depends on the value:

```ts
useLayoutEffect(() => {
  ...
  const scrollHeight = ref.current.scrollHeight;
  ref.current.style.height = scrollHeight + 'px';
}, [props.value, props.resizable, maxHeight]);
```

**When it runs before the element has been laid out, `scrollHeight` is 0, so the height is
set to `0px`.** That is what happens inside the dialog `ModalSystemContext` renders. Because
the effect only depends on the value, a textarea whose value never changes afterwards keeps
`height: 0px` forever, and `overflow-y: hidden` hides the content.

**This is invisible in development.** `main.tsx` wraps the tree in `React.StrictMode`, which
invokes effects twice, and the second run happens after layout and repairs the height. In a
production build the effect runs once, so the modal stays broken — which is why #1171
reproduces on a deployed environment but not with `npm run dev`.

### Measured

I rendered `ModalSystemContext` in isolation and measured it in a headless browser, toggling
`StrictMode` to reproduce a production build:

| | `style.height` | `clientHeight` | `scrollHeight` |
|---|---|---|---|
| StrictMode on (dev), before | 36px | 34 | 36 |
| **StrictMode off (prod), before** | **0px** | **12** (padding only) | 36 |
| StrictMode on, after | 38px | 36 | 36 |
| **StrictMode off, after** | **38px** | **36** | 36 |

The `0px` row is the bug, and it matches the screenshot in #1171.

### The fix

- observe the element with a `ResizeObserver` and re-measure whenever its box changes, so
  the height catches up once the element is laid out. A re-entrancy guard keeps the observer
  from reacting to the height it sets itself
- also add the border back to the computed height: `scrollHeight` covers the content and the
  padding but not the border, while the assigned `height` is interpreted as the full border
  box because Tailwind sets `box-sizing: border-box` (this is the 2px in the table above)

**Scope:** `Textarea` is used in 13 places, but only ones whose value never changes after
mount can get stuck; everywhere else the height is recomputed on each keystroke, which is
why this has not been noticed more widely. `ModalSystemContext` is used by `ChatPage`,
`RagKnowledgeBasePage` and `SharedChatPage`, so the RAG chat is affected too.

**Compatibility:** no API change. Textareas that were already sized correctly get 2px taller
(the border); ones that were stuck at `0px` now size to their content.

## Checklist

- [x] Modified relevant documentation — n/a (shared component; the reason is captured in
      comments next to the calculation)
- [x] Verified operation in local environment (headless browser, measurements above)
- [x] Executed `npm run cdk:test` — no changes under `packages/cdk`, snapshots unaffected

Also run:

- `npm run web:test` — 278 passed
- `eslint` and `prettier --check` clean

## Related Issues

- #1171
