### PR TITLE
feat(agent-builder): エージェント定義を JSON で共有できるようにする

### DIFF
--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -49,6 +49,7 @@ agent_builder:
   environment_variables: Environment Variables
   environment_variables_label: Environment Variables
   example_github: GitHub
+  export: Export
   external: External
   external_agent_description: Pre-configured external agents with specialized capabilities
   external_agents: External Agents
@@ -63,6 +64,8 @@ agent_builder:
   generate_short: Generate
   generate_with_ai: Generate with AI
   generating_prompt: Generating system prompt...
+  import: Import
+  import_failed: Could not read that file as an agent definition
   loading_agent: Loading agent...
   mcp_server_configuration: MCP Server Configuration
   mcp_server_description: >-

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -50,6 +50,7 @@ agent_builder:
   environment_variables: 環境変数
   environment_variables_label: 環境変数
   example_github: GitHub
+  export: エクスポート
   external: 外部
   external_agent_description: 特別な機能を持つ事前設定済みの外部エージェント
   external_agents: 外部エージェント
@@ -63,6 +64,8 @@ agent_builder:
   generate_short: 生成
   generate_with_ai: AIにより生成する
   generating_prompt: システムプロンプトを生成中...
+  import: インポート
+  import_failed: エージェント定義として読み込めませんでした
   loading_agent: エージェントを読み込み中...
   mcp_server_configuration: MCPサーバー設定
   mcp_server_description: エージェントに追加機能を提供するMCPサーバーを選択してください。これらのサーバーはセキュリティのため管理者によって事前設定されています。

--- a/packages/web/src/pages/agentBuilder/AgentBuilderEditPage.tsx
+++ b/packages/web/src/pages/agentBuilder/AgentBuilderEditPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams, useNavigate } from 'react-router-dom';
 import Button from '../../components/Button';
@@ -13,7 +13,12 @@ import {
   PiArrowLeft as BackIcon,
   PiPencilSimple,
   PiEye,
+  PiUploadSimple as ImportIcon,
 } from 'react-icons/pi';
