### PR TITLE
fix(cdk): wire video copy Lambda into API handler

### DIFF
--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -421,6 +421,10 @@ export class Api extends Construct {
       vpc,
       securityGroups,
     });
+    apiHandler.addEnvironment(
+      'COPY_VIDEO_JOB_FUNCTION_ARN',
+      copyVideoJob.functionArn
+    );
     for (const region of Object.keys(props.videoBucketRegionMap)) {
       const bucketName = props.videoBucketRegionMap[region];
       copyVideoJob.role?.addToPrincipalPolicy(

--- a/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
+++ b/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
@@ -6075,6 +6075,12 @@ exports[`GenerativeAiUseCases matches the snapshot (closed network mode) 6`] = `
                 "Agents",
               ],
             },
+            "COPY_VIDEO_JOB_FUNCTION_ARN": {
+              "Fn::GetAtt": [
+                "APICopyVideoJobB772026B",
+                "Arn",
+              ],
+            },
             "CROSS_ACCOUNT_BEDROCK_ROLE_ARN": "",
             "CUSTOM_AGENTS_JSON": "[]",
             "GUARDRAIL_IDENTIFIER": {
@@ -12543,6 +12549,12 @@ exports[`GenerativeAiUseCases matches the snapshot (closed network mode) 6`] = `
               "Fn::GetAtt": [
                 "AgentRemoteOutputs90CFA880",
                 "Agents",
+              ],
+            },
+            "COPY_VIDEO_JOB_FUNCTION_ARN": {
+              "Fn::GetAtt": [
+                "APICopyVideoJobB772026B",
+                "Arn",
               ],
             },
             "CROSS_ACCOUNT_BEDROCK_ROLE_ARN": "",
@@ -19915,6 +19927,12 @@ exports[`GenerativeAiUseCases matches the snapshot 6`] = `
                 "Agents",
               ],
             },
+            "COPY_VIDEO_JOB_FUNCTION_ARN": {
+              "Fn::GetAtt": [
+                "APICopyVideoJobB772026B",
+                "Arn",
+              ],
+            },
             "CROSS_ACCOUNT_BEDROCK_ROLE_ARN": "",
             "CUSTOM_AGENTS_JSON": "[]",
             "GUARDRAIL_IDENTIFIER": {
@@ -26263,6 +26281,12 @@ exports[`GenerativeAiUseCases matches the snapshot 6`] = `
               "Fn::GetAtt": [
                 "AgentRemoteOutputs90CFA880",
                 "Agents",
+              ],
+            },
+            "COPY_VIDEO_JOB_FUNCTION_ARN": {
+              "Fn::GetAtt": [
+                "APICopyVideoJobB772026B",
+                "Arn",
               ],
             },
             "CROSS_ACCOUNT_BEDROCK_ROLE_ARN": "",


### PR DESCRIPTION
## Description of Changes

Issue #1692 reports that Bedrock video generation jobs remain `InProgress` and the generated videos cannot be played even after the asynchronous Bedrock job completes.

The API Lambda invokes the existing `repositoryVideoJob` flow, which requires `COPY_VIDEO_JOB_FUNCTION_ARN` to asynchronously invoke `CopyVideoJob` after a Bedrock job completes. The CDK stack created `CopyVideoJob` but did not inject its ARN into the API Lambda environment. This change wires the deployed function ARN into the API Lambda and updates the existing CDK snapshots.

This is backward-compatible for existing deployments. It changes only the generated Lambda environment configuration and enables the already implemented completion flow; no API contract or data schema changes are introduced.

## Checklist

- [ ] Modified relevant documentation (not applicable; no documentation behavior changed)
- [x] Verified operation in local environment
- [x] Executed focused Lambda tests and CDK build checks; the CDK snapshot suite was attempted with the repository Docker bundling configuration, but the required public SAM image download was rate-limited before the suite could complete.

## Related Issues

Closes #1692

## Validation

- `npm run build --prefix packages/cdk` — passed
- `npm run lambda-build-dryrun --prefix packages/cdk` — passed
- `npm test --prefix packages/cdk -- --runInBand test/lambda` — 5 suites and 34 tests passed
- Focused ESLint parser/rules check for `packages/cdk/lib/construct/api.ts` — passed
- `git diff --check` — passed
- `npm test --prefix packages/cdk -- --runInBand test/generative-ai-use-cases.test.ts` — attempted; repository Docker bundling was blocked by severe rate limiting while pulling `public.ecr.aws/sam/build-nodejs22.x:latest`

The live AWS/Bedrock deployment smoke test was not run locally because no target deployment environment or credentials were available.
