### PR TITLE
fix(agent-core): point docker-compose at the real MCP config directory

### DIFF
--- a/packages/cdk/lambda-python/generic-agent-core-runtime/docker-compose.yml
+++ b/packages/cdk/lambda-python/generic-agent-core-runtime/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   generic-agent-core-runtime:
     build:
@@ -17,6 +15,10 @@ services:
       # Optional: S3 bucket for file uploads (set if you want to test file uploads)
       - FILE_BUCKET=${FILE_BUCKET:-test-bucket}
 
+      # MCP servers are only loaded when this points at an existing file.
+      # Override it to test the Agent Builder set of servers.
+      - MCP_CONFIG_PATH=${MCP_CONFIG_PATH:-/var/task/mcp-configs/generic/mcp.json}
+
       # Agent Core Runtime specific
       - PYTHONUNBUFFERED=1
       - LOG_LEVEL=INFO
@@ -27,7 +29,7 @@ services:
       # Mount source code for development (optional - remove for production)
       - ./src:/var/task/src:ro
       - ./app.py:/var/task/app.py:ro
-      - ./mcp.json:/var/task/mcp.json:ro
+      - ./mcp-configs:/var/task/mcp-configs:ro
 
       # Mount AWS credentials (optional - if using local AWS credentials)
       - ~/.aws:/root/.aws:ro


### PR DESCRIPTION
## Description of Changes

`docker-compose.yml` mounts a path that does not exist in the repository:

```yaml
volumes:
  - ./mcp.json:/var/task/mcp.json:ro
```

The MCP configs actually live in `mcp-configs/generic/mcp.json` and `mcp-configs/agent-builder/mcp.json` — the CDK points `MCP_CONFIG_PATH` at those (`lib/construct/generic-agent-core.ts:155,169`).

Because the source path is missing, Docker creates an **empty directory** named `mcp.json` in the working tree and mounts it over `/var/task/mcp.json`.

`MCP_CONFIG_PATH` is also not set in the compose file, and `load_mcp_tools()` returns `[]` when it is missing (`src/tools.py:84-89`), so **a container started with `docker compose up` loads no MCP servers at all**.

Reproduced on `main`:

```console
$ ls mcp.json
ls: mcp.json: No such file or directory

$ docker compose up -d && docker compose exec generic-agent-core-runtime \
    sh -c 'ls -ld /var/task/mcp.json; echo "MCP_CONFIG_PATH=[$MCP_CONFIG_PATH]"'
drwxr-xr-x 2 root root 64 Aug 23 02:59 /var/task/mcp.json     # a directory
MCP_CONFIG_PATH=[]

$ ls -ld mcp.json
drwxr-xr-x 2 ... mcp.json     # stray directory left in the working tree
```

This PR:

- mounts `./mcp-configs` instead of the non-existent `./mcp.json`
- defaults `MCP_CONFIG_PATH` to the generic config, overridable so the Agent Builder set can be tested:
  `MCP_CONFIG_PATH=/var/task/mcp-configs/agent-builder/mcp.json docker compose up`
- drops the obsolete top-level `version` key, which Compose v2 warns about on every invocation

After the change:

```console
$ docker compose up -d && docker compose exec generic-agent-core-runtime \
    sh -c 'echo "MCP_CONFIG_PATH=[$MCP_CONFIG_PATH]"; ls -l "$MCP_CONFIG_PATH"; ls /var/task/mcp-configs/'
MCP_CONFIG_PATH=[/var/task/mcp-configs/generic/mcp.json]
-rw-r--r-- 1 root root 2160 Aug 22 13:11 /var/task/mcp-configs/generic/mcp.json
agent-builder
generic

$ ls mcp.json
ls: mcp.json: No such file or directory     # no stray directory
```

`docker compose config` is clean — the `version` warning is gone.

## Checklist

- [x] Modified relevant documentation — n/a (local development compose file only)
- [x] Verified operation in local environment — `docker compose up` / `exec` / `down`, before and after, as shown above
- [x] Executed `npm run cdk:test` — n/a, no CDK or application code changed

## Related Issues

None. Found while working on the AgentCore runtime locally.