+import {
+  fromPortableAgent,
+  PortableAgent,
+} from '../../utils/agentDefinitionFile';
 
 const AgentBuilderEditPage: React.FC = () => {
   const { t } = useTranslation();
@@ -33,6 +38,30 @@ const AgentBuilderEditPage: React.FC = () => {
 
   // View toggle state for responsive layout
   const [activeView, setActiveView] = useState<'editor' | 'preview'>('editor');
+
+  // An imported definition stands in for the loaded one, so the form fills
+  // itself from the file rather than the user retyping it. Kept in state so
+  // it survives until they save or leave.
+  const [imported, setImported] = useState<PortableAgent | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+  const fileInput = useRef<HTMLInputElement>(null);
+
+  const handleImportFile = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      // Cleared straight away, or choosing the same file twice would not fire
+      // a change and the second import would go unnoticed.
+      event.target.value = '';
+      if (!file) return;
+      try {
+        setImported(fromPortableAgent(JSON.parse(await file.text())));
+        setImportError(null);
+      } catch {
+        setImportError(t('agent_builder.import_failed'));
+      }
+    },
+    [t]
+  );
 
   const handleSave = useCallback(
     async (formData: AgentFormData) => {
@@ -137,6 +166,19 @@ const AgentBuilderEditPage: React.FC = () => {
           <div>
             <h1 className="text-2xl font-bold text-gray-900">{title}</h1>
           </div>
+          <Button outlined onClick={() => fileInput.current?.click()}>
+            <ImportIcon className="h-4 w-4 sm:mr-2" />
+            <span className="hidden sm:inline">
+              {t('agent_builder.import')}
+            </span>
+          </Button>
+          <input
+            ref={fileInput}
+            type="file"
+            accept=".json,application/json"
+            onChange={handleImportFile}
+            className="hidden"
+          />
         </div>
 
         {/* View Toggle for small screens - aligned with title on right */}
@@ -170,13 +212,19 @@ const AgentBuilderEditPage: React.FC = () => {
         </div>
       </div>
 
+      {importError && (
+        <div className="mb-4 rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {importError}
+        </div>
+      )}
+
       {/* Content - Large screens: side-by-side, Small screens: toggle view */}
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
         {/* Agent Configuration - Always visible on large screens, toggle on small */}
         <div
           className={`space-y-6 ${activeView !== 'editor' ? 'hidden lg:block' : ''}`}>
           <AgentForm
-            initialData={agent || undefined}
+            initialData={imported || agent || undefined}
             onSave={handleSave}
             onCancel={handleCancel}
             onFormDataChange={handleFormDataChange}

--- a/packages/web/src/pages/agentBuilder/AgentBuilderListPage.tsx
+++ b/packages/web/src/pages/agentBuilder/AgentBuilderListPage.tsx
@@ -17,9 +17,14 @@ import {
   PiPencil as EditIcon,
   PiCopy as CloneIcon,
   PiTrash as DeleteIcon,
+  PiDownloadSimple as ExportIcon,
   PiDotsThreeOutlineFill as MoreIcon,
 } from 'react-icons/pi';
 import { AgentConfiguration } from 'generative-ai-use-cases';
+import {
+  agentFileName,
+  toPortableAgent,
+} from '../../utils/agentDefinitionFile';
 import useAgentBuilderList from '../../hooks/agentBuilder/useAgentBuilderList';
 
 export type AgentFilter = 'my' | 'favorites' | 'public' | 'external';
@@ -170,6 +175,21 @@ const AgentBuilderListPage: React.FC = () => {
     },
     [cloneAgent]
   );
+
+  const handleExportAgent = useCallback((agent: AgentConfiguration) => {
+    const blob = new Blob([JSON.stringify(toPortableAgent(agent), null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = agentFileName(agent.name);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+    setOpenDropdown(null);
+  }, []);
 
   const handleDeleteAgent = useCallback(
     async (agentId: string) => {
@@ -435,6 +455,15 @@ const AgentBuilderListPage: React.FC = () => {
                           className="flex w-full items-center px-4 py-2.5 text-sm text-gray-700 transition-colors hover:bg-gray-50">
                           <CloneIcon className="mr-3 h-4 w-4 text-gray-500" />
                           {t('agent_builder.clone')}
+                        </button>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleAction(() => handleExportAgent(agent));
+                          }}
+                          className="flex w-full items-center px-4 py-2.5 text-sm text-gray-700 transition-colors hover:bg-gray-50">
+                          <ExportIcon className="mr-3 h-4 w-4 text-gray-500" />
+                          {t('agent_builder.export')}
                         </button>
                         {currentFilter === 'my' && (
                           <>

--- a/packages/web/src/utils/agentDefinitionFile.ts
+++ b/packages/web/src/utils/agentDefinitionFile.ts
@@ -1,0 +1,67 @@
+import { AgentContent } from 'generative-ai-use-cases';
+
+/**
+ * An agent definition as a file, so one can be handed to someone else.
+ *
+ * Only the fields that describe the agent travel. Ownership, id, favourites
+ * and timestamps belong to the copy they were read from, and carrying them
+ * would either be meaningless in another installation or would claim
+ * something about the person importing it.
+ */
+export type PortableAgent = {
+  name: string;
+  description: string;
+  systemPrompt: string;
+  modelId: string;
+  mcpServers: string[];
+  codeExecutionEnabled: boolean;
+};
+
+export const toPortableAgent = (
+  agent: Partial<AgentContent>
+): PortableAgent => ({
+  name: agent.name ?? '',
+  description: agent.description ?? '',
+  systemPrompt: agent.systemPrompt ?? '',
+  modelId: agent.modelId ?? '',
+  mcpServers: agent.mcpServers ?? [],
+  codeExecutionEnabled: !!agent.codeExecutionEnabled,
+});
+
+/**
+ * Reads a definition from a file someone was given.
+ *
+ * The file comes from outside, so every field is checked rather than trusted:
+ * a name that is not a string, or servers that are not a list, would other-
+ * wise reach the form and fail somewhere further away from the cause.
+ */
+export const fromPortableAgent = (parsed: unknown): PortableAgent => {
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error('not an agent definition');
+  }
+  const raw = parsed as Record<string, unknown>;
+  const text = (key: string): string =>
+    typeof raw[key] === 'string' ? (raw[key] as string) : '';
+
+  // A definition with no prompt describes no agent, whatever else it holds.
+  if (!text('systemPrompt') && !text('name')) {
+    throw new Error('not an agent definition');
+  }
+
+  return {
+    name: text('name'),
+    description: text('description'),
+    systemPrompt: text('systemPrompt'),
+    modelId: text('modelId'),
+    mcpServers: Array.isArray(raw.mcpServers)
+      ? raw.mcpServers.filter((s): s is string => typeof s === 'string')
+      : [],
+    codeExecutionEnabled: raw.codeExecutionEnabled === true,
+  };
+};
+
+/** A filename that survives being written to disk. */
+export const agentFileName = (name: string): string => {
+  const safe = name.replace(/[\\/:*?"<>|]/g, '').trim();
+  return `${safe || 'agent'}.json`;
+};

--- a/packages/web/tests/hooks/agentDefinitionFile.test.ts
+++ b/packages/web/tests/hooks/agentDefinitionFile.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+
+// The names here stand in for what a user would call an agent, and a
+// Japanese one is the case worth covering: it has to survive being written
+// to a file and read back.
+/* eslint-disable i18nhelper/no-jp-string */
+import {
+  toPortableAgent,
+  fromPortableAgent,
+  agentFileName,
+} from '../../src/utils/agentDefinitionFile';
+
+const complete = {
+  name: '書類作成エージェント',
+  description: 'Officeツールを使って文書を作成する',
+  systemPrompt: 'あなたは書類作成エージェントです。',
+  modelId: 'global.anthropic.claude-sonnet-4-6',
+  mcpServers: ['powerpoint', 'excel'],
+  codeExecutionEnabled: true,
+};
+
+describe('writing an agent out', () => {
+  it('keeps what describes the agent', () => {
+    expect(toPortableAgent(complete)).toEqual(complete);
+  });
+
+  // The id, the owner and the star count belong to the copy it was read
+  // from; carrying them would claim something about whoever imports it.
+  it('leaves behind what belongs to the original', () => {
+    const written = toPortableAgent({
+      ...complete,
+      agentId: 'abc',
+      createdByEmail: 'someone@example.com',
+      isPublic: true,
+    } as never);
+    expect(written).not.toHaveProperty('agentId');
+    expect(written).not.toHaveProperty('createdByEmail');
+    expect(written).not.toHaveProperty('isPublic');
+  });
+
+  it('fills in what an incomplete agent leaves out', () => {
+    expect(toPortableAgent({ name: 'x', systemPrompt: 'y' })).toEqual({
+      name: 'x',
+      description: '',
+      systemPrompt: 'y',
+      modelId: '',
+      mcpServers: [],
+      codeExecutionEnabled: false,
+    });
+  });
+});
+
+describe('reading an agent in', () => {
+  it('reads back what it wrote', () => {
+    expect(fromPortableAgent(JSON.parse(JSON.stringify(complete)))).toEqual(
+      complete
+    );
+  });
+
+  // The file comes from outside, so a field of the wrong type must not reach
+  // the form and fail somewhere further from the cause.
+  it('ignores fields that are not the shape they should be', () => {
+    const read = fromPortableAgent({
+      name: 'x',
+      systemPrompt: 'y',
+      description: 42,
+      mcpServers: 'powerpoint',
+      codeExecutionEnabled: 'true',
+    });
+    expect(read.description).toBe('');
+    expect(read.mcpServers).toEqual([]);
+    expect(read.codeExecutionEnabled).toBe(false);
+  });
+
+  it('drops entries in the server list that are not names', () => {
+    const read = fromPortableAgent({
+      name: 'x',
+      systemPrompt: 'y',
+      mcpServers: ['excel', 3, null, 'word'],
+    });
+    expect(read.mcpServers).toEqual(['excel', 'word']);
+  });
+
+  it('refuses something that is not an agent at all', () => {
+    for (const junk of [null, 'a string', 42, [], {}, { unrelated: 1 }]) {
+      expect(() => fromPortableAgent(junk)).toThrow();
+    }
+  });
+
+  // codeExecutionEnabled decides whether the agent may run code, so anything
+  // short of a literal true is false.
+  it('only enables code execution on a real true', () => {
+    const on = (value: unknown) =>
+      fromPortableAgent({
+        name: 'x',
+        systemPrompt: 'y',
+        codeExecutionEnabled: value,
+      }).codeExecutionEnabled;
+    expect(on(true)).toBe(true);
+    expect(on('true')).toBe(false);
+    expect(on(1)).toBe(false);
+  });
+});
+
+describe('naming the file', () => {
+  it('names it after the agent', () => {
+    expect(agentFileName('書類作成エージェント')).toBe(
+      '書類作成エージェント.json'
+    );
+  });
+
+  it('drops characters a filesystem would refuse', () => {
+    expect(agentFileName('a/b:c*?"<>|d')).toBe('abcd.json');
+  });
+
+  it('falls back when the name says nothing', () => {
+    expect(agentFileName('')).toBe('agent.json');
+    expect(agentFileName('///')).toBe('agent.json');
+  });
+});


### PR DESCRIPTION
## 概要

ユースケースビルダーには JSON でユースケースを書き出す・読み込む機能がありますが、エージェントビルダーにはありません。エージェント定義も同じくらい作り込むものなので、同じ2つの操作を追加します。

## 変更内容

- **エクスポート** — 一覧のメニューに追加（クローンの隣）
- **インポート** — 編集画面のヘッダーに追加。読み込むとフォームに反映されます

書き出すのはエージェントを説明する項目だけです。

```json
{
  "name": "...",
  "description": "...",
  "systemPrompt": "...",
  "modelId": "...",
  "mcpServers": ["..."],
  "codeExecutionEnabled": false
}
```

`agentId`・作成者・お気に入り数は含めていません。元のコピーに属する値で、持ち回ると取り込んだ人について何かを主張することになるためです。ユースケース側の実装も同じ考え方です。

読み込むファイルは外部から来るため、各フィールドを型ごとに検証しています。特に `codeExecutionEnabled` はコード実行の可否を決めるので、真偽値の `true` 以外は `false` として扱います（手で編集した JSON の `"true"` で有効になってはいけないため）。読めなかった場合はフォームを中途半端に埋めず、画面上にエラーを表示します。

## 補足

`agent_builder` の翻訳は ja と en にのみ存在するため、その2言語に追加しました。

## テスト

`packages/web/tests/hooks/agentDefinitionFile.test.ts` に11件追加しています。

```
npm run test -w packages/web
→ Test Files 14 passed, Tests 289 passed
```
