### PR TITLE
fix: add fork guard to GenU AutoDeploy workflow

### DIFF
--- a/.github/workflows/genu-auto-deploy.yml
+++ b/.github/workflows/genu-auto-deploy.yml
@@ -11,8 +11,9 @@ permissions:
 jobs:
   deploy:
     if: >-
-      (github.event.action == 'labeled' && github.event.label.name == 'auto-deploy') ||
-      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'auto-deploy'))
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      ((github.event.action == 'labeled' && github.event.label.name == 'auto-deploy') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'auto-deploy')))
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
@@ -85,7 +86,10 @@ jobs:
           HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
 
   cleanup:
-    if: github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'auto-deploy')
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.action == 'closed' &&
+      contains(github.event.pull_request.labels.*.name, 'auto-deploy')
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials


### PR DESCRIPTION
Restrict the auto-deploy and cleanup jobs to pull requests originating from the base repository. PRs from forked repositories will no longer trigger deployment, adding a defense-in-depth control on top of the existing maintainer-only label gating.

## Description of Changes

Please explain the changes in detail.
If there is any impact on existing users (compatibility, degradation, breaking changes, etc.), be sure to include it in the explanation.

## Checklist

- [x] Modified relevant documentation
- [x] Verified operation in local environment
- [x] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

Please list related issues as much as possible.
